### PR TITLE
Reduce Cloudflare pages deploy time

### DIFF
--- a/cloudflare-deploy.sh
+++ b/cloudflare-deploy.sh
@@ -22,7 +22,10 @@ cp --no-target-directory ./.cargo/config.toml ./.cargo/config.toml.backup
 cp --no-target-directory ./.cargo/config_wasm.toml ./.cargo/config.toml
 trap "mv --no-target-directory ./.cargo/config.toml.backup ./.cargo/config.toml" EXIT
 
-cargo install --locked trunk
+# install cargo-binstall
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+# install trunk
+cargo-binstall --locked trunk
 
 # web_sys unstable APIs needed for copy to clipboard functionality
 export RUSTFLAGS="--cfg=web_sys_unstable_apis -Ctarget-feature=+atomics,+bulk-memory -Clink-arg=--max-memory=4294967296"

--- a/cloudflare-deploy.sh
+++ b/cloudflare-deploy.sh
@@ -25,7 +25,7 @@ trap "mv --no-target-directory ./.cargo/config.toml.backup ./.cargo/config.toml"
 # install cargo-binstall
 curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 # install trunk
-cargo-binstall --locked trunk
+cargo-binstall --no-confirm --locked trunk
 
 # web_sys unstable APIs needed for copy to clipboard functionality
 export RUSTFLAGS="--cfg=web_sys_unstable_apis -Ctarget-feature=+atomics,+bulk-memory -Clink-arg=--max-memory=4294967296"


### PR DESCRIPTION
When deploying to Cloudflare, the majority of time is spent on building `trunk`. Using `cargo-binstall` to install `trunk` instead of building from source speeds up the build time significantly:
- Before: 10m 32s
- After: 4m 29s