### PR TITLE
Add item name label widget with context menu

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10,9 +10,7 @@ use std::time::Instant;
 use web_time::Instant;
 
 use egui::{Align, CursorIcon, FontData, FontDefinitions, FontFamily, Id, Layout, TextStyle};
-use game_data::{
-    action_name, get_initial_quality, get_item_name, get_job_name, Consumable, Locale,
-};
+use game_data::{action_name, get_initial_quality, get_job_name, Consumable, Locale};
 
 use simulator::Action;
 
@@ -434,8 +432,8 @@ impl MacroSolverApp {
                         if item.can_be_hq {
                             has_hq_ingredient = true;
                             ui.horizontal(|ui| {
-                                ui.label(get_item_name(ingredient.item_id, false, self.locale));
-                                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                                ui.add(ItemNameLabel::new(ingredient.item_id, false, self.locale));
+                                ui.with_layout(Layout::right_to_left(Align::Center), |ui: &mut egui::Ui| {
                                     let mut max_placeholder = ingredient.amount;
                                     ui.add_enabled(false, egui::DragValue::new(&mut max_placeholder));
                                     ui.monospace("/");

--- a/src/widgets/food_select.rs
+++ b/src/widgets/food_select.rs
@@ -3,7 +3,9 @@ use egui::{
     Align, Id, Layout, Widget,
 };
 use egui_extras::Column;
-use game_data::{find_meals, get_item_name, Consumable, CrafterStats, Locale};
+use game_data::{find_meals, Consumable, CrafterStats, Locale};
+
+use super::ItemNameLabel;
 
 #[derive(Default)]
 struct FoodFinder {}
@@ -42,10 +44,14 @@ impl<'a> Widget for FoodSelect<'a> {
             ui.vertical(|ui| {
                 ui.horizontal(|ui| {
                     ui.label(egui::RichText::new("Food").strong());
-                    ui.label(match self.selected_consumable {
-                        Some(item) => get_item_name(item.item_id, item.hq, self.locale),
-                        None => "None".to_string(),
-                    });
+                    match self.selected_consumable {
+                        None => {
+                            ui.label("None".to_string());
+                        }
+                        Some(item) => {
+                            ui.add(ItemNameLabel::new(item.item_id, item.hq, self.locale));
+                        }
+                    }
                     ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                         if ui
                             .add_enabled(
@@ -109,7 +115,7 @@ impl<'a> Widget for FoodSelect<'a> {
                             }
                         });
                         row.col(|ui| {
-                            ui.label(get_item_name(item.item_id, item.hq, self.locale));
+                            ui.add(ItemNameLabel::new(item.item_id, item.hq, self.locale));
                         });
                         row.col(|ui| {
                             ui.label(item.effect_string(

--- a/src/widgets/item_name_label.rs
+++ b/src/widgets/item_name_label.rs
@@ -1,0 +1,61 @@
+use game_data::{get_item_name, Locale};
+
+pub struct ItemNameLabel {
+    item_id: u32,
+    text: String,
+}
+
+impl ItemNameLabel {
+    pub fn new(item_id: u32, hq: bool, locale: Locale) -> Self {
+        Self {
+            item_id: item_id,
+            text: get_item_name(item_id, hq, locale),
+        }
+    }
+}
+
+impl egui::Widget for ItemNameLabel {
+    fn ui(self, ui: &mut egui::Ui) -> egui::Response {
+        let id = egui::Id::new(ui.id().value() ^ u64::from(self.item_id));
+
+        let response;
+        if ui.ctx().animate_bool_with_time(id, false, 0.25) == 0.0 {
+            response = ui
+                .add(egui::Label::new(egui::RichText::new(&self.text)).sense(egui::Sense::click()));
+        } else {
+            response = ui.add(
+                egui::Label::new(
+                    egui::RichText::new(&self.text).color(ui.style().visuals.weak_text_color()),
+                )
+                .sense(egui::Sense::click()),
+            );
+        }
+
+        response.context_menu(|ui| {
+            if ui.input(|i| i.key_pressed(egui::Key::Escape)) {
+                ui.close_menu();
+            }
+            let mut selection_made = false;
+            if ui.button("Copy Item Name").clicked() {
+                let copy_item_name: String = self
+                    .text
+                    .trim_end_matches(&[' ', game_data::HQ_ICON_CHAR, game_data::CL_ICON_CHAR])
+                    .to_string();
+                ui.output_mut(|output| output.copied_text = copy_item_name);
+                ui.close_menu();
+                selection_made = true;
+            }
+            ui.separator();
+            if ui.button("Copy Item ID").clicked() {
+                ui.output_mut(|output| output.copied_text = self.item_id.to_string());
+                ui.close_menu();
+                selection_made = true;
+            }
+
+            if selection_made {
+                ui.ctx().animate_bool_with_time(id, true, 0.0);
+            }
+        });
+        response
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -18,3 +18,6 @@ pub use stats_edit::StatsEdit;
 
 mod help_text;
 pub use help_text::HelpText;
+
+mod item_name_label;
+pub use item_name_label::ItemNameLabel;

--- a/src/widgets/potion_select.rs
+++ b/src/widgets/potion_select.rs
@@ -3,7 +3,9 @@ use egui::{
     Align, Id, Layout, Widget,
 };
 use egui_extras::Column;
-use game_data::{find_potions, get_item_name, Consumable, CrafterStats, Locale};
+use game_data::{find_potions, Consumable, CrafterStats, Locale};
+
+use super::ItemNameLabel;
 
 #[derive(Default)]
 struct PotionFinder {}
@@ -42,10 +44,14 @@ impl<'a> Widget for PotionSelect<'a> {
             ui.vertical(|ui| {
                 ui.horizontal(|ui| {
                     ui.label(egui::RichText::new("Potion").strong());
-                    ui.label(match self.selected_consumable {
-                        Some(item) => get_item_name(item.item_id, item.hq, self.locale),
-                        None => "None".to_string(),
-                    });
+                    match self.selected_consumable {
+                        None => {
+                            ui.label("None".to_string());
+                        }
+                        Some(item) => {
+                            ui.add(ItemNameLabel::new(item.item_id, item.hq, self.locale));
+                        }
+                    }
                     ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                         if ui
                             .add_enabled(
@@ -109,7 +115,7 @@ impl<'a> Widget for PotionSelect<'a> {
                             }
                         });
                         row.col(|ui| {
-                            ui.label(get_item_name(item.item_id, item.hq, self.locale));
+                            ui.add(ItemNameLabel::new(item.item_id, item.hq, self.locale));
                         });
                         row.col(|ui| {
                             ui.label(item.effect_string(

--- a/src/widgets/recipe_select.rs
+++ b/src/widgets/recipe_select.rs
@@ -4,11 +4,12 @@ use egui::{
 };
 use egui_extras::Column;
 use game_data::{
-    find_recipes, get_game_settings, get_item_name, get_job_name, Consumable, Ingredient, Locale,
-    RLVLS,
+    find_recipes, get_game_settings, get_job_name, Consumable, Ingredient, Locale, RLVLS,
 };
 
 use crate::config::{CrafterConfig, QualitySource, RecipeConfiguration};
+
+use super::ItemNameLabel;
 
 #[derive(Default)]
 struct RecipeFinder {}
@@ -101,7 +102,7 @@ impl<'a> RecipeSelect<'a> {
                     ui.label(get_job_name(recipe.job_id, self.locale));
                 });
                 row.col(|ui| {
-                    ui.label(get_item_name(recipe.item_id, false, self.locale));
+                    ui.add(ItemNameLabel::new(recipe.item_id, false, self.locale));
                 });
             });
         });
@@ -214,11 +215,11 @@ impl<'a> Widget for RecipeSelect<'a> {
 
                 ui.horizontal(|ui| {
                     ui.label(egui::RichText::new("Recipe").strong());
-                    ui.label(egui::RichText::new(get_item_name(
+                    ui.add(ItemNameLabel::new(
                         self.recipe_config.recipe.item_id,
                         false,
                         self.locale,
-                    )));
+                    ));
                     ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                         if ui.checkbox(&mut custom_recipe, "Custom Recipe").changed() {
                             self.recipe_config.quality_source = match custom_recipe {


### PR DESCRIPTION
Adds an item name label widget that replaces the generic `egui::Label` that is currently used for displaying item names.
Additionally, using this new widget, a context menu when right-clicking the item name is added, from which the user can copy the item's name (excluding special characters) or the item's ID.

**Caveats:**
* Clicking on an item with a left-or the middle-click makes it visually respond to the interaction although no functionality is implemented for it
	* This quirk stems from egui requiring the widget to sense `egui::Sense::click()` for the context menu to work. While it should be possible to override the style of the widget after a left- and middle-click so that it appears unchanged, that would add code to undo previously done work and would make it inconsistent to how other default egui widgets work (e.g. the same behaviour can be seen for checkboxes and `DragValue`s)
* Since the central panels are all disabled during a solve, and with how egui handles disabled elements, it is impossible to open the context menu during a solve
* On smartphones, long pressing an egui text field doesn't make the system's native paste option appear, making actually using the pasted text depend on the specifics of the keyboard implementation of the device
* Most users will have no use for an item's ID. The option is provided since the CLI uses them and currently the only way of finding them is by searching in the game data

**Preview:**

https://github.com/user-attachments/assets/140a2c06-6fe8-4ada-b5b4-ae52f348d14a

