### PR TITLE
Add ability to specify custom end-of-macro notifications

### DIFF
--- a/src/widgets/macro_view.rs
+++ b/src/widgets/macro_view.rs
@@ -157,6 +157,56 @@ impl<'a> MacroView<'a> {
     }
 }
 
+impl MacroView<'_> {
+    fn macro_notification_menu(ui: &mut egui::Ui, notification_cfg: &mut MacroNotificationConfig) {
+        ui.horizontal(|ui| {
+            ui.radio_value(
+                &mut notification_cfg.default_notification,
+                true,
+                "Use default notification",
+            );
+            ui.add_enabled_ui(notification_cfg.default_notification, |ui| {
+                ui.reset_style();
+                ui.add_sized(
+                    [50.0, ui.available_height()],
+                    egui::DragValue::new(&mut notification_cfg.notification_sound)
+                        .range(1..=16)
+                        .prefix("<se.")
+                        .suffix(">"),
+                );
+            });
+        });
+
+        ui.separator();
+        ui.horizontal(|ui| {
+            ui.radio_value(
+                &mut notification_cfg.default_notification,
+                false,
+                "Use custom notification format",
+            );
+            ui.add(super::HelpText::new("Specify the exact format of the command that is executed at the end of each macro.\n\nUse the special format strings \"{index}\", \"{max_index}\", and \"{reverse_index}\" to add the respective value to the notification."));
+        });
+
+        ui.add_space(5.0);
+        ui.add_enabled_ui(!notification_cfg.default_notification, |ui| {
+            ui.vertical(|ui| {
+                ui.text_edit_singleline(&mut notification_cfg.custom_notification_format);
+                ui.add_space(5.0);
+                ui.checkbox(
+                    &mut notification_cfg.different_last_notification,
+                    "Use different format for last notification",
+                );
+                ui.add_enabled_ui(notification_cfg.different_last_notification, |ui| {
+                    egui::TextEdit::singleline(
+                        &mut notification_cfg.custom_last_notification_format,
+                    )
+                    .ui(ui);
+                });
+            });
+        });
+    }
+}
+
 impl Widget for MacroView<'_> {
     fn ui(self, ui: &mut egui::Ui) -> egui::Response {
         ui.group(|ui| {
@@ -201,44 +251,10 @@ impl Widget for MacroView<'_> {
                                     .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside),
                             )
                             .ui(ui, |ui| {
-                                ui.horizontal(|ui| {
-                                    ui.radio_value(&mut self.config.notification_config.default_notification, true,
-                                        "Use default notification",
-                                    );
-                                    ui.add_enabled_ui(
-                                        self.config.notification_config.default_notification,
-                                        |ui| {
-                                            ui.reset_style();
-                                            ui.add_sized([50.0, ui.available_height()], egui::DragValue::new(&mut self.config.notification_config.notification_sound).range(1..=16).prefix("<se.").suffix(">"));
-                                        },
-                                    );
-                                });
-
-                                ui.separator();
-                                ui.horizontal(|ui| {
-                                    ui.radio_value(&mut self.config.notification_config.default_notification, false, "Use custom notification format");
-                                ui.add(super::HelpText::new("Specify the exact format of the command that is executed at the end of each macro.\n\nUse the special format strings \"{index}\", \"{max_index}\", and \"{reverse_index}\" to add the respective value to the notification."));
-                                });
-
-                                ui.add_space(5.0);
-                                ui.add_enabled_ui(!self.config.notification_config.default_notification, |ui| {
-                                    ui.vertical(|ui| {
-                                        ui.text_edit_singleline(
-                                            &mut self
-                                                .config
-                                                .notification_config
-                                                .custom_notification_format,
-                                        );
-                                        ui.add_space(5.0);
-                                        ui.checkbox(&mut self.config.notification_config.different_last_notification, "Use different format for last notification");
-                                        ui.add_enabled_ui(self.config.notification_config.different_last_notification, |ui| {
-                                            egui::TextEdit::singleline(&mut self
-                                                .config
-                                                .notification_config
-                                                .custom_last_notification_format).ui(ui);
-                                        });
-                                    });
-                                });
+                                Self::macro_notification_menu(
+                                    ui,
+                                    &mut self.config.notification_config,
+                                )
                             });
                     });
                 });

--- a/src/widgets/macro_view.rs
+++ b/src/widgets/macro_view.rs
@@ -48,8 +48,7 @@ impl Default for MacroNotificationConfig {
         Self {
             default_notification: true,
             notification_sound: 1,
-            custom_notification_format: "/echo Example ({index}/{max_index}) <se.{reverse_index}>"
-                .to_owned(),
+            custom_notification_format: "/echo Example ({index}/{max_index}) <se.1>".to_owned(),
             different_last_notification: false,
             custom_last_notification_format: "/echo Example End".to_owned(),
         }
@@ -64,7 +63,6 @@ fn format_custom_notification(notification_format: &str, index: usize, max_index
     notification_format
         .replace("{index}", &index.to_string())
         .replace("{max_index}", &max_index.to_string())
-        .replace("{reverse_index}", &(max_index - index + 1).to_string())
 }
 
 impl MacroTextBox {
@@ -184,7 +182,7 @@ impl MacroView<'_> {
                 false,
                 "Use custom notification format",
             );
-            ui.add(super::HelpText::new("Specify the exact format of the command that is executed at the end of each macro.\n\nUse the special format strings \"{index}\", \"{max_index}\", and \"{reverse_index}\" to add the respective value to the notification."));
+            ui.add(super::HelpText::new("Specify the exact format of the command that is executed at the end of each macro.\n\nUse the special format strings \"{index}\" and \"{max_index}\" to add the respective value to the notification."));
         });
 
         ui.add_space(5.0);

--- a/src/widgets/macro_view.rs
+++ b/src/widgets/macro_view.rs
@@ -48,9 +48,9 @@ impl Default for MacroNotificationConfig {
         Self {
             default_notification: true,
             notification_sound: 1,
-            custom_notification_format: "/echo Example ({index}/{max_index}) <se.1>".to_owned(),
+            custom_notification_format: String::new(),
             different_last_notification: false,
-            custom_last_notification_format: "/echo Example End".to_owned(),
+            custom_last_notification_format: String::new(),
         }
     }
 }
@@ -182,14 +182,14 @@ impl MacroView<'_> {
                 false,
                 "Use custom notification format",
             );
-            ui.add(super::HelpText::new("Specify the exact format of the command that is executed at the end of each macro.\n\nUse the special format strings \"{index}\" and \"{max_index}\" to add the respective value to the notification."));
         });
 
         ui.add_enabled_ui(!notification_cfg.default_notification, |ui| {
             ui.vertical(|ui| {
                 ui.add(
                     egui::TextEdit::singleline(&mut notification_cfg.custom_notification_format)
-                        .font(egui::TextStyle::Monospace),
+                        .font(egui::TextStyle::Monospace)
+                        .hint_text("/echo Done {index}/{max_index} <se.1>"),
                 );
                 ui.checkbox(
                     &mut notification_cfg.different_last_notification,
@@ -200,7 +200,8 @@ impl MacroView<'_> {
                     egui::TextEdit::singleline(
                         &mut notification_cfg.custom_last_notification_format,
                     )
-                    .font(egui::TextStyle::Monospace),
+                    .font(egui::TextStyle::Monospace)
+                    .hint_text("/echo All macros done <se.2>"),
                 );
             });
         });
@@ -245,7 +246,7 @@ impl Widget for MacroView<'_> {
                         "End-of-macro notification",
                     ));
                     ui.add_enabled_ui(self.config.notification_enabled, |ui| {
-                        egui::containers::menu::MenuButton::new("✏ Edit contents")
+                        egui::containers::menu::MenuButton::new("✏ Edit")
                             .config(
                                 egui::containers::menu::MenuConfig::default()
                                     .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside),

--- a/src/widgets/macro_view.rs
+++ b/src/widgets/macro_view.rs
@@ -157,53 +157,44 @@ impl<'a> MacroView<'a> {
 
 impl MacroView<'_> {
     fn macro_notification_menu(ui: &mut egui::Ui, notification_cfg: &mut MacroNotificationConfig) {
+        ui.style_mut().spacing.item_spacing.y = 3.0;
         ui.horizontal(|ui| {
             ui.radio_value(
                 &mut notification_cfg.default_notification,
                 true,
                 "Use default notification",
             );
-            ui.add_enabled_ui(notification_cfg.default_notification, |ui| {
-                ui.reset_style();
-                ui.add_sized(
-                    [50.0, ui.available_height()],
-                    egui::DragValue::new(&mut notification_cfg.notification_sound)
-                        .range(1..=16)
-                        .prefix("<se.")
-                        .suffix(">"),
-                );
-            });
-        });
-
-        ui.separator();
-        ui.horizontal(|ui| {
-            ui.radio_value(
-                &mut notification_cfg.default_notification,
-                false,
-                "Use custom notification format",
+            ui.add_enabled(
+                notification_cfg.default_notification,
+                egui::DragValue::new(&mut notification_cfg.notification_sound)
+                    .range(1..=16)
+                    .prefix("<se.")
+                    .suffix(">"),
             );
         });
-
+        ui.separator();
+        ui.radio_value(
+            &mut notification_cfg.default_notification,
+            false,
+            "Use custom notification format",
+        );
         ui.add_enabled_ui(!notification_cfg.default_notification, |ui| {
-            ui.vertical(|ui| {
-                ui.add(
-                    egui::TextEdit::singleline(&mut notification_cfg.custom_notification_format)
-                        .font(egui::TextStyle::Monospace)
-                        .hint_text("/echo Done {index}/{max_index} <se.1>"),
-                );
-                ui.checkbox(
-                    &mut notification_cfg.different_last_notification,
-                    "Use different format for last notification",
-                );
-                ui.add_enabled(
-                    notification_cfg.different_last_notification,
-                    egui::TextEdit::singleline(
-                        &mut notification_cfg.custom_last_notification_format,
-                    )
+            ui.add(
+                egui::TextEdit::singleline(&mut notification_cfg.custom_notification_format)
+                    .font(egui::TextStyle::Monospace)
+                    .hint_text("/echo Done {index}/{max_index} <se.1>"),
+            );
+            ui.add_space(2.0);
+            ui.checkbox(
+                &mut notification_cfg.different_last_notification,
+                "Use different format for last notification",
+            );
+            ui.add_enabled(
+                notification_cfg.different_last_notification,
+                egui::TextEdit::singleline(&mut notification_cfg.custom_last_notification_format)
                     .font(egui::TextStyle::Monospace)
                     .hint_text("/echo All macros done <se.2>"),
-                );
-            });
+            );
         });
     }
 }
@@ -252,6 +243,7 @@ impl Widget for MacroView<'_> {
                                     .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside),
                             )
                             .ui(ui, |ui| {
+                                ui.reset_style(); // prevent egui::DragValue from looking weird
                                 Self::macro_notification_menu(
                                     ui,
                                     &mut self.config.notification_config,

--- a/src/widgets/macro_view.rs
+++ b/src/widgets/macro_view.rs
@@ -185,21 +185,23 @@ impl MacroView<'_> {
             ui.add(super::HelpText::new("Specify the exact format of the command that is executed at the end of each macro.\n\nUse the special format strings \"{index}\" and \"{max_index}\" to add the respective value to the notification."));
         });
 
-        ui.add_space(5.0);
         ui.add_enabled_ui(!notification_cfg.default_notification, |ui| {
             ui.vertical(|ui| {
-                ui.text_edit_singleline(&mut notification_cfg.custom_notification_format);
-                ui.add_space(5.0);
+                ui.add(
+                    egui::TextEdit::singleline(&mut notification_cfg.custom_notification_format)
+                        .font(egui::TextStyle::Monospace),
+                );
                 ui.checkbox(
                     &mut notification_cfg.different_last_notification,
                     "Use different format for last notification",
                 );
-                ui.add_enabled_ui(notification_cfg.different_last_notification, |ui| {
+                ui.add_enabled(
+                    notification_cfg.different_last_notification,
                     egui::TextEdit::singleline(
                         &mut notification_cfg.custom_last_notification_format,
                     )
-                    .ui(ui);
-                });
+                    .font(egui::TextStyle::Monospace),
+                );
             });
         });
     }


### PR DESCRIPTION
Adds the ability to specify a custom end-of-macro notification/command. Format string-like syntax can be used to specify the inclusion of special values, for example, the index of the macro. Additionally, it is possible to specify a different format to be used by the last macro.

**Caveats:**
- The configuration menu is implemented differently to that of the macro history or crafter stats. It is a `MenuButton` instead of a window
- Nested menus seem to be broken, so the drop-down menu for the notification sound selection is replaced with a `DragValue` to circumvent the issue
- Due to the changes made to the config struct, the selected notification sound that was saved by previous versions is reset

**Preview:**
![Screenshot 2025-03-29 at 18 28 13](https://github.com/user-attachments/assets/13a17288-d5c8-4cd1-984b-acc6df78a750)
