### PR TITLE
Add ability to import and export crafter config to and from clipboard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ eframe = { version = "0.27.2", features = ["persistence"] }
 egui_extras = { version = "0.27.2", features = ["all_loaders"] }
 image = { version = "0.24.9", default-features = false, features = ["webp"] }
 serde = { version = "1.0.203", features = ["derive"] }
-serde_json = "1.0"
+ron = "0.8"
 log = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ eframe = { version = "0.27.2", features = ["persistence"] }
 egui_extras = { version = "0.27.2", features = ["all_loaders"] }
 image = { version = "0.24.9", default-features = false, features = ["webp"] }
 serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0"
 log = "0.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/widgets/stats_edit.rs
+++ b/src/widgets/stats_edit.rs
@@ -48,6 +48,58 @@ impl<'a> Widget for StatsEdit<'a> {
                     ui.checkbox(&mut stats.quick_innovation, "Quick Innovation");
                 });
             }
+
+            ui.separator().rect.width();
+            ui.horizontal(|ui| {
+                let button_text = "🗐 Copy Crafter Config";
+                let button_response;
+                if ui
+                    .ctx()
+                    .animate_bool_with_time(egui::Id::new(button_text), false, 0.25)
+                    == 0.0
+                {
+                    button_response = ui.button(button_text);
+                } else {
+                    button_response = ui.add_enabled(false, egui::Button::new(button_text));
+                }
+                if button_response.clicked() {
+                    ui.output_mut(|output| {
+                        output.copied_text = serde_json::to_string(self.crafter_config).unwrap()
+                    });
+                    ui.ctx()
+                        .animate_bool_with_time(egui::Id::new(button_text), true, 0.0);
+                }
+
+                ui.add_space(button_response.rect.width() * 0.5);
+                let selected_job = self.crafter_config.selected_job;
+                let hint_text = "📋 Paste Config here to Load";
+                let input_string = &mut String::new();
+                let input_response;
+                if ui
+                    .ctx()
+                    .animate_bool_with_time(egui::Id::new(hint_text), false, 0.25)
+                    == 0.0
+                {
+                    input_response =
+                        ui.add(egui::TextEdit::singleline(input_string).hint_text(hint_text));
+                } else {
+                    input_response = ui.add_enabled(
+                        false,
+                        egui::TextEdit::singleline(input_string).hint_text(hint_text),
+                    );
+                }
+                if input_response.changed() {
+                    match serde_json::from_str(&input_string) {
+                        Ok(crafter_config) => {
+                            *self.crafter_config = crafter_config;
+                            self.crafter_config.selected_job = selected_job;
+                            ui.ctx()
+                                .animate_bool_with_time(egui::Id::new(hint_text), true, 0.0);
+                        }
+                        Err(_) => {}
+                    }
+                }
+            });
         })
         .response
     }

--- a/src/widgets/stats_edit.rs
+++ b/src/widgets/stats_edit.rs
@@ -64,7 +64,7 @@ impl<'a> Widget for StatsEdit<'a> {
                 }
                 if button_response.clicked() {
                     ui.output_mut(|output| {
-                        output.copied_text = serde_json::to_string(self.crafter_config).unwrap()
+                        output.copied_text = ron::to_string(self.crafter_config).unwrap()
                     });
                     ui.ctx()
                         .animate_bool_with_time(egui::Id::new(button_text), true, 0.0);
@@ -89,7 +89,7 @@ impl<'a> Widget for StatsEdit<'a> {
                     );
                 }
                 if input_response.changed() {
-                    match serde_json::from_str(&input_string) {
+                    match ron::from_str(&input_string) {
                         Ok(crafter_config) => {
                             *self.crafter_config = crafter_config;
                             self.crafter_config.selected_job = selected_job;


### PR DESCRIPTION
Adds a button for copying the crafter config (stats, selected actions, etc.) to the clipboard and a text input field for importing them in the stats edit window.
The representation of the crafter config is created and parsed using `serde_json`.

This (arguably) resolves the last item of #49.

**Caveats:**
* Importing is done in a roundabout way, by having a text input field that is used for pasting the config into. Ideally, a button to read the clipboard would be used instead. 
  * egui doesn't provide a method for reading the contents of the clipboard and implementing it is not simple (for the Web version using `web-sys` to call the Web API functions directly is possible but those come with caveats by themselves). Using a text input field and having the user paste the contents of the clipboard themself manually ensures that we get the value without any issues.
* On smartphones, long pressing an egui text field doesn't make the system's native paste option appear, making actually using the pasted text depend on the specifics of the keyboard implementation of the device

**Preview:**

https://github.com/user-attachments/assets/e318a8e1-d4de-4ab1-a156-60804e742080

