### PR TITLE
Fix binding generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,7 @@ overflow-checks = false
 opt-level = 3
 lto = "thin"
 overflow-checks = true
+
+[patch.crates-io]
+# unsafe(no_mangle) fix for csbindgen in raphael-bindings
+csbindgen = { git = "https://github.com/Cysharp/csbindgen.git", rev = "refs/pull/103/head" }

--- a/raphael-bindings/Cargo.toml
+++ b/raphael-bindings/Cargo.toml
@@ -12,5 +12,5 @@ raphael-sim = { workspace = true }
 raphael-solver = { workspace = true }
 
 [build-dependencies]
-cbindgen = "0.27.0"
+cbindgen = "0.28.0"
 csbindgen = "1.9.3"

--- a/raphael-bindings/NativeMethods.g.cs
+++ b/raphael-bindings/NativeMethods.g.cs
@@ -10,8 +10,73 @@ using System.Runtime.InteropServices;
 
 namespace Raphael
 {
-    
+    public static unsafe partial class NativeMethods
+    {
+        const string __DllName = "raphael_bindings";
 
+
+
+        [DllImport(__DllName, EntryPoint = "solve", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void solve(SolveArgs* args);
+
+
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe partial struct SolveArgs
+    {
+        public delegate* unmanaged[Cdecl]<bool*, void> on_start;
+        public delegate* unmanaged[Cdecl]<Action*, nuint, void> on_finish;
+        public delegate* unmanaged[Cdecl]<Action*, nuint, void> on_suggest_solution;
+        public delegate* unmanaged[Cdecl]<nuint, void> on_progress;
+        public ulong action_mask;
+        public ushort progress;
+        public ushort quality;
+        public ushort base_progress;
+        public ushort base_quality;
+        public short cp;
+        public sbyte durability;
+        public byte job_level;
+        [MarshalAs(UnmanagedType.U1)] public bool adversarial;
+        [MarshalAs(UnmanagedType.U1)] public bool backload_progress;
+        [MarshalAs(UnmanagedType.U1)] public bool unsound_branch_pruning;
+    }
+
+
+    public enum Action : byte
+    {
+        BasicSynthesis,
+        BasicTouch,
+        MasterMend,
+        Observe,
+        TricksOfTheTrade,
+        WasteNot,
+        Veneration,
+        StandardTouch,
+        GreatStrides,
+        Innovation,
+        WasteNot2,
+        ByregotsBlessing,
+        PreciseTouch,
+        MuscleMemory,
+        CarefulSynthesis,
+        Manipulation,
+        PrudentTouch,
+        AdvancedTouch,
+        Reflect,
+        PreparatoryTouch,
+        Groundwork,
+        DelicateSynthesis,
+        IntensiveSynthesis,
+        TrainedEye,
+        HeartAndSoul,
+        PrudentSynthesis,
+        TrainedFinesse,
+        RefinedTouch,
+        QuickInnovation,
+        ImmaculateMend,
+        TrainedPerfection,
+    }
 
 
 }

--- a/raphael-bindings/bindings.h
+++ b/raphael-bindings/bindings.h
@@ -4,3 +4,61 @@
 #include <cstdlib>
 #include <ostream>
 #include <new>
+
+enum class Action : uint8_t {
+  BasicSynthesis,
+  BasicTouch,
+  MasterMend,
+  Observe,
+  TricksOfTheTrade,
+  WasteNot,
+  Veneration,
+  StandardTouch,
+  GreatStrides,
+  Innovation,
+  WasteNot2,
+  ByregotsBlessing,
+  PreciseTouch,
+  MuscleMemory,
+  CarefulSynthesis,
+  Manipulation,
+  PrudentTouch,
+  AdvancedTouch,
+  Reflect,
+  PreparatoryTouch,
+  Groundwork,
+  DelicateSynthesis,
+  IntensiveSynthesis,
+  TrainedEye,
+  HeartAndSoul,
+  PrudentSynthesis,
+  TrainedFinesse,
+  RefinedTouch,
+  QuickInnovation,
+  ImmaculateMend,
+  TrainedPerfection,
+};
+
+struct SolveArgs {
+  void (*on_start)(bool*);
+  void (*on_finish)(const Action*, size_t);
+  void (*on_suggest_solution)(const Action*, size_t);
+  void (*on_progress)(size_t);
+  uint64_t action_mask;
+  uint16_t progress;
+  uint16_t quality;
+  uint16_t base_progress;
+  uint16_t base_quality;
+  int16_t cp;
+  int8_t durability;
+  uint8_t job_level;
+  bool adversarial;
+  bool backload_progress;
+  bool unsound_branch_pruning;
+};
+
+extern "C" {
+
+void solve(const SolveArgs *args);
+
+}  // extern "C"


### PR DESCRIPTION
Rust 2024 edition uses `#[unsafe(no_mangle)]` now, so the following dependencies have to be updated as such. `csbindgen`'s fix hasn't been merged in yet, so I added a patch section for it in the meantime.