### PR TITLE
Add custom recipe overrides

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ web-time = "1.1.0"
 
 [package]
 name = "raphael-xiv"
-version = "0.19.5"
+version = "0.19.6"
 edition = "2024"
 default-run = "raphael-xiv"
 

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -225,7 +225,8 @@ pub fn execute(args: &SolveArgs) {
         quick_innovation: args.quick_innovation,
     };
 
-    let mut settings = get_game_settings(*recipe, crafter_stats, food, potion, args.adversarial);
+    let mut settings =
+        get_game_settings(*recipe, None, crafter_stats, food, potion, args.adversarial);
     let target_quality = match args.target_quality {
         Some(target) => target.clamp(0, settings.max_quality),
         None => settings.max_quality,

--- a/raphael-data/tests/test_get_game_settings.rs
+++ b/raphael-data/tests/test_get_game_settings.rs
@@ -45,7 +45,7 @@ fn test_roast_chicken() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
     assert_eq!(
         settings,
         Settings {
@@ -87,7 +87,7 @@ fn test_turali_pineapple_ponzecake() {
         heart_and_soul: true,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
     assert_eq!(
         settings,
         Settings {
@@ -128,7 +128,7 @@ fn test_smaller_water_otter_hardware() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
     assert_eq!(
         settings,
         Settings {
@@ -169,7 +169,7 @@ fn test_grade_8_tincture() {
         heart_and_soul: true,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
     assert_eq!(
         settings,
         Settings {
@@ -203,7 +203,7 @@ fn test_claro_walnut_spinning_wheel() {
         heart_and_soul: false,
         quick_innovation: true,
     };
-    let settings = get_game_settings(recipe, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
     assert_eq!(
         settings,
         Settings {
@@ -234,7 +234,7 @@ fn test_habitat_chair_lv100() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
     assert_eq!(
         settings,
         Settings {
@@ -267,7 +267,7 @@ fn test_habitat_chair_lv97() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
     assert_eq!(
         settings,
         Settings {
@@ -300,7 +300,7 @@ fn test_habitat_chair_lv98() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
     assert_eq!(
         settings,
         Settings {
@@ -333,7 +333,7 @@ fn test_standard_indurate_rings_lv93() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
     assert_eq!(
         settings,
         Settings {
@@ -366,7 +366,7 @@ fn test_lunar_alloy_ingots_lv90() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
     assert_eq!(
         settings,
         Settings {
@@ -399,7 +399,7 @@ fn test_standard_high_density_fiberboard_lv91() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
     assert_eq!(
         settings,
         Settings {

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use raphael_data::{Consumable, Locale, action_name, get_initial_quality, get_job
 
 use raphael_sim::{Action, ActionImpl, HeartAndSoul, Manipulation, QuickInnovation};
 
-use crate::config::{CrafterConfig, QualitySource, QualityTarget, RecipeConfiguration};
+use crate::config::{CrafterConfig, CustomRecipeOverridesConfiguration, QualitySource, QualityTarget, RecipeConfiguration};
 use crate::widgets::*;
 
 fn load<T: DeserializeOwned>(cc: &eframe::CreationContext<'_>, key: &'static str, default: T) -> T {
@@ -37,6 +37,7 @@ pub struct SolverConfig {
 pub struct MacroSolverApp {
     locale: Locale,
     recipe_config: RecipeConfiguration,
+    custom_recipe_overrides_config: CustomRecipeOverridesConfiguration,
     selected_food: Option<Consumable>,
     selected_potion: Option<Consumable>,
     crafter_config: CrafterConfig,
@@ -89,6 +90,7 @@ impl MacroSolverApp {
         Self {
             locale: load(cc, "LOCALE", Locale::EN),
             recipe_config: load(cc, "RECIPE_CONFIG", RecipeConfiguration::default()),
+            custom_recipe_overrides_config: load(cc, "CUSTOM_RECIPE_OVERRIDES_CONFIG", CustomRecipeOverridesConfiguration::default()),
             selected_food: load(cc, "SELECTED_FOOD", None),
             selected_potion: load(cc, "SELECTED_POTION", None),
             crafter_config: load(cc, "CRAFTER_CONFIG", CrafterConfig::default()),
@@ -397,6 +399,7 @@ impl eframe::App for MacroSolverApp {
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
         eframe::set_value(storage, "LOCALE", &self.locale);
         eframe::set_value(storage, "RECIPE_CONFIG", &self.recipe_config);
+        eframe::set_value(storage, "CUSTOM_RECIPE_OVERRIDES_CONFIG", &self.custom_recipe_overrides_config);
         eframe::set_value(storage, "SELECTED_FOOD", &self.selected_food);
         eframe::set_value(storage, "SELECTED_POTION", &self.selected_potion);
         eframe::set_value(storage, "CRAFTER_CONFIG", &self.crafter_config);
@@ -446,6 +449,10 @@ impl MacroSolverApp {
     fn draw_simulator_widget(&mut self, ui: &mut egui::Ui) {
         let game_settings = raphael_data::get_game_settings(
             self.recipe_config.recipe,
+            match self.custom_recipe_overrides_config.use_custom_recipe {
+                true => Some(self.custom_recipe_overrides_config.custom_recipe_overrides),
+                false => None,
+            },
             *self.crafter_config.active_stats(),
             self.selected_food,
             self.selected_potion,
@@ -478,6 +485,7 @@ impl MacroSolverApp {
             ui.add(RecipeSelect::new(
                 &mut self.crafter_config,
                 &mut self.recipe_config,
+                &mut self.custom_recipe_overrides_config,
                 self.selected_food,
                 self.selected_potion,
                 self.locale,
@@ -687,6 +695,10 @@ impl MacroSolverApp {
                 ui.style_mut().spacing.item_spacing = [4.0, 4.0].into();
                 let game_settings = raphael_data::get_game_settings(
                     self.recipe_config.recipe,
+                    match self.custom_recipe_overrides_config.use_custom_recipe {
+                        true => Some(self.custom_recipe_overrides_config.custom_recipe_overrides),
+                        false => None,
+                    },
                     self.crafter_config.crafter_stats[self.crafter_config.selected_job as usize],
                     self.selected_food,
                     self.selected_potion,
@@ -794,6 +806,10 @@ impl MacroSolverApp {
         self.start_time = web_time::Instant::now();
         let mut game_settings = raphael_data::get_game_settings(
             self.recipe_config.recipe,
+            match self.custom_recipe_overrides_config.use_custom_recipe {
+                true => Some(self.custom_recipe_overrides_config.custom_recipe_overrides),
+                false => None,
+            },
             self.crafter_config.crafter_stats[self.crafter_config.selected_job as usize],
             self.selected_food,
             self.selected_potion,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,17 @@
-use raphael_data::{CrafterStats, Recipe};
+use raphael_data::{CrafterStats, CustomRecipeOverrides, Recipe};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum QualitySource {
     HqMaterialList([u8; 6]),
     Value(u16),
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+pub struct CustomRecipeOverridesConfiguration {
+    pub use_custom_recipe: bool,
+    pub custom_recipe_overrides: CustomRecipeOverrides,
+    pub use_base_increase_overrides: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]


### PR DESCRIPTION
Adds back the ability to set progress and quality of custom recipes directly, and additionally allows the user to optionally specify the base progress/quality, which allows the user to enter custom recipes without knowing any hidden values.

Closes #122.