### PR TITLE
Fix low durability recipes with no manipulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ web-time = "1.1.0"
 
 [package]
 name = "raphael-xiv"
-version = "0.19.4"
+version = "0.19.5"
 edition = "2024"
 default-run = "raphael-xiv"
 

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -285,9 +285,9 @@ impl Drop for QualityUpperBoundSolver {
 
 /// Calculates the CP cost to "magically" restore 5 durability
 fn durability_cost(settings: &Settings) -> i16 {
-    let mut cost = 20;
+    let mut cost = 100;
     if settings.is_action_allowed::<MasterMend>() {
-        let cost_per_five = MasterMend::CP_COST / 6;
+        let cost_per_five = MasterMend::CP_COST / std::cmp::min(6, settings.max_durability as i16 / 5 - 1);
         cost = std::cmp::min(cost, cost_per_five);
     }
     if settings.is_action_allowed::<Manipulation>() {


### PR DESCRIPTION
Potentially closes #123, I haven't tested the web version yet.

For native it lowers the time the fast lower bound solver takes from >500s to <30s for the craft shown in the issue.