### PR TITLE
Publish native app assets on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,14 +19,31 @@ jobs:
         run: rustup update nightly && rustup default nightly
       - name: Build
         run: cargo build --release
-      - name: Publish asset
+      - name: Upload Asset
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >
-          curl
-            -X POST
-            -H "Authorization: token $GITHUB_TOKEN"
-            -H "Content-Type: application/octet-stream"
-            --data-binary @target/release/raphael-xiv
-            https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=raphael_x86_64_linux
+        with:
+          upload_url: ${{ github.event.release.upload_url }} 
+          asset_path: ./target/release/raphael-xiv
+          asset_name: raphael_x86_64_linux
+          asset_content_type: application/octet-stream
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use nightly toolchain
+        run: rustup update nightly && rustup default nightly
+      - name: Build
+        run: cargo build --release
+      - name: Upload Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }} 
+          asset_path: ./target/release/raphael-xiv.exe
+          asset_name: raphael_x86_64_windows.exe
+          asset_content_type: application/octet-stream
           

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Publish Release Assets
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use nightly toolchain
+        run: rustup update nightly && rustup default nightly
+      - name: Build
+        run: cargo build --release
+      - name: Publish asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          curl
+            -X POST
+            -H "Authorization: token $GITHUB_TOKEN"
+            -H "Content-Type: application/octet-stream"
+            --data-binary @target/release/raphael-xiv
+            https://uploads.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}/assets?name=raphael_x86_64_linux
+          


### PR DESCRIPTION
This will run a workflow when you create a release to run a build for both windows and linux and upload them as assets.