### PR TITLE
Add specialist checkbox

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,8 @@ pub struct RecipeConfiguration {
 pub struct CrafterConfig {
     pub selected_job: u8,
     pub crafter_stats: [CrafterStats; 8],
+    #[serde(default)]
+    pub specialists: [bool; 8],
 }
 
 impl CrafterConfig {
@@ -27,6 +29,14 @@ impl CrafterConfig {
     pub fn active_stats_mut(&mut self) -> &mut CrafterStats {
         &mut self.crafter_stats[self.selected_job as usize]
     }
+
+    pub fn active_specialist_status(&self) -> &bool {
+        &self.specialists[self.selected_job as usize]
+    }
+
+    pub fn active_specialist_status_mut(&mut self) -> &mut bool {
+        &mut self.specialists[self.selected_job as usize]
+    }
 }
 
 impl Default for CrafterConfig {
@@ -34,6 +44,7 @@ impl Default for CrafterConfig {
         Self {
             selected_job: 1,
             crafter_stats: Default::default(),
+            specialists: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Adds a specialist checkbox to the crafter stats display and one for each class in the stats edit window.

Toggling the checkbox adds/subtracts the stat bonus to/from each stat and enables/disables the specialist actions from being used by the solver. The stat and action selection changes are handled by the UI, i.e. specialist status is not passed to the solver to preserve the current functionality.
The action selection change is implemented as a kind of mask, meaning that the user selection of which of the specialist actions may be used are not forgotten when deselecting specialist. Additionally, in the stats edit window, the "Copy to all" button copies the base stats (without specialist bonus stats) to all other classes and not the specialist status.

**Caveats:**
* Specialist action checkboxes are disabled when the current class is not a specialist. This may confuse the user if they don't recognise the actions' names. With the way egui handles disabled elements, it seems impossible to add text to appear when hovering over the checkboxes which would have allowed to clarify the need to enable specialist for the class
* The way in which the "Copy to all" button behaves with these changes is kind of unintuitive. I chose this behaviour since I expect it to be the most useful, because I would expect the button to be used when updating the stats for new gear. In this case, it would not make sense to copy specialist status and bonus stats, especially since it is not possible to have more than three classes as specialist at once
* While the `CrafterConfig` crafter config struct can be deserialised from an older version without issue, a user must manually enable the specialist status for the relevant classes and readjust the stats after doing so

The addition of specialist checkboxes was previously requested and briefly discussed on the Discord server, with a tendentially negative evaluation on its usefulness when implemented in this way. I hope my way of implementing it, i.e. limiting the logic to the UI while keeping old functionality intact, alleviates most concerns with this approach. At the very least, this implementation can be used to test how this approach may effect the user's experience.

**Preview:**

https://github.com/user-attachments/assets/a3c8d0f9-07be-4150-af57-56d7913ec5f8

