### PR TITLE
Fix base increase overrides not being reset when toggled off

### DIFF
--- a/src/widgets/recipe_select.rs
+++ b/src/widgets/recipe_select.rs
@@ -261,10 +261,18 @@ impl<'a> RecipeSelect<'a> {
                     )
                     .changed()
                 {
-                    custom_recipe_overrides.base_progress_override =
-                        Some(default_game_settings.base_progress);
-                    custom_recipe_overrides.base_quality_override =
-                        Some(default_game_settings.base_quality);
+                    if self
+                        .custom_recipe_overrides_config
+                        .use_base_increase_overrides
+                    {
+                        custom_recipe_overrides.base_progress_override =
+                            Some(default_game_settings.base_progress);
+                        custom_recipe_overrides.base_quality_override =
+                            Some(default_game_settings.base_quality);
+                    } else {
+                        custom_recipe_overrides.base_progress_override = None;
+                        custom_recipe_overrides.base_quality_override = None;
+                    }
                 }
             });
         });


### PR DESCRIPTION
Fixes an oversight in the UI code dealing with the "per 100% efficiency" increase overrides, where they are not reset when the option to use them is toggled off.