### PR TITLE
Add ability to specify recipe by ID & allow for custom recipes in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ cargo run --release --package raphael-cli -- solve --help
 
 Some basic examples:
 ```
-cargo run --release --package raphael-cli -- search "Archeo Fending"
-cargo run --release --package raphael-cli -- solve --item-id 8548 --stats 5000 4000 500
+cargo run --release --package raphael-cli -- search --pattern "Fiberboard"
+cargo run --release --package raphael-cli -- solve --recipe-id 36183 --stats 5400 4900 600
 ```
 
 The CLI can also be installed so that it can be called from anywhere:

--- a/raphael-cli/Cargo.toml
+++ b/raphael-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raphael-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/raphael-cli/src/commands/search.rs
+++ b/raphael-cli/src/commands/search.rs
@@ -1,5 +1,5 @@
 use clap::{Args, ValueEnum};
-use raphael_data::{Locale, RECIPES, Recipe, get_item_name};
+use raphael_data::{Locale, RECIPES, get_item_name, get_job_name};
 
 #[derive(Args, Debug)]
 pub struct SearchArgs {
@@ -47,10 +47,10 @@ pub fn execute(args: &SearchArgs) {
     let locale = args.language.into();
     let matches = if args.pattern.is_some() {
         raphael_data::find_recipes(&args.pattern.clone().unwrap(), locale).iter()
-            .map(|recipe_id| raphael_data::RECIPES.get_entry(recipe_id).unwrap())
+            .map(|recipe_id| RECIPES.get_entry(recipe_id).unwrap())
             .collect()
     } else if args.recipe_id.is_some() {
-        if let Some(entry) = raphael_data::RECIPES.entries().find(|(id, _)| **id == args.recipe_id.unwrap()) {
+        if let Some(entry) = RECIPES.entries().find(|(id, _)| **id == args.recipe_id.unwrap()) {
             vec!(entry)
         } else {
             Vec::new()
@@ -70,7 +70,7 @@ pub fn execute(args: &SearchArgs) {
         println!(
             "{recipe_id}{separator}{job_name}{separator}{item_id}{separator}{name}",
             recipe_id = recipe_id,
-            job_name = raphael_data::get_job_name(recipe.job_id, locale),
+            job_name = get_job_name(recipe.job_id, locale),
             item_id = recipe.item_id,
             separator = args.output_field_separator,
             name = name.trim_end_matches(&[' ', raphael_data::CL_ICON_CHAR])

--- a/raphael-cli/src/commands/search.rs
+++ b/raphael-cli/src/commands/search.rs
@@ -52,6 +52,7 @@ pub fn execute(args: &SearchArgs) {
         matches = Vec::new();
         matches.push(*raphael_data::RECIPES.entries().find(|(id, _)| **id == args.recipe_id.unwrap()).map(|(_, recipe)| recipe).unwrap());
     } else {
+        log::warn!("Item IDs do not uniquely corresponds to a specific recipe config. Consider using the recipe ID instead.");
         matches = raphael_data::RECIPES.values().filter(|recipe| recipe.item_id == args.item_id.unwrap()).map(|recipe| *recipe).collect();
     }
     if matches.is_empty() {

--- a/raphael-cli/src/commands/search.rs
+++ b/raphael-cli/src/commands/search.rs
@@ -4,15 +4,15 @@ use raphael_data::{Locale, RECIPES, Recipe, get_item_name};
 #[derive(Args, Debug)]
 pub struct SearchArgs {
     /// Search pattern to use for search though names, can be partial name
-    #[arg(short, long, required_unless_present_any(["recipe_id", "item_id"]), required_unless_present_any(["recipe_id", "item_id"]))]
+    #[arg(short, long, required_unless_present_any(["recipe_id", "item_id"]), conflicts_with_all(["recipe_id", "item_id"]))]
     pub pattern: Option<String>,
 
     /// Recipe ID to search for
-    #[arg(short, long, required_unless_present_any(["pattern", "item_id"]), required_unless_present_any(["pattern", "item_id"]))]
+    #[arg(short, long, required_unless_present_any(["pattern", "item_id"]), conflicts_with = "item_id")]
     pub recipe_id: Option<u32>,
 
     /// Recipe ID to search for
-    #[arg(short, long, required_unless_present_any(["pattern", "recipe_id"]), required_unless_present_any(["pattern", "recipe_id"]))]
+    #[arg(short, long, required_unless_present_any(["pattern", "recipe_id"]))]
     pub item_id: Option<u32>,
 
     /// The delimiter the output uses between fields

--- a/raphael-cli/src/commands/search.rs
+++ b/raphael-cli/src/commands/search.rs
@@ -3,7 +3,7 @@ use raphael_data::{Locale, RECIPES, get_item_name, get_job_name};
 
 #[derive(Args, Debug)]
 pub struct SearchArgs {
-    /// Search pattern to use for search though names, can be partial name
+    /// Search string to use, can be partial name
     #[arg(short, long, required_unless_present_any(["recipe_id", "item_id"]), conflicts_with_all(["recipe_id", "item_id"]))]
     pub pattern: Option<String>,
 
@@ -11,7 +11,7 @@ pub struct SearchArgs {
     #[arg(short, long, required_unless_present_any(["pattern", "item_id"]), conflicts_with = "item_id")]
     pub recipe_id: Option<u32>,
 
-    /// Recipe ID to search for
+    /// Item ID to search for
     #[arg(short, long, required_unless_present_any(["pattern", "recipe_id"]))]
     pub item_id: Option<u32>,
 

--- a/raphael-cli/src/commands/search.rs
+++ b/raphael-cli/src/commands/search.rs
@@ -32,9 +32,9 @@ pub enum SearchLanguage {
     JP,
 }
 
-impl Into<Locale> for SearchLanguage {
-    fn into(self) -> Locale {
-        match self {
+impl From<SearchLanguage> for Locale {
+    fn from(val: SearchLanguage) -> Self {
+        match val {
             SearchLanguage::EN => Locale::EN,
             SearchLanguage::DE => Locale::DE,
             SearchLanguage::FR => Locale::FR,
@@ -46,18 +46,27 @@ impl Into<Locale> for SearchLanguage {
 pub fn execute(args: &SearchArgs) {
     let locale = args.language.into();
     let matches = if args.pattern.is_some() {
-        raphael_data::find_recipes(&args.pattern.clone().unwrap(), locale).iter()
+        raphael_data::find_recipes(&args.pattern.clone().unwrap(), locale)
+            .iter()
             .map(|recipe_id| RECIPES.get_entry(recipe_id).unwrap())
             .collect()
     } else if args.recipe_id.is_some() {
-        if let Some(entry) = RECIPES.entries().find(|(id, _)| **id == args.recipe_id.unwrap()) {
-            vec!(entry)
+        if let Some(entry) = RECIPES
+            .entries()
+            .find(|(id, _)| **id == args.recipe_id.unwrap())
+        {
+            vec![entry]
         } else {
             Vec::new()
         }
     } else {
-        log::warn!("Item IDs do not uniquely corresponds to a specific recipe config. Consider using the recipe ID instead.");
-        raphael_data::RECIPES.entries().filter(|(_, recipe)| recipe.item_id == args.item_id.unwrap()).collect()
+        log::warn!(
+            "Item IDs do not uniquely corresponds to a specific recipe config. Consider using the recipe ID instead."
+        );
+        raphael_data::RECIPES
+            .entries()
+            .filter(|(_, recipe)| recipe.item_id == args.item_id.unwrap())
+            .collect()
     };
     if matches.is_empty() {
         println!("No matches found");
@@ -73,7 +82,7 @@ pub fn execute(args: &SearchArgs) {
             job_name = get_job_name(recipe.job_id, locale),
             item_id = recipe.item_id,
             separator = args.output_field_separator,
-            name = name.trim_end_matches(&[' ', raphael_data::CL_ICON_CHAR])
+            name = name.trim_end_matches([' ', raphael_data::CL_ICON_CHAR])
         );
     }
 }

--- a/raphael-cli/src/commands/search.rs
+++ b/raphael-cli/src/commands/search.rs
@@ -45,27 +45,31 @@ impl Into<Locale> for SearchLanguage {
 
 pub fn execute(args: &SearchArgs) {
     let locale = args.language.into();
-    let mut matches: Vec<raphael_data::Recipe>;
-    if args.pattern.is_some() {
-        matches = raphael_data::find_recipes(&args.pattern.clone().unwrap(), locale).iter().map(|index| RECIPES[index]).collect();
+    let matches = if args.pattern.is_some() {
+        raphael_data::find_recipes(&args.pattern.clone().unwrap(), locale).iter()
+            .map(|recipe_id| raphael_data::RECIPES.get_entry(recipe_id).unwrap())
+            .collect()
     } else if args.recipe_id.is_some() {
-        matches = Vec::new();
-        matches.push(*raphael_data::RECIPES.entries().find(|(id, _)| **id == args.recipe_id.unwrap()).map(|(_, recipe)| recipe).unwrap());
+        if let Some(entry) = raphael_data::RECIPES.entries().find(|(id, _)| **id == args.recipe_id.unwrap()) {
+            vec!(entry)
+        } else {
+            Vec::new()
+        }
     } else {
         log::warn!("Item IDs do not uniquely corresponds to a specific recipe config. Consider using the recipe ID instead.");
-        matches = raphael_data::RECIPES.values().filter(|recipe| recipe.item_id == args.item_id.unwrap()).map(|recipe| *recipe).collect();
-    }
+        raphael_data::RECIPES.entries().filter(|(_, recipe)| recipe.item_id == args.item_id.unwrap()).collect()
+    };
     if matches.is_empty() {
         println!("No matches found");
         return;
     }
 
-    for recipe in matches {
+    for (recipe_id, recipe) in matches {
         let name =
             get_item_name(recipe.item_id, false, locale).unwrap_or("Unknown item".to_owned());
         println!(
             "{recipe_id}{separator}{job_name}{separator}{item_id}{separator}{name}",
-            recipe_id = recipe.id,
+            recipe_id = recipe_id,
             job_name = raphael_data::get_job_name(recipe.job_id, locale),
             item_id = recipe.item_id,
             separator = args.output_field_separator,

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -6,11 +6,11 @@ use raphael_solver::{AtomicFlag, MacroSolver, SolverSettings};
 #[derive(Args, Debug)]
 pub struct SolveArgs {
     /// Recipe ID
-    #[arg(short, long, required_unless_present_any(["item_id", "custom_recipe"]))]
+    #[arg(short, long, required_unless_present_any(["item_id", "custom_recipe"]), conflicts_with_all(["item_id", "item_id"]))]
     pub recipe_id: Option<u32>,
 
     /// Item ID, in case multiple recipes for the same item exist, the one with the lowest recipe ID is selected
-    #[arg(short, long, required_unless_present_any(["recipe_id, custom_recipe"]))]
+    #[arg(short, long, required_unless_present_any(["recipe_id, custom_recipe"]), conflicts_with_all(["recipe_id", "custom_recipe"]))]
     pub item_id: Option<u32>,
 
     /// Custom recipe. Base progress/quality are optional but must both be specified if one is provided, in which case, rlvl, crafstamnship, and control are ignored
@@ -91,7 +91,7 @@ pub struct SolveArgs {
 
     /// Output the provided list of variables. The output is deliminated by the output-field-separator
     ///
-    /// <IDENTIFIER> can be any of the following: `item_id`, `recipe`, `food`, `potion`, `craftsmanship`, `control`, `cp`, `crafter_stats`, `settings`, `initial_quality`, `target_quality`, `recipe_max_quality`, `actions`, `final_state`, `state_quality`, `final_quality`, `steps`, `duration`.
+    /// <IDENTIFIER> can be any of the following: `recipe_id`, `item_id`, `recipe`, `food`, `potion`, `craftsmanship`, `control`, `cp`, `crafter_stats`, `settings`, `initial_quality`, `target_quality`, `recipe_max_quality`, `actions`, `final_state`, `state_quality`, `final_quality`, `steps`, `duration`.
     /// While the output is mainly intended for generating CSVs, some output can contain `,` inside brackets that are not deliminating columns. For this reason they are wrapped in double quotes and the argument `output-field-separator` can be used to override the delimiter to something that is easier to parse and process
     #[arg(long, num_args = 1.., value_name = "IDENTIFIER")]
     pub output_variables: Vec<String>,
@@ -321,7 +321,7 @@ pub fn execute(args: &SolveArgs) {
     let duration: u8 = actions.iter().map(|action| action.time_cost()).sum();
 
     if args.output_variables.is_empty() {
-        println!("Item ID: {}", recipe.item_id);
+        println!("Recipe ID: {}", recipe.id);
         println!("Quality: {}/{}", final_quality, recipe_max_quality);
         println!(
             "Progress: {}/{}",
@@ -336,11 +336,10 @@ pub fn execute(args: &SolveArgs) {
     } else {
         let mut output_string = "".to_owned();
 
-        //let output_format = args.output_variables.clone().unwrap();
-        //let segments: Vec<&str> = args.output_variables;
         for identifier in &args.output_variables {
             let map_to_debug_str = |actions: Vec<raphael_sim::Action>| match &*(*identifier) {
-                "item_id" => format!("{:?}", args.item_id),
+                "recipe_id" => format!("{:?}", recipe.id),
+                "item_id" => format!("{:?}", recipe.item_id),
                 "recipe" => format!("\"{:?}\"", recipe),
                 "food" => format!("\"{:?}\"", food),
                 "potion" => format!("\"{:?}\"", potion),

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -337,6 +337,7 @@ pub fn execute(args: &SolveArgs) {
             final_state.progress, settings.max_progress
         );
         println!("Quality: {}/{}", final_quality, recipe_max_quality);
+        println!("Durability: {}/{}", final_state.durability, settings.max_durability);
         println!("Steps: {}", steps);
         println!("Duration: {} seconds", duration);
         println!("\nActions:");

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -331,11 +331,11 @@ pub fn execute(args: &SolveArgs) {
 
     if args.output_variables.is_empty() {
         println!("Recipe ID: {}", recipe.id);
-        println!("Quality: {}/{}", final_quality, recipe_max_quality);
         println!(
             "Progress: {}/{}",
             final_state.progress, settings.max_progress
         );
+        println!("Quality: {}/{}", final_quality, recipe_max_quality);
         println!("Steps: {}", steps);
         println!("Duration: {} seconds", duration);
         println!("\nActions:");

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -173,10 +173,11 @@ pub fn execute(args: &SolveArgs) {
     } else if args.recipe_id.is_some() {
         *raphael_data::RECIPES.get(&args.recipe_id.unwrap()).expect(&format!( "Unable to find Recipe with ID: {}", args.recipe_id.unwrap()))
     } else {
+        log::warn!("Item IDs do not uniquely corresponds to a specific recipe config. Consider using the recipe ID instead.\nThe first match, i.e. the recipe with the lowest ID, will be selected.");
         *RECIPES
-        .values()
-        .find(|recipe| recipe.item_id == args.item_id.unwrap())
-        .expect(&format!("Unable to find Recipe for an item with item ID: {}", args.item_id.unwrap()))
+            .values()
+            .find(|recipe| recipe.item_id == args.item_id.unwrap())
+            .expect(&format!("Unable to find Recipe for an item with item ID: {}", args.item_id.unwrap()))
     };
     let food = match args.food {
         Some(food_arg) => {

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -166,7 +166,7 @@ pub fn execute(args: &SolveArgs) {
     }
 
     let use_custom_recipe = !args.custom_recipe.is_empty();
-    let recipe: raphael_data::Recipe = if use_custom_recipe {
+    let mut recipe: raphael_data::Recipe = if use_custom_recipe {
         raphael_data::Recipe {
             job_id: 0,
             item_id: 0,
@@ -285,11 +285,12 @@ pub fn execute(args: &SolveArgs) {
             ..Default::default()
         })
     } else {
+        recipe.recipe_level = raphael_data::LEVEL_ADJUST_TABLE[args.override_base_increases[0] as usize];
         Some(CustomRecipeOverrides {
             max_progress_override: args.custom_recipe[1],
             max_quality_override: args.custom_recipe[2],
             max_durability_override: args.custom_recipe[3],
-            base_progress_override: Some(args.override_base_increases[1]), // TODO use level, at args.override_base_increases[0]
+            base_progress_override: Some(args.override_base_increases[1]),
             base_quality_override: Some(args.override_base_increases[2]),
         })
     };

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -179,7 +179,7 @@ pub fn execute(args: &SolveArgs) {
             is_expert: false,
         }
     } else if args.recipe_id.is_some() {
-        *raphael_data::RECIPES.get(&args.recipe_id.unwrap()).expect(&format!( "Unable to find Recipe with ID: {}", args.recipe_id.unwrap()))
+        *RECIPES.get(&args.recipe_id.unwrap()).expect(&format!( "Unable to find Recipe with ID: {}", args.recipe_id.unwrap()))
     } else {
         log::warn!("Item IDs do not uniquely corresponds to a specific recipe config. Consider using the recipe ID instead.\nThe first match, i.e. the recipe with the lowest ID, will be selected.");
         *RECIPES
@@ -187,7 +187,7 @@ pub fn execute(args: &SolveArgs) {
             .find(|recipe| recipe.item_id == args.item_id.unwrap())
             .expect(&format!("Unable to find Recipe for an item with item ID: {}", args.item_id.unwrap()))
     };
-    let recipe_id = raphael_data::RECIPES.entries().find(|(_, entry_recipe)| **entry_recipe == recipe).map(|(recipe_id, _)| *recipe_id).unwrap_or_default();
+    let recipe_id = RECIPES.entries().find(|(_, entry_recipe)| **entry_recipe == recipe).map(|(recipe_id, _)| *recipe_id).unwrap_or_default();
     let food = match args.food {
         Some(food_arg) => {
             let item_id;

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -187,6 +187,7 @@ pub fn execute(args: &SolveArgs) {
             .find(|recipe| recipe.item_id == args.item_id.unwrap())
             .expect(&format!("Unable to find Recipe for an item with item ID: {}", args.item_id.unwrap()))
     };
+    let recipe_id = raphael_data::RECIPES.entries().find(|(_, entry_recipe)| **entry_recipe == recipe).map(|(recipe_id, _)| *recipe_id).unwrap_or_default();
     let food = match args.food {
         Some(food_arg) => {
             let item_id;
@@ -330,7 +331,7 @@ pub fn execute(args: &SolveArgs) {
     let duration: u8 = actions.iter().map(|action| action.time_cost()).sum();
 
     if args.output_variables.is_empty() {
-        println!("Recipe ID: {}", recipe.id);
+        println!("Recipe ID: {}", recipe_id);
         println!(
             "Progress: {}/{}",
             final_state.progress, settings.max_progress
@@ -347,7 +348,7 @@ pub fn execute(args: &SolveArgs) {
 
         for identifier in &args.output_variables {
             let map_to_debug_str = |actions: Vec<raphael_sim::Action>| match &*(*identifier) {
-                "recipe_id" => format!("{:?}", recipe.id),
+                "recipe_id" => format!("{:?}", recipe_id),
                 "item_id" => format!("{:?}", recipe.item_id),
                 "recipe" => format!("\"{:?}\"", recipe),
                 "food" => format!("\"{:?}\"", food),

--- a/raphael-cli/src/main.rs
+++ b/raphael-cli/src/main.rs
@@ -7,7 +7,6 @@ mod commands;
     version,
     about = "A command-line interface for the Raphael-XIV crafting solver."
 )]
-
 struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
Adds the ability to specify recipes using their IDs in the CLI. Additionally, custom recipes can also be specified as an option.

Since some arguments have changed the version is bumped to `0.2.0`.

Depends on the merge of #131 in order for all functionality to be implemented.