### PR TITLE
Fix logging on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,11 @@ opt-level = 3
 lto = "fat"
 overflow-checks = false
 
+[profile.release-with-debug]
+inherits = "release"
+debug = true
+debug-assertions = true
+
 [profile.test]
 opt-level = 3
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,6 @@ ron = "0.8"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11.5"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-windows = {version = "0.58" , features = ["Win32_System_Console"]}
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ ron = "0.8"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11.5"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = {version = "0.58" , features = ["Win32_System_Console"]}
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,50 +4,28 @@
 
 #[cfg(target_os = "windows")]
 fn init_logging() {
-    use windows::Win32::System::Console::{ATTACH_PARENT_PROCESS, AttachConsole};
-
-    // Check if parent process has a console and attach to it if it does
-    // Running the app from a Shortcut, the Start Menu, or File Explorer will log to a file
-    // while running it from a console or console script will output to them directly
-    let mut detached = true;
-    unsafe {
-        let result = AttachConsole(ATTACH_PARENT_PROCESS);
-        if result.is_ok() {
-            detached = false;
-            eprintln!(
-                "WARNING: Attached to Parent Console. Console may not wait for app to terminate!"
-            );
-        }
+    // Ensure app storage folder exists
+    let mut file_path = eframe::storage_dir("Raphael XIV").unwrap();
+    if !std::fs::exists(&file_path).unwrap() {
+        let creation_result = std::fs::create_dir_all(&file_path);
+        assert!(creation_result.is_ok());
     }
 
-    if detached {
-        // Get log file target. File is truncated if it allready exists
-        let mut file_path = eframe::storage_dir("Raphael XIV").unwrap();
-        if !std::fs::exists(&file_path).unwrap() {
-            let creation_result = std::fs::create_dir_all(&file_path);
-            assert!(creation_result.is_ok());
-        }
+    // Get log file target. File is truncated if it already exists
+    file_path.push("log.txt");
+    let log_file_target = Box::new(std::fs::File::create(file_path).unwrap());
 
-        file_path.push("log.txt");
-        let log_file_target = Box::new(std::fs::File::create(file_path).unwrap());
+    env_logger::builder()
+        .format_timestamp(None)
+        .format_target(false)
+        .target(env_logger::Target::Pipe(log_file_target))
+        .init();
 
-        env_logger::builder()
-            .format_timestamp(None)
-            .format_target(false)
-            .target(env_logger::Target::Pipe(log_file_target))
-            .init();
-
-        // Ensure panics are logged when detached, since the default hook outputs to stderr
-        // Backtraces are currently not generated
-        std::panic::set_hook(Box::new(|info| {
-            log::error!("{}", info);
-        }));
-    } else {
-        env_logger::builder()
-            .format_timestamp(None)
-            .format_target(false)
-            .init();
-    }
+    // Ensure panics are logged when detached, since the default hook outputs to stderr
+    // Backtraces are currently not generated
+    std::panic::set_hook(Box::new(|info| {
+        log::error!("{}", info);
+    }));
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 // Prevents a console from being opened on Windows
 // This attribute is ignored for all other platforms
-#![windows_subsystem = "windows"]
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", not(debug_assertions)))]
 fn init_logging() {
     // Ensure app storage folder exists
     let mut file_path = eframe::storage_dir("Raphael XIV").unwrap();
@@ -34,7 +34,7 @@ fn init_logging() {
     eframe::WebLogger::init(log::LevelFilter::Debug).ok();
 }
 
-#[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
+#[cfg(not(any(all(target_os = "windows", not(debug_assertions)), target_arch = "wasm32")))]
 fn init_logging() {
     env_logger::builder()
         .format_timestamp(None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,11 @@ fn init_logging() {
     if detached {
         // Get log file target. File is truncated if it allready exists
         let mut file_path = eframe::storage_dir("Raphael XIV").unwrap();
+        if !std::fs::exists(&file_path).unwrap() {
+            let creation_result = std::fs::create_dir_all(&file_path);
+            assert!(creation_result.is_ok());
+        }
+
         file_path.push("log.txt");
         let log_file_target = Box::new(std::fs::File::create(file_path).unwrap());
 


### PR DESCRIPTION
Fixes there being no way to view what was logged on Windows, as `#![windows_subsystem = "windows"]` causes the app to not output the logged messages or attach to a console even when started from one.

To fix this, the implementation creates a log file when started with no console to output to or attaches to the parent process's console if available.

**Caveats:**
- Attaching to the parent's console is janky since the console does not wait for the app to exit by default. `cargo` does but executing directly from command prompt or powershell does not
- Multiple running app instances write to the same log file, truncating it on start.
Logging to the log file also currently does not directly specify a log level and therefore uses the usual environment variable

Instead of attaching to the parent's console, it would also be possible to create a new one, when, for example, an argument is provided or an environment variable is set. I mainly chose the current approach to make developing on Windows less cumbersome, but in general only logging to a log file on Windows would make for the simplest and most consistent approach.