### PR TITLE
Fix potential `u16` overflow for large base progress and quality

### DIFF
--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -266,7 +266,7 @@ pub fn execute(args: &SolveArgs) {
 
     let final_state = SimulationState::from_macro(&settings, &actions).unwrap();
     let state_quality = final_state.quality;
-    let final_quality = state_quality.saturating_add(initial_quality);
+    let final_quality = state_quality + u32::from(initial_quality);
     let steps = actions.len();
     let duration: u8 = actions.iter().map(|action| action.time_cost()).sum();
 

--- a/raphael-data/src/lib.rs
+++ b/raphael-data/src/lib.rs
@@ -47,7 +47,7 @@ pub struct Recipe {
     pub recipe_level: u16,
     pub progress: u16,
     pub quality: u16,
-    pub durability: i8,
+    pub durability: i16,
     pub material_quality_factor: u16,
     pub ingredients: [Ingredient; 6],
     pub is_expert: bool,

--- a/raphael-data/src/lib.rs
+++ b/raphael-data/src/lib.rs
@@ -141,7 +141,9 @@ const HQ_LOOKUP: [u8; 101] = [
     71, 74, 76, 78, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 94, 96, 98, 100,
 ];
 
-pub fn hq_percentage(quality: u16, max_quality: u16) -> Option<u8> {
-    let ratio = (quality as usize * 100).checked_div(max_quality as usize)?;
-    Some(HQ_LOOKUP[std::cmp::min(ratio, 100)])
+pub fn hq_percentage(quality: impl Into<u32>, max_quality: impl Into<u32>) -> Option<u8> {
+    let quality: u32 = quality.into();
+    let max_quality: u32 = max_quality.into();
+    let ratio = (quality * 100).checked_div(max_quality)?;
+    Some(HQ_LOOKUP[std::cmp::min(ratio as usize, 100)])
 }

--- a/raphael-sim/src/actions.rs
+++ b/raphael-sim/src/actions.rs
@@ -55,7 +55,7 @@ pub trait ActionImpl {
             / 100_000_000) as u16
     }
 
-    fn durability_cost(state: &SimulationState, settings: &Settings, _condition: Condition) -> i8 {
+    fn durability_cost(state: &SimulationState, settings: &Settings, _condition: Condition) -> i16 {
         if state.effects.trained_perfection_active() {
             return 0;
         }
@@ -75,7 +75,7 @@ pub trait ActionImpl {
     fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         0
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         0
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -97,7 +97,7 @@ impl ActionImpl for BasicSynthesis {
     fn base_progress_increase(_state: &SimulationState, settings: &Settings) -> u16 {
         if settings.job_level < 31 { 100 } else { 120 }
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
 }
@@ -112,7 +112,7 @@ impl ActionImpl for BasicTouch {
     fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         100
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -134,8 +134,7 @@ impl ActionImpl for MasterMend {
         Self::CP_COST
     }
     fn transform_post(state: &mut SimulationState, settings: &Settings, _condition: Condition) {
-        state.durability =
-            std::cmp::min(settings.max_durability, state.durability.saturating_add(30));
+        state.durability = std::cmp::min(i16::from(settings.max_durability), state.durability + 30);
     }
 }
 
@@ -218,7 +217,7 @@ impl ActionImpl for StandardTouch {
     fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         125
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(state: &SimulationState, _settings: &Settings) -> i16 {
@@ -297,7 +296,7 @@ impl ActionImpl for ByregotsBlessing {
     fn base_quality_increase(state: &SimulationState, _settings: &Settings) -> u16 {
         100 + 20 * state.effects.inner_quiet() as u16
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -328,7 +327,7 @@ impl ActionImpl for PreciseTouch {
     fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         150
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -360,7 +359,7 @@ impl ActionImpl for MuscleMemory {
     fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         300
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -381,7 +380,7 @@ impl ActionImpl for CarefulSynthesis {
             82.. => 180,
         }
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -424,7 +423,7 @@ impl ActionImpl for PrudentTouch {
     fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         100
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         5
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -439,7 +438,7 @@ impl ActionImpl for AdvancedTouch {
     fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         150
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(state: &SimulationState, _settings: &Settings) -> i16 {
@@ -467,7 +466,7 @@ impl ActionImpl for Reflect {
     fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         300
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -489,7 +488,7 @@ impl ActionImpl for PreparatoryTouch {
     fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         200
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         20
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -515,7 +514,7 @@ impl ActionImpl for Groundwork {
         }
         base
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         20
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -536,7 +535,7 @@ impl ActionImpl for DelicateSynthesis {
     fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         100
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -566,7 +565,7 @@ impl ActionImpl for IntensiveSynthesis {
     fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         400
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -603,7 +602,7 @@ impl ActionImpl for TrainedEye {
     fn base_quality_increase(_state: &SimulationState, settings: &Settings) -> u16 {
         settings.max_quality
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -649,7 +648,7 @@ impl ActionImpl for PrudentSynthesis {
     fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         180
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         5
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -699,7 +698,7 @@ impl ActionImpl for RefinedTouch {
     fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
         100
     }
-    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i8 {
+    fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -746,7 +745,7 @@ impl ActionImpl for ImmaculateMend {
         Self::CP_COST
     }
     fn transform_post(state: &mut SimulationState, settings: &Settings, _condition: Condition) {
-        state.durability = settings.max_durability;
+        state.durability = i16::from(settings.max_durability);
     }
 }
 

--- a/raphael-sim/src/actions.rs
+++ b/raphael-sim/src/actions.rs
@@ -19,7 +19,7 @@ pub trait ActionImpl {
         state: &SimulationState,
         settings: &Settings,
         _condition: Condition,
-    ) -> u16 {
+    ) -> u32 {
         let efficiency_mod = Self::base_progress_increase(state, settings) as u64;
         let mut effect_mod = 100;
         if state.effects.muscle_memory() != 0 {
@@ -28,10 +28,10 @@ pub trait ActionImpl {
         if state.effects.veneration() != 0 {
             effect_mod += 50;
         }
-        (settings.base_progress as u64 * efficiency_mod * effect_mod / 10000) as u16
+        (settings.base_progress as u64 * efficiency_mod * effect_mod / 10000) as u32
     }
 
-    fn quality_increase(state: &SimulationState, settings: &Settings, condition: Condition) -> u16 {
+    fn quality_increase(state: &SimulationState, settings: &Settings, condition: Condition) -> u32 {
         let efficieny_mod = Self::base_quality_increase(state, settings) as u64;
         let condition_mod = match condition {
             Condition::Good => 150,
@@ -52,7 +52,7 @@ pub trait ActionImpl {
             * condition_mod
             * effect_mod
             * inner_quiet_mod
-            / 100_000_000) as u16
+            / 100_000_000) as u32
     }
 
     fn durability_cost(state: &SimulationState, settings: &Settings, _condition: Condition) -> i16 {
@@ -69,10 +69,10 @@ pub trait ActionImpl {
         Self::base_cp_cost(state, settings)
     }
 
-    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         0
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         0
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -94,7 +94,7 @@ pub struct BasicSynthesis {}
 impl ActionImpl for BasicSynthesis {
     const LEVEL_REQUIREMENT: u8 = 1;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::BasicSynthesis);
-    fn base_progress_increase(_state: &SimulationState, settings: &Settings) -> u16 {
+    fn base_progress_increase(_state: &SimulationState, settings: &Settings) -> u32 {
         if settings.job_level < 31 { 100 } else { 120 }
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -109,7 +109,7 @@ impl BasicTouch {
 impl ActionImpl for BasicTouch {
     const LEVEL_REQUIREMENT: u8 = 5;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::BasicTouch);
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         100
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -214,7 +214,7 @@ pub struct StandardTouch {}
 impl ActionImpl for StandardTouch {
     const LEVEL_REQUIREMENT: u8 = 18;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::StandardTouch);
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         125
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -293,8 +293,8 @@ impl ActionImpl for ByregotsBlessing {
             _ => Ok(()),
         }
     }
-    fn base_quality_increase(state: &SimulationState, _settings: &Settings) -> u16 {
-        100 + 20 * state.effects.inner_quiet() as u16
+    fn base_quality_increase(state: &SimulationState, _settings: &Settings) -> u32 {
+        100 + 20 * state.effects.inner_quiet() as u32
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
@@ -324,7 +324,7 @@ impl ActionImpl for PreciseTouch {
         }
         Ok(())
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         150
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -356,7 +356,7 @@ impl ActionImpl for MuscleMemory {
         }
         Ok(())
     }
-    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         300
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -374,7 +374,7 @@ pub struct CarefulSynthesis {}
 impl ActionImpl for CarefulSynthesis {
     const LEVEL_REQUIREMENT: u8 = 62;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::CarefulSynthesis);
-    fn base_progress_increase(_state: &SimulationState, settings: &Settings) -> u16 {
+    fn base_progress_increase(_state: &SimulationState, settings: &Settings) -> u32 {
         match settings.job_level {
             0..82 => 150,
             82.. => 180,
@@ -420,7 +420,7 @@ impl ActionImpl for PrudentTouch {
         }
         Ok(())
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         100
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -435,7 +435,7 @@ pub struct AdvancedTouch {}
 impl ActionImpl for AdvancedTouch {
     const LEVEL_REQUIREMENT: u8 = 68;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::AdvancedTouch);
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         150
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -463,7 +463,7 @@ impl ActionImpl for Reflect {
         }
         Ok(())
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         300
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -485,7 +485,7 @@ impl PreparatoryTouch {
 impl ActionImpl for PreparatoryTouch {
     const LEVEL_REQUIREMENT: u8 = 71;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::PreparatoryTouch);
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         200
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -504,7 +504,7 @@ pub struct Groundwork {}
 impl ActionImpl for Groundwork {
     const LEVEL_REQUIREMENT: u8 = 72;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::Groundwork);
-    fn base_progress_increase(state: &SimulationState, settings: &Settings) -> u16 {
+    fn base_progress_increase(state: &SimulationState, settings: &Settings) -> u32 {
         let base = match settings.job_level {
             0..86 => 300,
             86.. => 360,
@@ -526,13 +526,13 @@ pub struct DelicateSynthesis {}
 impl ActionImpl for DelicateSynthesis {
     const LEVEL_REQUIREMENT: u8 = 76;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::DelicateSynthesis);
-    fn base_progress_increase(_state: &SimulationState, settings: &Settings) -> u16 {
+    fn base_progress_increase(_state: &SimulationState, settings: &Settings) -> u32 {
         match settings.job_level {
             0..94 => 100,
             94.. => 150,
         }
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         100
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -562,7 +562,7 @@ impl ActionImpl for IntensiveSynthesis {
         }
         Ok(())
     }
-    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         400
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -596,11 +596,11 @@ impl ActionImpl for TrainedEye {
         _state: &SimulationState,
         settings: &Settings,
         _condition: Condition,
-    ) -> u16 {
-        settings.max_quality
+    ) -> u32 {
+        u32::from(settings.max_quality)
     }
-    fn base_quality_increase(_state: &SimulationState, settings: &Settings) -> u16 {
-        settings.max_quality
+    fn base_quality_increase(_state: &SimulationState, settings: &Settings) -> u32 {
+        u32::from(settings.max_quality)
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
         10
@@ -645,7 +645,7 @@ impl ActionImpl for PrudentSynthesis {
         }
         Ok(())
     }
-    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         180
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -670,7 +670,7 @@ impl ActionImpl for TrainedFinesse {
         }
         Ok(())
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         100
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> i16 {
@@ -695,7 +695,7 @@ impl ActionImpl for RefinedTouch {
         }
         Ok(())
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u16 {
+    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
         100
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> i16 {

--- a/raphael-sim/src/actions.rs
+++ b/raphael-sim/src/actions.rs
@@ -222,13 +222,13 @@ impl ActionImpl for StandardTouch {
         10
     }
     fn base_cp_cost(state: &SimulationState, _settings: &Settings) -> i16 {
-        match state.combo {
+        match state.effects.combo() {
             Combo::BasicTouch => 18,
             _ => 32,
         }
     }
     fn combo(state: &SimulationState, _settings: &Settings, _condition: Condition) -> Combo {
-        match state.combo {
+        match state.effects.combo() {
             Combo::BasicTouch => Combo::StandardTouch,
             _ => Combo::None,
         }
@@ -352,7 +352,7 @@ impl ActionImpl for MuscleMemory {
         _settings: &Settings,
         _condition: Condition,
     ) -> Result<(), &'static str> {
-        if state.combo != Combo::SynthesisBegin {
+        if state.effects.combo() != Combo::SynthesisBegin {
             return Err("Muscle Memory can only be used at synthesis begin.");
         }
         Ok(())
@@ -443,7 +443,7 @@ impl ActionImpl for AdvancedTouch {
         10
     }
     fn base_cp_cost(state: &SimulationState, _settings: &Settings) -> i16 {
-        match state.combo {
+        match state.effects.combo() {
             Combo::StandardTouch => 18,
             _ => 46,
         }
@@ -459,7 +459,7 @@ impl ActionImpl for Reflect {
         _settings: &Settings,
         _condition: Condition,
     ) -> Result<(), &'static str> {
-        if state.combo != Combo::SynthesisBegin {
+        if state.effects.combo() != Combo::SynthesisBegin {
             return Err("Reflect can only be used at synthesis begin.");
         }
         Ok(())
@@ -588,7 +588,7 @@ impl ActionImpl for TrainedEye {
         _settings: &Settings,
         _condition: Condition,
     ) -> Result<(), &'static str> {
-        if state.combo != Combo::SynthesisBegin {
+        if state.effects.combo() != Combo::SynthesisBegin {
             return Err("Trained Eye can only be used at synthesis begin.");
         }
         Ok(())
@@ -691,7 +691,7 @@ impl ActionImpl for RefinedTouch {
         _settings: &Settings,
         _condition: Condition,
     ) -> Result<(), &'static str> {
-        if state.combo != Combo::BasicTouch {
+        if state.effects.combo() != Combo::BasicTouch {
             return Err("Refined Touch can only be used after Observe or Basic Touch.");
         }
         Ok(())
@@ -826,6 +826,7 @@ impl Combo {
 
     pub const fn from_bits(value: u8) -> Self {
         match value {
+            0 => Self::None,
             1 => Self::SynthesisBegin,
             2 => Self::BasicTouch,
             3 => Self::StandardTouch,

--- a/raphael-sim/src/effects.rs
+++ b/raphael-sim/src/effects.rs
@@ -1,4 +1,4 @@
-use crate::Settings;
+use crate::{Combo, Settings};
 
 #[bitfield_struct::bitfield(u32, default = false)]
 #[derive(PartialEq, Eq, Hash)]
@@ -11,7 +11,7 @@ pub struct Effects {
     pub innovation: u8,
     #[bits(3)]
     pub veneration: u8,
-    #[bits(3)]
+    #[bits(2)]
     pub great_strides: u8,
     #[bits(3)]
     pub muscle_memory: u8,
@@ -26,8 +26,8 @@ pub struct Effects {
     pub trained_perfection_active: bool,
     pub heart_and_soul_active: bool,
 
-    #[bits(1)]
-    _padding: u8,
+    #[bits(2)]
+    pub combo: Combo,
 }
 
 impl Effects {
@@ -43,6 +43,7 @@ impl Effects {
             .with_quick_innovation_available(
                 settings.is_action_allowed::<crate::actions::QuickInnovation>(),
             )
+            .with_combo(Combo::SynthesisBegin)
     }
 
     pub fn tick_down(&mut self) {

--- a/raphael-sim/src/state.rs
+++ b/raphael-sim/src/state.rs
@@ -5,7 +5,7 @@ use crate::{Condition, Settings};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SimulationState {
     pub cp: i16,
-    pub durability: i8,
+    pub durability: i16,
     pub progress: u16,
     pub quality: u16,            // previous unguarded action = Poor
     pub unreliable_quality: u16, // previous unguarded action = Normal, diff with quality
@@ -16,7 +16,7 @@ impl SimulationState {
     pub fn new(settings: &Settings) -> Self {
         Self {
             cp: settings.max_cp,
-            durability: settings.max_durability,
+            durability: i16::from(settings.max_durability),
             progress: 0,
             quality: 0,
             unreliable_quality: 0,
@@ -135,7 +135,7 @@ impl SimulationState {
         if A::TICK_EFFECTS {
             if state.effects.manipulation() != 0 {
                 state.durability =
-                    std::cmp::min(settings.max_durability, state.durability.saturating_add(5));
+                    std::cmp::min(i16::from(settings.max_durability), state.durability + 5);
             }
             state.effects.tick_down();
         }

--- a/raphael-sim/src/state.rs
+++ b/raphael-sim/src/state.rs
@@ -10,7 +10,6 @@ pub struct SimulationState {
     pub quality: u16,            // previous unguarded action = Poor
     pub unreliable_quality: u16, // previous unguarded action = Normal, diff with quality
     pub effects: Effects,
-    pub combo: Combo,
 }
 
 impl SimulationState {
@@ -22,7 +21,6 @@ impl SimulationState {
             quality: 0,
             unreliable_quality: 0,
             effects: Effects::initial(settings),
-            combo: Combo::SynthesisBegin,
         }
     }
 
@@ -148,7 +146,9 @@ impl SimulationState {
 
         A::transform_post(&mut state, settings, condition);
 
-        state.combo = A::combo(&state, settings, condition);
+        state
+            .effects
+            .set_combo(A::combo(&state, settings, condition));
 
         Ok(state)
     }

--- a/raphael-sim/src/state.rs
+++ b/raphael-sim/src/state.rs
@@ -6,9 +6,9 @@ use crate::{Condition, Settings};
 pub struct SimulationState {
     pub cp: i16,
     pub durability: i16,
-    pub progress: u16,
-    pub quality: u16,            // previous unguarded action = Poor
-    pub unreliable_quality: u16, // previous unguarded action = Normal, diff with quality
+    pub progress: u32,
+    pub quality: u32,            // previous unguarded action = Poor
+    pub unreliable_quality: u32, // previous unguarded action = Normal, diff with quality
     pub effects: Effects,
 }
 
@@ -54,7 +54,7 @@ impl SimulationState {
     }
 
     pub fn is_final(&self, settings: &Settings) -> bool {
-        self.durability <= 0 || self.progress >= settings.max_progress
+        self.durability <= 0 || self.progress >= u32::from(settings.max_progress)
     }
 
     fn check_common_preconditions<A: ActionImpl>(

--- a/raphael-sim/tests/action_tests.rs
+++ b/raphael-sim/tests/action_tests.rs
@@ -17,11 +17,11 @@ const SETTINGS: Settings = Settings {
 /// - Quality
 /// - Durability (used)
 /// - CP (used)
-fn primary_stats(state: &SimulationState, settings: &Settings) -> (u16, u16, i8, i16) {
+fn primary_stats(state: &SimulationState, settings: &Settings) -> (u16, u16, i16, i16) {
     (
         state.progress,
         state.quality,
-        settings.max_durability - state.durability,
+        i16::from(SETTINGS.max_durability) - state.durability,
         settings.max_cp - state.cp,
     )
 }
@@ -62,7 +62,7 @@ fn test_basic_touch() {
 fn test_master_mend() {
     // Durability-restore fully utilized
     let initial_state = SimulationState {
-        durability: SETTINGS.max_durability - 40,
+        durability: i16::from(SETTINGS.max_durability) - 40,
         ..SimulationState::new(&SETTINGS)
     };
     let state = initial_state
@@ -71,7 +71,7 @@ fn test_master_mend() {
     assert_eq!(primary_stats(&state, &SETTINGS), (0, 0, 10, 88));
     // Durability-restore partially utilized
     let initial_state = SimulationState {
-        durability: SETTINGS.max_durability - 10,
+        durability: i16::from(SETTINGS.max_durability) - 10,
         ..SimulationState::new(&SETTINGS)
     };
     let state = initial_state
@@ -315,7 +315,7 @@ fn test_manipulation() {
     assert_eq!(state.effects.manipulation(), 8);
     // Using Manipulation while Manipulation is already active doesn't restore durability
     let initial_state = SimulationState {
-        durability: SETTINGS.max_durability - 5,
+        durability: i16::from(SETTINGS.max_durability) - 5,
         effects: Effects::new().with_manipulation(2),
         ..SimulationState::new(&SETTINGS)
     };
@@ -417,7 +417,7 @@ fn test_groundwork() {
         .unwrap();
     assert_eq!(
         primary_stats(&state, &SETTINGS),
-        (180, 0, SETTINGS.max_durability + 10, 18)
+        (180, 0, i16::from(SETTINGS.max_durability) + 10, 18)
     );
     // Potency isn't halved when Waste Not causes durability cost to fit into remaining durability
     let initial_state = SimulationState {
@@ -430,7 +430,7 @@ fn test_groundwork() {
         .unwrap();
     assert_eq!(
         primary_stats(&state, &SETTINGS),
-        (360, 0, SETTINGS.max_durability, 18)
+        (360, 0, i16::from(SETTINGS.max_durability), 18)
     );
     // Potency isn't halved when Trained Perfection is active
     let initial_state = SimulationState {
@@ -443,7 +443,7 @@ fn test_groundwork() {
         .unwrap();
     assert_eq!(
         primary_stats(&state, &SETTINGS),
-        (360, 0, SETTINGS.max_durability - 10, 18)
+        (360, 0, i16::from(SETTINGS.max_durability) - 10, 18)
     );
 }
 
@@ -582,7 +582,7 @@ fn test_immaculate_mend() {
     );
     match state {
         Ok(state) => {
-            assert_eq!(state.durability, SETTINGS.max_durability);
+            assert_eq!(state.durability, i16::from(SETTINGS.max_durability));
         }
         Err(e) => panic!("Unexpected error: {}", e),
     }
@@ -600,7 +600,7 @@ fn test_trained_perfection() {
     );
     match state {
         Ok(state) => {
-            assert_eq!(state.durability, SETTINGS.max_durability);
+            assert_eq!(state.durability, i16::from(SETTINGS.max_durability));
         }
         Err(e) => panic!("Unexpected error: {}", e),
     };

--- a/raphael-sim/tests/action_tests.rs
+++ b/raphael-sim/tests/action_tests.rs
@@ -55,7 +55,7 @@ fn test_basic_touch() {
         .unwrap();
     assert_eq!(primary_stats(&state, &SETTINGS), (0, 100, 10, 18));
     assert_eq!(state.effects.inner_quiet(), 1);
-    assert_eq!(state.combo, Combo::BasicTouch);
+    assert_eq!(state.effects.combo(), Combo::BasicTouch);
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn test_observe() {
         .use_action(Action::Observe, Condition::Normal, &SETTINGS)
         .unwrap();
     assert_eq!(primary_stats(&state, &SETTINGS), (0, 0, 0, 7));
-    assert_eq!(state.combo, Combo::StandardTouch);
+    assert_eq!(state.effects.combo(), Combo::StandardTouch);
 }
 
 #[test]
@@ -157,18 +157,16 @@ fn test_standard_touch() {
         .unwrap();
     assert_eq!(primary_stats(&state, &SETTINGS), (0, 125, 10, 32));
     assert_eq!(state.effects.inner_quiet(), 1);
-    assert_eq!(state.combo, Combo::None);
+    assert_eq!(state.effects.combo(), Combo::None);
     // Combo requirement fulfilled
-    let initial_state = SimulationState {
-        combo: Combo::BasicTouch,
-        ..SimulationState::new(&SETTINGS)
-    };
+    let mut initial_state = SimulationState::new(&SETTINGS);
+    initial_state.effects.set_combo(Combo::BasicTouch);
     let state = initial_state
         .use_action(Action::StandardTouch, Condition::Normal, &SETTINGS)
         .unwrap();
     assert_eq!(primary_stats(&state, &SETTINGS), (0, 125, 10, 18));
     assert_eq!(state.effects.inner_quiet(), 1);
-    assert_eq!(state.combo, Combo::StandardTouch);
+    assert_eq!(state.effects.combo(), Combo::StandardTouch);
 }
 
 #[test]
@@ -272,10 +270,8 @@ fn test_precise_touch() {
 #[test]
 fn test_muscle_memory() {
     // Precondition unfulfilled
-    let initial_state = SimulationState {
-        combo: Combo::None,
-        ..SimulationState::new(&SETTINGS)
-    };
+    let mut initial_state = SimulationState::new(&SETTINGS);
+    initial_state.effects.set_combo(Combo::None);
     let error = initial_state
         .use_action(Action::MuscleMemory, Condition::Normal, &SETTINGS)
         .unwrap_err();
@@ -360,10 +356,8 @@ fn test_advanced_touch() {
     assert_eq!(primary_stats(&state, &SETTINGS), (0, 150, 10, 46));
     assert_eq!(state.effects.inner_quiet(), 1);
     // Combo requirement fulfilled
-    let initial_state = SimulationState {
-        combo: Combo::StandardTouch,
-        ..SimulationState::new(&SETTINGS)
-    };
+    let mut initial_state = SimulationState::new(&SETTINGS);
+    initial_state.effects.set_combo(Combo::StandardTouch);
     let state = initial_state
         .use_action(Action::AdvancedTouch, Condition::Normal, &SETTINGS)
         .unwrap();
@@ -374,10 +368,8 @@ fn test_advanced_touch() {
 #[test]
 fn test_reflect() {
     // Precondition unfulfilled
-    let initial_state = SimulationState {
-        combo: Combo::None,
-        ..SimulationState::new(&SETTINGS)
-    };
+    let mut initial_state = SimulationState::new(&SETTINGS);
+    initial_state.effects.set_combo(Combo::None);
     let error = initial_state
         .use_action(Action::Reflect, Condition::Normal, &SETTINGS)
         .unwrap_err();
@@ -517,10 +509,8 @@ fn test_intensive_synthesis() {
 #[test]
 fn test_trained_eye() {
     // Precondition unfulfilled
-    let initial_state = SimulationState {
-        combo: Combo::None,
-        ..SimulationState::new(&SETTINGS)
-    };
+    let mut initial_state = SimulationState::new(&SETTINGS);
+    initial_state.effects.set_combo(Combo::None);
     let error = initial_state
         .use_action(Action::TrainedEye, Condition::Normal, &SETTINGS)
         .unwrap_err();
@@ -640,7 +630,7 @@ fn test_heart_and_soul() {
     );
     match state {
         Ok(state) => {
-            assert_eq!(state.combo, Combo::None); // combo is removed
+            assert_eq!(state.effects.combo(), Combo::None); // combo is removed
             assert_eq!(state.effects.guard(), 1); // guard is unaffected because condition is not re-rolled
             assert_eq!(state.effects.manipulation(), 7); // effects are not ticked
             assert_eq!(state.effects.heart_and_soul_available(), false);
@@ -710,7 +700,7 @@ fn test_quick_innovation() {
     );
     match state {
         Ok(state) => {
-            assert_eq!(state.combo, Combo::None); // combo is removed
+            assert_eq!(state.effects.combo(), Combo::None); // combo is removed
             assert_eq!(state.effects.guard(), 1); // guard is unaffected because condition is not re-rolled
             assert_eq!(state.effects.manipulation(), 7); // effects are not ticked
             assert_eq!(state.effects.innovation(), 1);

--- a/raphael-sim/tests/action_tests.rs
+++ b/raphael-sim/tests/action_tests.rs
@@ -17,7 +17,7 @@ const SETTINGS: Settings = Settings {
 /// - Quality
 /// - Durability (used)
 /// - CP (used)
-fn primary_stats(state: &SimulationState, settings: &Settings) -> (u16, u16, i16, i16) {
+fn primary_stats(state: &SimulationState, settings: &Settings) -> (u32, u32, i16, i16) {
     (
         state.progress,
         state.quality,
@@ -521,7 +521,7 @@ fn test_trained_eye() {
         .unwrap();
     assert_eq!(
         primary_stats(&state, &SETTINGS),
-        (0, SETTINGS.max_quality, 10, 250)
+        (0, u32::from(SETTINGS.max_quality), 10, 250)
     );
     assert_eq!(state.effects.inner_quiet(), 1);
 }

--- a/raphael-sim/tests/adversarial_tests.rs
+++ b/raphael-sim/tests/adversarial_tests.rs
@@ -12,7 +12,7 @@ const SETTINGS: Settings = Settings {
 };
 
 /// Calculate the minimum achievable Quality across all possible Condition rolls
-fn guaranteed_quality(mut settings: Settings, actions: &[Action]) -> Result<u16, &'static str> {
+fn guaranteed_quality(mut settings: Settings, actions: &[Action]) -> Result<u32, &'static str> {
     let is_valid_mask = |mut mask: i32| {
         // a 1-bit denotes an Excellent proc
         if (mask & 1) != 0 {
@@ -31,7 +31,7 @@ fn guaranteed_quality(mut settings: Settings, actions: &[Action]) -> Result<u16,
     };
 
     settings.adversarial = false;
-    let mut min_quality = u16::MAX;
+    let mut min_quality = u32::MAX;
 
     for mask in 0..(1 << actions.len()) {
         if !is_valid_mask(mask) {

--- a/raphael-sim/tests/effect_tests.rs
+++ b/raphael-sim/tests/effect_tests.rs
@@ -17,7 +17,7 @@ const SETTINGS: Settings = Settings {
 /// - Quality
 /// - Durability (used)
 /// - CP (used)
-fn primary_stats(state: &SimulationState, settings: &Settings) -> (u16, u16, i16, i16) {
+fn primary_stats(state: &SimulationState, settings: &Settings) -> (u32, u32, i16, i16) {
     (
         state.progress,
         state.quality,

--- a/raphael-sim/tests/effect_tests.rs
+++ b/raphael-sim/tests/effect_tests.rs
@@ -17,11 +17,11 @@ const SETTINGS: Settings = Settings {
 /// - Quality
 /// - Durability (used)
 /// - CP (used)
-fn primary_stats(state: &SimulationState, settings: &Settings) -> (u16, u16, i8, i16) {
+fn primary_stats(state: &SimulationState, settings: &Settings) -> (u16, u16, i16, i16) {
     (
         state.progress,
         state.quality,
-        settings.max_durability - state.durability,
+        i16::from(SETTINGS.max_durability) - state.durability,
         settings.max_cp - state.cp,
     )
 }

--- a/raphael-solver/src/actions.rs
+++ b/raphael-solver/src/actions.rs
@@ -193,6 +193,6 @@ pub fn use_action_combo(
         state.effects.set_guard(0);
         state.effects.set_quick_innovation_available(false);
     }
-    state.combo = Combo::None;
+    state.effects.set_combo(Combo::None);
     Ok(state)
 }

--- a/raphael-solver/src/finish_solver.rs
+++ b/raphael-solver/src/finish_solver.rs
@@ -9,7 +9,7 @@ use crate::{
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct ReducedState {
-    durability: i8,
+    durability: i16,
     cp: i16,
     effects: Effects,
 }

--- a/raphael-solver/src/finish_solver.rs
+++ b/raphael-solver/src/finish_solver.rs
@@ -12,7 +12,6 @@ struct ReducedState {
     durability: i8,
     cp: i16,
     effects: Effects,
-    combo: Combo,
 }
 
 impl ReducedState {
@@ -27,7 +26,6 @@ impl ReducedState {
                 .with_great_strides(0)
                 .with_guard(0)
                 .with_quick_innovation_available(false),
-            combo: state.combo,
         }
     }
 
@@ -39,7 +37,6 @@ impl ReducedState {
             quality: 0,
             unreliable_quality: 0,
             effects: self.effects,
-            combo: self.combo,
         }
     }
 }

--- a/raphael-solver/src/finish_solver.rs
+++ b/raphael-solver/src/finish_solver.rs
@@ -44,7 +44,7 @@ impl ReducedState {
 pub struct FinishSolver {
     settings: SolverSettings,
     // maximum attainable progress for each state
-    max_progress: HashMap<ReducedState, u16>,
+    max_progress: HashMap<ReducedState, u32>,
 }
 
 impl FinishSolver {
@@ -57,10 +57,10 @@ impl FinishSolver {
 
     pub fn can_finish(&mut self, state: &SimulationState) -> bool {
         let max_progress = self.solve_max_progress(ReducedState::from_state(state));
-        state.progress + max_progress >= self.settings.simulator_settings.max_progress
+        state.progress + max_progress >= self.settings.max_progress()
     }
 
-    fn solve_max_progress(&mut self, state: ReducedState) -> u16 {
+    fn solve_max_progress(&mut self, state: ReducedState) -> u32 {
         match self.max_progress.get(&state) {
             Some(max_progress) => *max_progress,
             None => {
@@ -78,10 +78,10 @@ impl FinishSolver {
                                 std::cmp::max(max_progress, child_progress + new_state.progress);
                         }
                     }
-                    if max_progress >= self.settings.simulator_settings.max_progress {
+                    if max_progress >= self.settings.max_progress() {
                         // stop early if progress is already maxed out
                         // this optimization would work better with a better action ordering
-                        max_progress = self.settings.simulator_settings.max_progress;
+                        max_progress = self.settings.max_progress();
                         break;
                     }
                 }

--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -31,14 +31,34 @@ pub struct SolverSettings {
 }
 
 impl SolverSettings {
-    /// Convenience function to get max progress
+    pub fn max_durability(&self) -> i16 {
+        #[allow(clippy::useless_conversion)]
+        i16::from(self.simulator_settings.max_durability)
+    }
+
+    pub fn max_cp(&self) -> i16 {
+        #[allow(clippy::useless_conversion)]
+        i16::from(self.simulator_settings.max_cp)
+    }
+
     pub fn max_progress(&self) -> u32 {
+        #[allow(clippy::useless_conversion)]
         u32::from(self.simulator_settings.max_progress)
     }
 
-    /// Convenience function to get max quality
     pub fn max_quality(&self) -> u32 {
+        #[allow(clippy::useless_conversion)]
         u32::from(self.simulator_settings.max_quality)
+    }
+
+    pub fn base_progress(&self) -> u32 {
+        #[allow(clippy::useless_conversion)]
+        u32::from(self.simulator_settings.base_progress)
+    }
+
+    pub fn base_quality(&self) -> u32 {
+        #[allow(clippy::useless_conversion)]
+        u32::from(self.simulator_settings.base_quality)
     }
 }
 

--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -30,6 +30,18 @@ pub struct SolverSettings {
     pub allow_unsound_branch_pruning: bool,
 }
 
+impl SolverSettings {
+    /// Convenience function to get max progress
+    pub fn max_progress(&self) -> u32 {
+        u32::from(self.simulator_settings.max_progress)
+    }
+
+    /// Convenience function to get max quality
+    pub fn max_quality(&self) -> u32 {
+        u32::from(self.simulator_settings.max_quality)
+    }
+}
+
 pub mod test_utils {
     use crate::{MacroSolver, SolverException, SolverSettings, utils::AtomicFlag};
     use raphael_sim::*;
@@ -53,23 +65,23 @@ pub mod test_utils {
         .solve()
     }
 
-    pub fn get_score_quad(settings: &Settings, actions: &[Action]) -> (u16, u8, u8, u16) {
+    pub fn get_score_quad(settings: &Settings, actions: &[Action]) -> (u32, u8, u8, u32) {
         let quality = get_quality(settings, actions);
-        let capped_quality = std::cmp::min(quality, settings.max_quality);
-        let overflow_quality = quality.saturating_sub(settings.max_quality);
+        let capped_quality = std::cmp::min(quality, u32::from(settings.max_quality));
+        let overflow_quality = quality.saturating_sub(u32::from(settings.max_quality));
         let steps = actions.len() as u8;
         let duration: u8 = actions.iter().map(|action| action.time_cost()).sum();
         (capped_quality, steps, duration, overflow_quality)
     }
 
-    pub fn get_quality(settings: &Settings, actions: &[Action]) -> u16 {
+    pub fn get_quality(settings: &Settings, actions: &[Action]) -> u32 {
         let mut state = SimulationState::new(settings);
         for action in actions {
             state = state
                 .use_action(*action, Condition::Normal, settings)
                 .unwrap();
         }
-        assert!(state.progress >= settings.max_progress);
+        assert!(state.progress >= u32::from(settings.max_progress));
         state.quality
     }
 

--- a/raphael-solver/src/macro_solver/fast_lower_bound.rs
+++ b/raphael-solver/src/macro_solver/fast_lower_bound.rs
@@ -94,7 +94,7 @@ fn should_use_action(
     allowed_actions: ActionMask,
 ) -> bool {
     // Force the use of an opener if one is available
-    if state.combo == Combo::SynthesisBegin {
+    if state.effects.combo() == Combo::SynthesisBegin {
         let action_is_opener = matches!(
             action,
             ActionCombo::Single(Action::Reflect | Action::MuscleMemory | Action::TrainedEye)

--- a/raphael-solver/src/macro_solver/fast_lower_bound.rs
+++ b/raphael-solver/src/macro_solver/fast_lower_bound.rs
@@ -38,7 +38,7 @@ pub fn fast_lower_bound(
 
     let mut search_queue = std::collections::BinaryHeap::default();
     let initial_node = Node {
-        quality_upper_bound: u32::from(settings.simulator_settings.max_quality),
+        quality_upper_bound: settings.max_quality(),
         state: initial_state,
     };
     search_queue.push(initial_node);
@@ -82,10 +82,7 @@ pub fn fast_lower_bound(
         }
     }
 
-    Ok(std::cmp::min(
-        u32::from(settings.simulator_settings.max_quality),
-        best_achieved_quality,
-    ))
+    Ok(std::cmp::min(settings.max_quality(), best_achieved_quality))
 }
 
 fn should_use_action(

--- a/raphael-solver/src/macro_solver/fast_lower_bound.rs
+++ b/raphael-solver/src/macro_solver/fast_lower_bound.rs
@@ -9,7 +9,7 @@ use crate::{
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Node {
-    quality_upper_bound: u16,
+    quality_upper_bound: u32,
     state: SimulationState,
 }
 
@@ -33,12 +33,12 @@ pub fn fast_lower_bound(
     interrupt_signal: AtomicFlag,
     finish_solver: &mut FinishSolver,
     quality_ub_solver: &mut QualityUpperBoundSolver,
-) -> Result<u16, SolverException> {
+) -> Result<u32, SolverException> {
     let _timer = ScopedTimer::new("Fast lower bound");
 
     let mut search_queue = std::collections::BinaryHeap::default();
     let initial_node = Node {
-        quality_upper_bound: settings.simulator_settings.max_quality,
+        quality_upper_bound: u32::from(settings.simulator_settings.max_quality),
         state: initial_state,
     };
     search_queue.push(initial_node);
@@ -83,7 +83,7 @@ pub fn fast_lower_bound(
     }
 
     Ok(std::cmp::min(
-        settings.simulator_settings.max_quality,
+        u32::from(settings.simulator_settings.max_quality),
         best_achieved_quality,
     ))
 }

--- a/raphael-solver/src/macro_solver/pareto_front/quality_pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front/quality_pareto_front.rs
@@ -6,8 +6,8 @@ use super::{Dominate, ParetoFront};
 #[derive(Clone, Copy, PartialEq, Eq)]
 struct Value {
     cp: i16,
-    quality: u16,
-    unreliable_quality: u16,
+    quality: u32,
+    unreliable_quality: u32,
     inner_quiet: u8,
     durability: i16,
 }
@@ -37,7 +37,7 @@ impl Dominate for Value {
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 struct Key {
-    progress: u16,
+    progress: u32,
     effects: Effects,
     combo: Combo,
 }

--- a/raphael-solver/src/macro_solver/pareto_front/quality_pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front/quality_pareto_front.rs
@@ -9,7 +9,7 @@ struct Value {
     quality: u16,
     unreliable_quality: u16,
     inner_quiet: u8,
-    durability: i8,
+    durability: i16,
 }
 
 impl Value {

--- a/raphael-solver/src/macro_solver/pareto_front/quality_pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front/quality_pareto_front.rs
@@ -47,7 +47,7 @@ impl Key {
         Self {
             progress: state.progress,
             effects: state.effects.with_inner_quiet(0), // iq is included in the pareto value
-            combo: state.combo,
+            combo: state.effects.combo(),
         }
     }
 }

--- a/raphael-solver/src/macro_solver/search_queue.rs
+++ b/raphael-solver/src/macro_solver/search_queue.rs
@@ -8,7 +8,7 @@ use super::pareto_front::{EffectParetoFront, QualityParetoFront};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SearchScore {
-    pub quality_upper_bound: u16,
+    pub quality_upper_bound: u32,
     pub steps_lower_bound: u8,
     pub duration_lower_bound: u8,
     pub current_steps: u8,
@@ -25,7 +25,7 @@ impl SearchScore {
     };
 
     pub const MAX: Self = Self {
-        quality_upper_bound: u16::MAX,
+        quality_upper_bound: u32::MAX,
         steps_lower_bound: 0,
         duration_lower_bound: 0,
         current_steps: 0,

--- a/raphael-solver/src/macro_solver/search_queue.rs
+++ b/raphael-solver/src/macro_solver/search_queue.rs
@@ -150,7 +150,7 @@ impl SearchQueue {
 fn pareto_weight(state: &SimulationState) -> u32 {
     state.cp as u32
         + state.durability as u32
-        + state.quality as u32
-        + state.unreliable_quality as u32
+        + state.quality
+        + state.unreliable_quality
         + state.effects.into_bits()
 }

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -86,7 +86,7 @@ impl<'a> MacroSolver<'a> {
             || {
                 let _timer = ScopedTimer::new("Step LB Solver");
                 let mut seed_state = SimulationState::new(&self.settings.simulator_settings);
-                seed_state.combo = Combo::None;
+                seed_state.effects.set_combo(Combo::None);
                 self.step_lb_solver.step_lower_bound(seed_state, 0)
             },
         );

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -80,8 +80,7 @@ impl<'a> MacroSolver<'a> {
         _ = rayon::join(
             || {
                 let _timer = ScopedTimer::new("Quality UB Solver");
-                self.quality_ub_solver
-                    .precompute(self.settings.simulator_settings.max_cp)
+                self.quality_ub_solver.precompute(self.settings.max_cp())
             },
             || {
                 let _timer = ScopedTimer::new("Step LB Solver");

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -219,8 +219,8 @@ impl Drop for QualityUpperBoundSolver {
         let num_states = self.solved_states.len();
         let num_values = self
             .solved_states
-            .iter()
-            .map(|(_key, value)| value.len())
+            .values()
+            .map(|value| value.len())
             .sum::<usize>();
         log::debug!("QualityUpperBoundSolver - states: {num_states}, values: {num_values}");
     }

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -123,10 +123,10 @@ impl QualityUpperBoundSolver {
     /// Returns an upper-bound on the maximum Quality achievable from this state while also maxing out Progress.
     /// There is no guarantee on the tightness of the upper-bound.
     pub fn quality_upper_bound(&mut self, state: SimulationState) -> Result<u16, SolverException> {
-        if state.combo != Combo::None {
+        if state.effects.combo() != Combo::None {
             return Err(SolverException::InternalError(format!(
                 "\"{:?}\" combo in quality upper bound solver",
-                state.combo
+                state.effects.combo()
             )));
         }
 

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -26,15 +26,14 @@ pub struct QualityUpperBoundSolver {
 impl QualityUpperBoundSolver {
     pub fn new(mut settings: SolverSettings, interrupt_signal: utils::AtomicFlag) -> Self {
         let durability_cost = durability_cost(&settings.simulator_settings);
-        settings.simulator_settings.max_cp +=
-            durability_cost * (settings.simulator_settings.max_durability as i16 / 5);
+        settings.simulator_settings.max_cp += durability_cost * (settings.max_durability() / 5);
         Self {
             settings,
             interrupt_signal,
             solved_states: SolvedStates::default(),
             pareto_front_builder: ParetoFrontBuilder::new(
-                u32::from(settings.simulator_settings.max_progress),
-                u32::from(settings.simulator_settings.max_quality),
+                settings.max_progress(),
+                settings.max_quality(),
             ),
             durability_cost,
         }
@@ -65,7 +64,7 @@ impl QualityUpperBoundSolver {
             templates
                 .par_iter()
                 .filter(|state| {
-                    let missing_cp = self.settings.simulator_settings.max_cp - cp;
+                    let missing_cp = self.settings.max_cp() - cp;
                     minimum_cp_cost(state, cost_per_inner_quiet_tick) <= missing_cp
                 })
                 .for_each_init(init, |(solved_mtx, pareto_front_builder), &state| {

--- a/raphael-solver/src/quality_upper_bound_solver/state.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/state.rs
@@ -26,7 +26,7 @@ impl ReducedState {
             state.cp += durability_cost * 4;
         }
         state.cp += state.durability as i16 / 5 * durability_cost;
-        state.durability = settings.simulator_settings.max_durability;
+        state.durability = i16::from(settings.simulator_settings.max_durability);
         Self::from_simulation_state_inner(&state, settings, durability_cost)
     }
 
@@ -36,8 +36,9 @@ impl ReducedState {
         durability_cost: i16,
     ) -> Self {
         let progress_only = is_progress_only_state(settings, state);
-        let used_durability = (settings.simulator_settings.max_durability - state.durability) / 5;
-        let cp = state.cp - used_durability as i16 * durability_cost;
+        let used_durability =
+            i16::from(settings.simulator_settings.max_durability) - state.durability;
+        let cp = state.cp - used_durability / 5 * durability_cost;
         let compressed_unreliable_quality = if progress_only {
             0
         } else {
@@ -64,7 +65,7 @@ impl ReducedState {
 
     fn to_simulation_state(self, settings: &Settings) -> SimulationState {
         SimulationState {
-            durability: settings.max_durability,
+            durability: i16::from(settings.max_durability),
             cp: self.cp,
             progress: 0,
             quality: 0,

--- a/raphael-solver/src/quality_upper_bound_solver/state.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/state.rs
@@ -26,7 +26,7 @@ impl ReducedState {
             state.cp += durability_cost * 4;
         }
         state.cp += state.durability as i16 / 5 * durability_cost;
-        state.durability = i16::from(settings.simulator_settings.max_durability);
+        state.durability = settings.max_durability();
         Self::from_simulation_state_inner(&state, settings, durability_cost)
     }
 
@@ -36,15 +36,14 @@ impl ReducedState {
         durability_cost: i16,
     ) -> Self {
         let progress_only = is_progress_only_state(settings, state);
-        let used_durability =
-            i16::from(settings.simulator_settings.max_durability) - state.durability;
+        let used_durability = settings.max_durability() - state.durability;
         let cp = state.cp - used_durability / 5 * durability_cost;
         let compressed_unreliable_quality = if progress_only {
             0
         } else {
             state
                 .unreliable_quality
-                .div_ceil(2 * u32::from(settings.simulator_settings.base_quality)) as u8
+                .div_ceil(2 * settings.base_quality()) as u8
         };
         let effects = {
             let great_strides_active = state.effects.great_strides() != 0;
@@ -63,14 +62,14 @@ impl ReducedState {
         }
     }
 
-    fn to_simulation_state(self, settings: &Settings) -> SimulationState {
+    fn to_simulation_state(self, settings: &SolverSettings) -> SimulationState {
         SimulationState {
-            durability: i16::from(settings.max_durability),
+            durability: settings.max_durability(),
             cp: self.cp,
             progress: 0,
             quality: 0,
             unreliable_quality: u32::from(self.compressed_unreliable_quality)
-                * (2 * u32::from(settings.base_quality)),
+                * (2 * settings.base_quality()),
             effects: self.effects,
         }
     }
@@ -105,7 +104,7 @@ impl ReducedState {
             ) => Err("Action not supported"),
             _ => {
                 let progress_only = self.progress_only;
-                let state = self.to_simulation_state(&settings.simulator_settings);
+                let state = self.to_simulation_state(settings);
                 match use_action_combo(settings, state, action) {
                     Ok(state) => {
                         let mut solver_state =

--- a/raphael-solver/src/quality_upper_bound_solver/state.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/state.rs
@@ -25,7 +25,7 @@ impl ReducedState {
         {
             state.cp += durability_cost * 4;
         }
-        state.cp += state.durability as i16 / 5 * durability_cost;
+        state.cp += state.durability / 5 * durability_cost;
         state.durability = settings.max_durability();
         Self::from_simulation_state_inner(&state, settings, durability_cost)
     }
@@ -80,7 +80,7 @@ impl ReducedState {
             && self.effects.innovation() == 0
             && self.effects.great_strides() == 0
             && self.effects.guard() == 0
-            && self.effects.quick_innovation_available() == false
+            && !self.effects.quick_innovation_available()
     }
 
     fn strip_quality_attributes(&mut self) {

--- a/raphael-solver/src/quality_upper_bound_solver/state.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/state.rs
@@ -44,7 +44,7 @@ impl ReducedState {
         } else {
             state
                 .unreliable_quality
-                .div_ceil(2 * settings.simulator_settings.base_quality) as u8
+                .div_ceil(2 * u32::from(settings.simulator_settings.base_quality)) as u8
         };
         let effects = {
             let great_strides_active = state.effects.great_strides() != 0;
@@ -69,9 +69,8 @@ impl ReducedState {
             cp: self.cp,
             progress: 0,
             quality: 0,
-            unreliable_quality: self.compressed_unreliable_quality as u16
-                * settings.base_quality
-                * 2,
+            unreliable_quality: u32::from(self.compressed_unreliable_quality)
+                * (2 * u32::from(settings.base_quality)),
             effects: self.effects,
         }
     }
@@ -99,7 +98,7 @@ impl ReducedState {
         action: ActionCombo,
         settings: &SolverSettings,
         durability_cost: i16,
-    ) -> Result<(Self, u16, u16), &'static str> {
+    ) -> Result<(Self, u32, u32), &'static str> {
         match action {
             ActionCombo::Single(
                 Action::MasterMend | Action::ImmaculateMend | Action::Manipulation,

--- a/raphael-solver/src/quality_upper_bound_solver/state.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/state.rs
@@ -72,7 +72,6 @@ impl ReducedState {
                 * settings.base_quality
                 * 2,
             effects: self.effects,
-            combo: Combo::None,
         }
     }
 

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::QualityUpperBoundSolver;
 
-fn solve(simulator_settings: Settings, actions: &[Action]) -> u16 {
+fn solve(simulator_settings: Settings, actions: &[Action]) -> u32 {
     let mut state = SimulationState::from_macro(&simulator_settings, actions).unwrap();
     state.effects.set_combo(Combo::None);
     let solver_settings = SolverSettings {
@@ -459,7 +459,7 @@ fn random_state(settings: &Settings) -> SimulationState {
     SimulationState {
         cp: rand::thread_rng().gen_range(0..=settings.max_cp),
         durability: rand::thread_rng().gen_range(1..=(i16::from(settings.max_durability) / 5)) * 5,
-        progress: rand::thread_rng().gen_range(0..settings.max_progress),
+        progress: rand::thread_rng().gen_range(0..u32::from(settings.max_progress)),
         quality: 0,
         unreliable_quality: 0,
         effects: random_effects(settings.adversarial),
@@ -485,8 +485,8 @@ fn monotonic_fuzz_check(simulator_settings: Settings) {
             let child_upper_bound = match use_action_combo(&solver_settings, state, *action) {
                 Ok(child) => match child.is_final(&simulator_settings) {
                     false => solver.quality_upper_bound(child).unwrap(),
-                    true if child.progress >= simulator_settings.max_progress => {
-                        std::cmp::min(simulator_settings.max_quality, child.quality)
+                    true if child.progress >= u32::from(simulator_settings.max_progress) => {
+                        std::cmp::min(u32::from(simulator_settings.max_quality), child.quality)
                     }
                     true => 0,
                 },

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -458,7 +458,7 @@ fn random_effects(adversarial: bool) -> Effects {
 fn random_state(settings: &Settings) -> SimulationState {
     SimulationState {
         cp: rand::thread_rng().gen_range(0..=settings.max_cp),
-        durability: rand::thread_rng().gen_range(1..=(settings.max_durability / 5)) * 5,
+        durability: rand::thread_rng().gen_range(1..=(i16::from(settings.max_durability) / 5)) * 5,
         progress: rand::thread_rng().gen_range(0..settings.max_progress),
         quality: 0,
         unreliable_quality: 0,

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -9,10 +9,8 @@ use crate::{
 use super::QualityUpperBoundSolver;
 
 fn solve(simulator_settings: Settings, actions: &[Action]) -> u16 {
-    let state = SimulationState {
-        combo: Combo::None,
-        ..SimulationState::from_macro(&simulator_settings, actions).unwrap()
-    };
+    let mut state = SimulationState::from_macro(&simulator_settings, actions).unwrap();
+    state.effects.set_combo(Combo::None);
     let solver_settings = SolverSettings {
         simulator_settings,
         backload_progress: false,
@@ -465,7 +463,6 @@ fn random_state(settings: &Settings) -> SimulationState {
         quality: 0,
         unreliable_quality: 0,
         effects: random_effects(settings.adversarial),
-        combo: Combo::None,
     }
     .try_into()
     .unwrap()

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -62,10 +62,10 @@ impl StepLowerBoundSolver {
         state: SimulationState,
         step_budget: NonZeroU8,
     ) -> Result<u16, SolverException> {
-        if state.combo != Combo::None {
+        if state.effects.combo() != Combo::None {
             return Err(SolverException::InternalError(format!(
                 "\"{:?}\" combo in step lower bound solver",
-                state.combo
+                state.effects.combo()
             )));
         }
 

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -173,8 +173,8 @@ impl Drop for StepLowerBoundSolver {
         let num_states = self.solved_states.len();
         let num_values = self
             .solved_states
-            .iter()
-            .map(|(_key, value)| value.len())
+            .values()
+            .map(|value| value.len())
             .sum::<usize>();
         log::debug!("StepLowerBoundSolver - states: {num_states}, values: {num_values}");
     }

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -31,8 +31,8 @@ impl StepLowerBoundSolver {
             interrupt_signal,
             solved_states: SolvedStates::default(),
             pareto_front_builder: ParetoFrontBuilder::new(
-                u32::from(settings.simulator_settings.max_progress),
-                u32::from(settings.simulator_settings.max_quality),
+                settings.max_progress(),
+                settings.max_quality(),
             ),
         }
     }

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -12,8 +12,8 @@ use raphael_sim::*;
 
 use super::state::ReducedState;
 
-type ParetoValue = utils::ParetoValue<u16, u16>;
-type ParetoFrontBuilder = utils::ParetoFrontBuilder<u16, u16>;
+type ParetoValue = utils::ParetoValue<u32, u32>;
+type ParetoFrontBuilder = utils::ParetoFrontBuilder<u32, u32>;
 type SolvedStates = rustc_hash::FxHashMap<ReducedState, Box<[ParetoValue]>>;
 
 pub struct StepLowerBoundSolver {
@@ -31,8 +31,8 @@ impl StepLowerBoundSolver {
             interrupt_signal,
             solved_states: SolvedStates::default(),
             pareto_front_builder: ParetoFrontBuilder::new(
-                settings.simulator_settings.max_progress,
-                settings.simulator_settings.max_quality,
+                u32::from(settings.simulator_settings.max_progress),
+                u32::from(settings.simulator_settings.max_quality),
             ),
         }
     }
@@ -44,13 +44,13 @@ impl StepLowerBoundSolver {
     ) -> Result<u8, SolverException> {
         if self.settings.backload_progress
             && state.progress != 0
-            && state.quality < self.settings.simulator_settings.max_quality
+            && state.quality < self.settings.max_quality()
         {
             return Ok(u8::MAX);
         }
         let mut hint = NonZeroU8::try_from(std::cmp::max(hint, 1)).unwrap();
         while hint.get() != u8::MAX
-            && self.quality_upper_bound(state, hint)? < self.settings.simulator_settings.max_quality
+            && self.quality_upper_bound(state, hint)? < self.settings.max_quality()
         {
             hint = hint.saturating_add(1);
         }
@@ -61,7 +61,7 @@ impl StepLowerBoundSolver {
         &mut self,
         state: SimulationState,
         step_budget: NonZeroU8,
-    ) -> Result<u16, SolverException> {
+    ) -> Result<u32, SolverException> {
         if state.effects.combo() != Combo::None {
             return Err(SolverException::InternalError(format!(
                 "\"{:?}\" combo in step lower bound solver",
@@ -71,17 +71,14 @@ impl StepLowerBoundSolver {
 
         let progress_only = is_progress_only_state(&self.settings, &state);
         let reduced_state = ReducedState::from_state(state, step_budget, progress_only);
-        let required_progress = self.settings.simulator_settings.max_progress - state.progress;
+        let required_progress = self.settings.max_progress() - state.progress;
 
         if let Some(pareto_front) = self.solved_states.get(&reduced_state) {
             let index = pareto_front.partition_point(|value| value.first < required_progress);
             let quality = pareto_front
                 .get(index)
-                .map_or(0, |value| state.quality.saturating_add(value.second));
-            return Ok(std::cmp::min(
-                self.settings.simulator_settings.max_quality,
-                quality,
-            ));
+                .map_or(0, |value| state.quality + value.second);
+            return Ok(std::cmp::min(self.settings.max_quality(), quality));
         }
 
         self.solve_state(reduced_state)?;
@@ -90,11 +87,8 @@ impl StepLowerBoundSolver {
             let index = pareto_front.partition_point(|value| value.first < required_progress);
             let quality = pareto_front
                 .get(index)
-                .map_or(0, |value| state.quality.saturating_add(value.second));
-            Ok(std::cmp::min(
-                self.settings.simulator_settings.max_quality,
-                quality,
-            ))
+                .map_or(0, |value| state.quality + value.second);
+            Ok(std::cmp::min(self.settings.max_quality(), quality))
         } else {
             unreachable!("State must be in memoization table after solver")
         }
@@ -153,8 +147,8 @@ impl StepLowerBoundSolver {
                         .unwrap()
                         .iter_mut()
                         .for_each(|value| {
-                            value.first = value.first.saturating_add(action_progress);
-                            value.second = value.second.saturating_add(action_quality);
+                            value.first += action_progress;
+                            value.second += action_quality;
                         });
                     self.pareto_front_builder.merge();
                 }

--- a/raphael-solver/src/step_lower_bound_solver/state.rs
+++ b/raphael-solver/src/step_lower_bound_solver/state.rs
@@ -6,7 +6,7 @@ use raphael_sim::*;
 pub struct ReducedState {
     pub steps_budget: NonZeroU8,
     pub progress_only: bool,
-    pub durability: i8,
+    pub durability: i16,
     pub effects: Effects,
 }
 
@@ -59,7 +59,7 @@ impl ReducedState {
         }
     }
 
-    fn optimize_durability(effects: Effects, durability: i8, step_budget: NonZeroU8) -> i8 {
+    fn optimize_durability(effects: Effects, durability: i16, step_budget: NonZeroU8) -> i16 {
         let mut usable_durability: i32 = step_budget.get() as i32 * 20;
         let usable_manipulation = std::cmp::min(effects.manipulation(), step_budget.get() - 1);
         usable_durability -= usable_manipulation as i32 * 5;

--- a/raphael-solver/src/step_lower_bound_solver/state.rs
+++ b/raphael-solver/src/step_lower_bound_solver/state.rs
@@ -56,7 +56,6 @@ impl ReducedState {
             quality: 0,
             unreliable_quality: 0,
             effects: self.effects,
-            combo: Combo::None,
         }
     }
 

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -9,10 +9,8 @@ use crate::{
 use super::*;
 
 fn solve(simulator_settings: Settings, actions: &[Action]) -> u8 {
-    let state = SimulationState {
-        combo: Combo::None,
-        ..SimulationState::from_macro(&simulator_settings, actions).unwrap()
-    };
+    let mut state = SimulationState::from_macro(&simulator_settings, actions).unwrap();
+    state.effects.set_combo(Combo::None);
     let solver_settings = SolverSettings {
         simulator_settings,
         backload_progress: false,
@@ -486,7 +484,6 @@ fn random_state(settings: &Settings) -> SimulationState {
         quality: 0,
         unreliable_quality: 0,
         effects: random_effects(settings.adversarial),
-        combo: Combo::None,
     }
     .try_into()
     .unwrap()

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -479,7 +479,7 @@ fn random_effects(adversarial: bool) -> Effects {
 fn random_state(settings: &Settings) -> SimulationState {
     SimulationState {
         cp: rand::thread_rng().gen_range(0..=settings.max_cp),
-        durability: rand::thread_rng().gen_range(1..=(settings.max_durability / 5)) * 5,
+        durability: rand::thread_rng().gen_range(1..=(i16::from(settings.max_durability) / 5)) * 5,
         progress: rand::thread_rng().gen_range(0..settings.max_progress),
         quality: 0,
         unreliable_quality: 0,

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -480,7 +480,7 @@ fn random_state(settings: &Settings) -> SimulationState {
     SimulationState {
         cp: rand::thread_rng().gen_range(0..=settings.max_cp),
         durability: rand::thread_rng().gen_range(1..=(i16::from(settings.max_durability) / 5)) * 5,
-        progress: rand::thread_rng().gen_range(0..settings.max_progress),
+        progress: rand::thread_rng().gen_range(0..u32::from(settings.max_progress)),
         quality: 0,
         unreliable_quality: 0,
         effects: random_effects(settings.adversarial),
@@ -505,8 +505,8 @@ fn monotonic_fuzz_check(simulator_settings: Settings) {
             let child_lower_bound = match use_action_combo(&solver_settings, state, *action) {
                 Ok(child) => match child.is_final(&simulator_settings) {
                     false => solver.step_lower_bound(child, 0).unwrap(),
-                    true if child.progress >= simulator_settings.max_progress
-                        && child.quality >= simulator_settings.max_quality =>
+                    true if child.progress >= u32::from(simulator_settings.max_progress)
+                        && child.quality >= u32::from(simulator_settings.max_quality) =>
                     {
                         0
                     }

--- a/raphael-solver/src/utils/pareto_front_builder.rs
+++ b/raphael-solver/src/utils/pareto_front_builder.rs
@@ -17,7 +17,7 @@ where
 {
     segments: Vec<usize>, // indices to the beginning of each segment
     buffer: Vec<ParetoValue<T, U>>,
-    merge_buffer: [ParetoValue<T, U>; 1024],
+    merge_buffer: [ParetoValue<T, U>; 512],
     // cut-off values
     max_first: T,
     max_second: U,
@@ -30,9 +30,9 @@ where
 {
     pub fn new(max_first: T, max_second: U) -> Self {
         Self {
-            segments: Vec::with_capacity(1 << 12),
-            buffer: Vec::with_capacity(1 << 12),
-            merge_buffer: [ParetoValue::default(); 1024],
+            segments: Vec::new(),
+            buffer: Vec::new(),
+            merge_buffer: [ParetoValue::default(); 512],
             max_first,
             max_second,
         }

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -64,20 +64,19 @@ fn max_quality() {
 }
 
 #[test]
-#[ignore = "TODO"]
 fn large_progress_quality_increase() {
     let settings = Settings {
         max_cp: 300,
         max_durability: 40,
         max_progress: 100,
         max_quality: 100,
-        base_progress: 5000,
-        base_quality: 5000,
+        base_progress: u16::MAX,
+        base_quality: u16::MAX,
         job_level: 100,
         allowed_actions: ActionMask::all(),
         adversarial: false,
     };
     let actions = solve(&settings, false, false).unwrap();
     let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (100, 1, 3, 4900));
+    assert_eq!(score, (100, 1, 3, u32::from(u16::MAX) - 100));
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -815,7 +815,7 @@ impl MacroSolverApp {
             );
         });
 
-        game_settings.max_quality = target_quality.saturating_sub(initial_quality);
+        game_settings.max_quality = target_quality.saturating_sub(initial_quality) as u16;
         spawn_solver(
             self.solver_config,
             game_settings,
@@ -956,7 +956,7 @@ fn spawn_solver(
                     let quality =
                         raphael_solver::test_utils::get_quality(&simulator_settings, &actions);
                     solver_events.push_back(SolverEvent::Actions(actions));
-                    if quality >= simulator_settings.max_quality {
+                    if quality >= u32::from(simulator_settings.max_quality) {
                         solver_events.push_back(SolverEvent::Finished(None));
                         return;
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1007,7 +1007,7 @@ fn fetch_latest_version(latest_version: Arc<Mutex<semver::Version>>) {
         request,
         move |result: ehttp::Result<ehttp::Response>| match result {
             Ok(response) => match response.json::<ApiResponse>() {
-                Ok(data) => match semver::Version::parse(data.tag_name.trim_start_matches("v")) {
+                Ok(data) => match semver::Version::parse(data.tag_name.trim_start_matches('v')) {
                     Ok(version) => {
                         log::debug!("Latest version: {}", version);
                         *latest_version.lock().unwrap() = version;

--- a/src/widgets/simulator.rs
+++ b/src/widgets/simulator.rs
@@ -128,7 +128,7 @@ impl Simulator<'_> {
                         )
                         .text(progress_bar_text(
                             state.durability,
-                            self.settings.max_durability,
+                            i16::from(self.settings.max_durability),
                         ))
                         .corner_radius(0),
                     );

--- a/src/widgets/simulator.rs
+++ b/src/widgets/simulator.rs
@@ -100,7 +100,7 @@ impl Simulator<'_> {
                         )
                         .text(progress_bar_text(
                             state.progress,
-                            self.settings.max_progress,
+                            u32::from(self.settings.max_progress),
                         ))
                         .corner_radius(0),
                     );
@@ -110,10 +110,13 @@ impl Simulator<'_> {
                     ui.allocate_ui_with_layout(text_size, text_layout, |ui| {
                         ui.label("Quality");
                     });
-                    let quality = self.initial_quality + state.quality;
+                    let quality = u32::from(self.initial_quality) + state.quality;
                     ui.add(
                         egui::ProgressBar::new(quality as f32 / self.settings.max_quality as f32)
-                            .text(progress_bar_text(quality, self.settings.max_quality))
+                            .text(progress_bar_text(
+                                quality,
+                                u32::from(self.settings.max_quality),
+                            ))
                             .corner_radius(0),
                     );
                 });
@@ -154,7 +157,7 @@ impl Simulator<'_> {
                         }));
                         if !state.is_final(self.settings) {
                             // do nothing
-                        } else if state.progress < self.settings.max_progress {
+                        } else if state.progress < u32::from(self.settings.max_progress) {
                             ui.label("Synthesis failed");
                         } else if self.item.always_collectable {
                             let (t1, t2, t3) = (
@@ -162,16 +165,16 @@ impl Simulator<'_> {
                                 QualityTarget::CollectableT2.get_target(self.settings.max_quality),
                                 QualityTarget::CollectableT3.get_target(self.settings.max_quality),
                             );
-                            let tier = match self.initial_quality + state.quality {
-                                quality if quality >= t3 => 3,
-                                quality if quality >= t2 => 2,
-                                quality if quality >= t1 => 1,
+                            let tier = match u32::from(self.initial_quality) + state.quality {
+                                quality if quality >= u32::from(t3) => 3,
+                                quality if quality >= u32::from(t2) => 2,
+                                quality if quality >= u32::from(t1) => 1,
                                 _ => 0,
                             };
                             ui.label(format!("Tier {} collectable", tier));
                         } else {
                             let hq = raphael_data::hq_percentage(
-                                self.initial_quality + state.quality,
+                                u32::from(self.initial_quality) + state.quality,
                                 self.settings.max_quality,
                             )
                             .unwrap_or(0);


### PR DESCRIPTION
Change representation of Progress, Quality, and Durability in `SimulationState` to `u32`, `u32`, and `i16` respectively.

Progress, Quality, and Durability in `Settings` remain unchanged (`u16`, `u16`, and `i8`).