### PR TITLE
Add snapshot tests for inner solver state count

### DIFF
--- a/raphael-solver/Cargo.toml
+++ b/raphael-solver/Cargo.toml
@@ -23,3 +23,4 @@ serde = ["dep:serde", "raphael-sim/serde"]
 [dev-dependencies]
 rand = "0.8.5"
 env_logger = "0.11.5"
+expect-test = "1.5.1"

--- a/raphael-solver/src/finish_solver.rs
+++ b/raphael-solver/src/finish_solver.rs
@@ -90,6 +90,10 @@ impl FinishSolver {
             }
         }
     }
+
+    pub fn num_states(&self) -> usize {
+        self.max_progress.len()
+    }
 }
 
 impl Drop for FinishSolver {

--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -4,10 +4,10 @@ mod finish_solver;
 use finish_solver::FinishSolver;
 
 mod quality_upper_bound_solver;
-use quality_upper_bound_solver::QualityUpperBoundSolver;
+use quality_upper_bound_solver::QualityUbSolver;
 
 mod step_lower_bound_solver;
-use step_lower_bound_solver::StepLowerBoundSolver;
+use step_lower_bound_solver::StepLbSolver;
 
 mod macro_solver;
 pub use macro_solver::MacroSolver;

--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -61,47 +61,7 @@ impl SolverSettings {
 }
 
 pub mod test_utils {
-    use crate::{MacroSolver, SolverException, SolverSettings, utils::AtomicFlag};
     use raphael_sim::*;
-
-    pub fn solve(
-        settings: &Settings,
-        backload_progress: bool,
-        allow_unsound_branch_pruning: bool,
-    ) -> Result<Vec<Action>, SolverException> {
-        let solver_settings = SolverSettings {
-            simulator_settings: *settings,
-            backload_progress,
-            allow_unsound_branch_pruning,
-        };
-        MacroSolver::new(
-            solver_settings,
-            Box::new(|_| {}),
-            Box::new(|_| {}),
-            AtomicFlag::new(),
-        )
-        .solve()
-    }
-
-    pub fn get_score_quad(settings: &Settings, actions: &[Action]) -> (u32, u8, u8, u32) {
-        let quality = get_quality(settings, actions);
-        let capped_quality = std::cmp::min(quality, u32::from(settings.max_quality));
-        let overflow_quality = quality.saturating_sub(u32::from(settings.max_quality));
-        let steps = actions.len() as u8;
-        let duration: u8 = actions.iter().map(|action| action.time_cost()).sum();
-        (capped_quality, steps, duration, overflow_quality)
-    }
-
-    pub fn get_quality(settings: &Settings, actions: &[Action]) -> u32 {
-        let mut state = SimulationState::new(settings);
-        for action in actions {
-            state = state
-                .use_action(*action, Condition::Normal, settings)
-                .unwrap();
-        }
-        assert!(state.progress >= u32::from(settings.max_progress));
-        state.quality
-    }
 
     pub fn is_progress_backloaded(actions: &[Action], settings: &Settings) -> bool {
         let mut state = SimulationState::new(settings);

--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -59,21 +59,3 @@ impl SolverSettings {
         u32::from(self.simulator_settings.base_quality)
     }
 }
-
-pub mod test_utils {
-    use raphael_sim::*;
-
-    pub fn is_progress_backloaded(actions: &[Action], settings: &Settings) -> bool {
-        let mut state = SimulationState::new(settings);
-        let mut quality_lock = None;
-        for action in actions {
-            state = state
-                .use_action(*action, Condition::Normal, settings)
-                .unwrap();
-            if state.progress != 0 && quality_lock.is_none() {
-                quality_lock = Some(state.quality);
-            }
-        }
-        quality_lock.is_none_or(|quality| state.quality == quality)
-    }
-}

--- a/raphael-solver/src/macro_solver/fast_lower_bound.rs
+++ b/raphael-solver/src/macro_solver/fast_lower_bound.rs
@@ -1,7 +1,7 @@
 use raphael_sim::*;
 
 use crate::{
-    AtomicFlag, QualityUpperBoundSolver, SolverException, SolverSettings,
+    AtomicFlag, QualityUbSolver, SolverException, SolverSettings,
     actions::{ActionCombo, QUALITY_ONLY_SEARCH_ACTIONS, use_action_combo},
     finish_solver::FinishSolver,
     utils::ScopedTimer,
@@ -32,7 +32,7 @@ pub fn fast_lower_bound(
     settings: SolverSettings,
     interrupt_signal: AtomicFlag,
     finish_solver: &mut FinishSolver,
-    quality_ub_solver: &mut QualityUpperBoundSolver,
+    quality_ub_solver: &mut QualityUbSolver,
 ) -> Result<u32, SolverException> {
     let _timer = ScopedTimer::new("Fast lower bound");
 

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -7,6 +7,8 @@ use crate::actions::{
 };
 use crate::macro_solver::fast_lower_bound::fast_lower_bound;
 use crate::macro_solver::search_queue::SearchQueue;
+use crate::quality_upper_bound_solver::QualityUbSolverStats;
+use crate::step_lower_bound_solver::StepLbSolverStats;
 use crate::utils::AtomicFlag;
 use crate::utils::ScopedTimer;
 use crate::{FinishSolver, QualityUbSolver, SolverException, SolverSettings, StepLbSolver};
@@ -31,6 +33,13 @@ impl Solution {
 
 type SolutionCallback<'a> = dyn Fn(&[Action]) + 'a;
 type ProgressCallback<'a> = dyn Fn(usize) + 'a;
+
+#[derive(Debug, Clone, Copy)]
+pub struct MacroSolverStats {
+    pub finish_states: usize,
+    pub quality_ub_stats: QualityUbSolverStats,
+    pub step_lb_stats: StepLbSolverStats,
+}
 
 pub struct MacroSolver<'a> {
     settings: SolverSettings,
@@ -208,5 +217,13 @@ impl<'a> MacroSolver<'a> {
         }
 
         solution.ok_or(SolverException::NoSolution)
+    }
+
+    pub fn runtime_stats(&self) -> MacroSolverStats {
+        MacroSolverStats {
+            finish_states: self.finish_solver.num_states(),
+            quality_ub_stats: self.quality_ub_solver.runtime_stats(),
+            step_lb_stats: self.step_lb_solver.runtime_stats(),
+        }
     }
 }

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -9,9 +9,7 @@ use crate::macro_solver::fast_lower_bound::fast_lower_bound;
 use crate::macro_solver::search_queue::SearchQueue;
 use crate::utils::AtomicFlag;
 use crate::utils::ScopedTimer;
-use crate::{
-    FinishSolver, QualityUpperBoundSolver, SolverException, SolverSettings, StepLowerBoundSolver,
-};
+use crate::{FinishSolver, QualityUbSolver, SolverException, SolverSettings, StepLbSolver};
 
 use std::vec::Vec;
 
@@ -39,8 +37,8 @@ pub struct MacroSolver<'a> {
     solution_callback: Box<SolutionCallback<'a>>,
     progress_callback: Box<ProgressCallback<'a>>,
     finish_solver: FinishSolver,
-    quality_ub_solver: QualityUpperBoundSolver,
-    step_lb_solver: StepLowerBoundSolver,
+    quality_ub_solver: QualityUbSolver,
+    step_lb_solver: StepLbSolver,
     interrupt_signal: AtomicFlag,
 }
 
@@ -56,8 +54,8 @@ impl<'a> MacroSolver<'a> {
             solution_callback,
             progress_callback,
             finish_solver: FinishSolver::new(settings),
-            quality_ub_solver: QualityUpperBoundSolver::new(settings, interrupt_signal.clone()),
-            step_lb_solver: StepLowerBoundSolver::new(settings, interrupt_signal.clone()),
+            quality_ub_solver: QualityUbSolver::new(settings, interrupt_signal.clone()),
+            step_lb_solver: StepLbSolver::new(settings, interrupt_signal.clone()),
             interrupt_signal,
         }
     }

--- a/raphael-solver/src/quality_upper_bound_solver/mod.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/mod.rs
@@ -1,7 +1,7 @@
 mod solver;
 mod state;
 
-pub use solver::QualityUbSolver;
+pub use solver::{QualityUbSolver, QualityUbSolverStats};
 
 #[cfg(test)]
 mod tests;

--- a/raphael-solver/src/quality_upper_bound_solver/mod.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/mod.rs
@@ -1,7 +1,7 @@
 mod solver;
 mod state;
 
-pub use solver::QualityUpperBoundSolver;
+pub use solver::QualityUbSolver;
 
 #[cfg(test)]
 mod tests;

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -12,7 +12,7 @@ type ParetoValue = utils::ParetoValue<u32, u32>;
 type ParetoFrontBuilder = utils::ParetoFrontBuilder<u32, u32>;
 type SolvedStates = rustc_hash::FxHashMap<ReducedState, Box<[ParetoValue]>>;
 
-pub struct QualityUpperBoundSolver {
+pub struct QualityUbSolver {
     settings: SolverSettings,
     interrupt_signal: utils::AtomicFlag,
     solved_states: SolvedStates,
@@ -20,7 +20,7 @@ pub struct QualityUpperBoundSolver {
     durability_cost: u16,
 }
 
-impl QualityUpperBoundSolver {
+impl QualityUbSolver {
     pub fn new(mut settings: SolverSettings, interrupt_signal: utils::AtomicFlag) -> Self {
         let durability_cost = durability_cost(&settings.simulator_settings);
         settings.simulator_settings.max_cp += durability_cost * (settings.max_durability() / 5);
@@ -128,7 +128,7 @@ impl QualityUpperBoundSolver {
         }
 
         log::debug!(
-            "QualityUpperBoundSolver - templates: {}, precomputed_states: {}",
+            "QualityUbSolver - templates: {}, precomputed_states: {}",
             templates.len(),
             self.solved_states.len()
         );
@@ -274,11 +274,11 @@ impl QualityUpperBoundSolver {
     }
 }
 
-impl Drop for QualityUpperBoundSolver {
+impl Drop for QualityUbSolver {
     fn drop(&mut self) {
         let num_states = self.computed_states();
         let num_values = self.computed_values();
-        log::debug!("QualityUpperBoundSolver - states: {num_states}, values: {num_values}");
+        log::debug!("QualityUbSolver - states: {num_states}, values: {num_values}");
     }
 }
 

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -12,6 +12,12 @@ type ParetoValue = utils::ParetoValue<u32, u32>;
 type ParetoFrontBuilder = utils::ParetoFrontBuilder<u32, u32>;
 type SolvedStates = rustc_hash::FxHashMap<ReducedState, Box<[ParetoValue]>>;
 
+#[derive(Debug, Clone, Copy)]
+pub struct QualityUbSolverStats {
+    pub states: usize,
+    pub pareto_values: usize,
+}
+
 pub struct QualityUbSolver {
     settings: SolverSettings,
     interrupt_signal: utils::AtomicFlag,
@@ -265,20 +271,11 @@ impl QualityUbSolver {
         Ok(())
     }
 
-    pub fn computed_states(&self) -> usize {
-        self.solved_states.len()
-    }
-
-    pub fn computed_values(&self) -> usize {
-        self.solved_states.values().map(|value| value.len()).sum()
-    }
-}
-
-impl Drop for QualityUbSolver {
-    fn drop(&mut self) {
-        let num_states = self.computed_states();
-        let num_values = self.computed_values();
-        log::debug!("QualityUbSolver - states: {num_states}, values: {num_values}");
+    pub fn runtime_stats(&self) -> QualityUbSolverStats {
+        QualityUbSolverStats {
+            states: self.solved_states.len(),
+            pareto_values: self.solved_states.values().map(|value| value.len()).sum(),
+        }
     }
 }
 

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -279,6 +279,17 @@ impl QualityUbSolver {
     }
 }
 
+impl Drop for QualityUbSolver {
+    fn drop(&mut self) {
+        let runtime_stats = self.runtime_stats();
+        log::debug!(
+            "QualityUbSolver - states: {}, values: {}",
+            runtime_stats.states,
+            runtime_stats.pareto_values
+        );
+    }
+}
+
 /// Calculates the CP cost to "magically" restore 5 durability
 fn durability_cost(settings: &Settings) -> u16 {
     let mut cost = 100;

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -1,3 +1,4 @@
+use expect_test::expect;
 use rand::Rng;
 use raphael_sim::*;
 
@@ -478,17 +479,20 @@ fn test_issue_113() {
             .remove(Action::QuickInnovation),
         adversarial: true,
     };
-
     let solver_settings = SolverSettings {
         simulator_settings,
         backload_progress: false,
         allow_unsound_branch_pruning: false,
     };
     let mut solver = QualityUbSolver::new(solver_settings, Default::default());
-
     solver.precompute(simulator_settings.max_cp);
-    assert_eq!(solver.computed_states(), 5764187);
-    assert_eq!(solver.computed_values(), 209923334);
+    let expected_runtime_stats = expect![[r#"
+        QualityUbSolverStats {
+            states: 5764187,
+            pareto_values: 209923334,
+        }
+    "#]];
+    expected_runtime_stats.assert_debug_eq(&solver.runtime_stats());
 }
 
 #[test]
@@ -507,17 +511,21 @@ fn test_issue_118() {
             .remove(Action::QuickInnovation),
         adversarial: true,
     };
-
     let solver_settings = SolverSettings {
         simulator_settings,
         backload_progress: false,
         allow_unsound_branch_pruning: false,
     };
     let mut solver = QualityUbSolver::new(solver_settings, Default::default());
-
     solver.precompute(simulator_settings.max_cp);
-    assert_eq!(solver.computed_states(), 3388741);
-    assert_eq!(solver.computed_values(), 36810126);
+    solver.precompute(simulator_settings.max_cp);
+    let expected_runtime_stats = expect![[r#"
+        QualityUbSolverStats {
+            states: 3388741,
+            pareto_values: 36810126,
+        }
+    "#]];
+    expected_runtime_stats.assert_debug_eq(&solver.runtime_stats());
 }
 
 fn random_effects(adversarial: bool) -> Effects {

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -6,7 +6,7 @@ use crate::{
     actions::{FULL_SEARCH_ACTIONS, use_action_combo},
 };
 
-use super::QualityUpperBoundSolver;
+use super::QualityUbSolver;
 
 fn solve(simulator_settings: Settings, actions: &[Action]) -> u32 {
     let mut state = SimulationState::from_macro(&simulator_settings, actions).unwrap();
@@ -16,7 +16,7 @@ fn solve(simulator_settings: Settings, actions: &[Action]) -> u32 {
         backload_progress: false,
         allow_unsound_branch_pruning: false,
     };
-    let mut solver = QualityUpperBoundSolver::new(solver_settings, Default::default());
+    let mut solver = QualityUbSolver::new(solver_settings, Default::default());
     solver.quality_upper_bound(state).unwrap()
 }
 
@@ -484,7 +484,7 @@ fn test_issue_113() {
         backload_progress: false,
         allow_unsound_branch_pruning: false,
     };
-    let mut solver = QualityUpperBoundSolver::new(solver_settings, Default::default());
+    let mut solver = QualityUbSolver::new(solver_settings, Default::default());
 
     solver.precompute(simulator_settings.max_cp);
     assert_eq!(solver.computed_states(), 5764187);
@@ -513,7 +513,7 @@ fn test_issue_118() {
         backload_progress: false,
         allow_unsound_branch_pruning: false,
     };
-    let mut solver = QualityUpperBoundSolver::new(solver_settings, Default::default());
+    let mut solver = QualityUbSolver::new(solver_settings, Default::default());
 
     solver.precompute(simulator_settings.max_cp);
     assert_eq!(solver.computed_states(), 3388741);
@@ -557,7 +557,7 @@ fn monotonic_fuzz_check(simulator_settings: Settings) {
         backload_progress: false,
         allow_unsound_branch_pruning: false,
     };
-    let mut solver = QualityUpperBoundSolver::new(solver_settings, Default::default());
+    let mut solver = QualityUbSolver::new(solver_settings, Default::default());
     solver.precompute(simulator_settings.max_cp);
     for _ in 0..100000 {
         let state = random_state(&simulator_settings);

--- a/raphael-solver/src/step_lower_bound_solver/mod.rs
+++ b/raphael-solver/src/step_lower_bound_solver/mod.rs
@@ -1,7 +1,7 @@
 mod solver;
 mod state;
 
-pub use solver::StepLbSolver;
+pub use solver::{StepLbSolver, StepLbSolverStats};
 
 #[cfg(test)]
 mod tests;

--- a/raphael-solver/src/step_lower_bound_solver/mod.rs
+++ b/raphael-solver/src/step_lower_bound_solver/mod.rs
@@ -1,7 +1,7 @@
 mod solver;
 mod state;
 
-pub use solver::StepLowerBoundSolver;
+pub use solver::StepLbSolver;
 
 #[cfg(test)]
 mod tests;

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -180,3 +180,14 @@ impl StepLbSolver {
         }
     }
 }
+
+impl Drop for StepLbSolver {
+    fn drop(&mut self) {
+        let runtime_stats = self.runtime_stats();
+        log::debug!(
+            "StepLbSolver - states: {}, values: {}",
+            runtime_stats.states,
+            runtime_stats.pareto_values
+        );
+    }
+}

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -16,14 +16,14 @@ type ParetoValue = utils::ParetoValue<u32, u32>;
 type ParetoFrontBuilder = utils::ParetoFrontBuilder<u32, u32>;
 type SolvedStates = rustc_hash::FxHashMap<ReducedState, Box<[ParetoValue]>>;
 
-pub struct StepLowerBoundSolver {
+pub struct StepLbSolver {
     settings: SolverSettings,
     interrupt_signal: utils::AtomicFlag,
     solved_states: SolvedStates,
     pareto_front_builder: ParetoFrontBuilder,
 }
 
-impl StepLowerBoundSolver {
+impl StepLbSolver {
     pub fn new(mut settings: SolverSettings, interrupt_signal: utils::AtomicFlag) -> Self {
         ReducedState::optimize_action_mask(&mut settings.simulator_settings);
         Self {
@@ -168,7 +168,7 @@ impl StepLowerBoundSolver {
     }
 }
 
-impl Drop for StepLowerBoundSolver {
+impl Drop for StepLbSolver {
     fn drop(&mut self) {
         let num_states = self.solved_states.len();
         let num_values = self
@@ -176,6 +176,6 @@ impl Drop for StepLowerBoundSolver {
             .values()
             .map(|value| value.len())
             .sum::<usize>();
-        log::debug!("StepLowerBoundSolver - states: {num_states}, values: {num_values}");
+        log::debug!("StepLbSolver - states: {num_states}, values: {num_values}");
     }
 }

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -16,6 +16,12 @@ type ParetoValue = utils::ParetoValue<u32, u32>;
 type ParetoFrontBuilder = utils::ParetoFrontBuilder<u32, u32>;
 type SolvedStates = rustc_hash::FxHashMap<ReducedState, Box<[ParetoValue]>>;
 
+#[derive(Debug, Clone, Copy)]
+pub struct StepLbSolverStats {
+    pub states: usize,
+    pub pareto_values: usize,
+}
+
 pub struct StepLbSolver {
     settings: SolverSettings,
     interrupt_signal: utils::AtomicFlag,
@@ -166,16 +172,11 @@ impl StepLbSolver {
         }
         Ok(())
     }
-}
 
-impl Drop for StepLbSolver {
-    fn drop(&mut self) {
-        let num_states = self.solved_states.len();
-        let num_values = self
-            .solved_states
-            .values()
-            .map(|value| value.len())
-            .sum::<usize>();
-        log::debug!("StepLbSolver - states: {num_states}, values: {num_values}");
+    pub fn runtime_stats(&self) -> StepLbSolverStats {
+        StepLbSolverStats {
+            states: self.solved_states.len(),
+            pareto_values: self.solved_states.values().map(|value| value.len()).sum(),
+        }
     }
 }

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -16,7 +16,7 @@ fn solve(simulator_settings: Settings, actions: &[Action]) -> u8 {
         backload_progress: false,
         allow_unsound_branch_pruning: false,
     };
-    StepLowerBoundSolver::new(solver_settings, Default::default())
+    StepLbSolver::new(solver_settings, Default::default())
         .step_lower_bound(state, 0)
         .unwrap()
 }
@@ -497,7 +497,7 @@ fn monotonic_fuzz_check(simulator_settings: Settings) {
         backload_progress: false,
         allow_unsound_branch_pruning: false,
     };
-    let mut solver = StepLowerBoundSolver::new(solver_settings, Default::default());
+    let mut solver = StepLbSolver::new(solver_settings, Default::default());
     for _ in 0..10000 {
         let state = random_state(&simulator_settings);
         let state_lower_bound = solver.step_lower_bound(state, 0).unwrap();

--- a/raphael-solver/tests/01_progress_backload_non_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_non_exhaustive.rs
@@ -1,9 +1,63 @@
+use expect_test::expect;
 use raphael_sim::*;
-use raphael_solver::test_utils::*;
+use raphael_solver::{AtomicFlag, MacroSolver, SolverSettings};
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+struct SolutionScore {
+    pub capped_quality: u32,
+    pub steps: u8,
+    pub duration: u8,
+    pub overflow_quality: u32,
+}
+
+fn is_progress_backloaded(settings: &SolverSettings, actions: &[Action]) -> bool {
+    let mut state = SimulationState::new(&settings.simulator_settings);
+    let mut quality_lock = None;
+    for action in actions {
+        state = state
+            .use_action(*action, Condition::Normal, &settings.simulator_settings)
+            .unwrap();
+        if state.progress != 0 && quality_lock.is_none() {
+            quality_lock = Some(state.quality);
+        }
+    }
+    quality_lock.is_none_or(|quality| state.quality == quality)
+}
+
+fn test_with_settings(
+    settings: SolverSettings,
+    expected_score: expect_test::Expect,
+    expected_runtime_stats: expect_test::Expect,
+) {
+    let mut solver = MacroSolver::new(
+        settings,
+        Box::new(|_| {}),
+        Box::new(|_| {}),
+        AtomicFlag::new(),
+    );
+    let result = solver.solve();
+    let score = result.map_or(None, |actions| {
+        let final_state =
+            SimulationState::from_macro(&settings.simulator_settings, &actions).unwrap();
+        assert!(final_state.progress >= settings.max_progress());
+        if settings.backload_progress {
+            assert!(is_progress_backloaded(&settings, &actions));
+        }
+        Some(SolutionScore {
+            capped_quality: std::cmp::min(final_state.quality, settings.max_quality()),
+            steps: actions.len() as u8,
+            duration: actions.iter().map(|action| action.time_cost()).sum(),
+            overflow_quality: final_state.quality.saturating_sub(settings.max_quality()),
+        })
+    });
+    expected_score.assert_debug_eq(&score);
+    expected_runtime_stats.assert_debug_eq(&solver.runtime_stats());
+}
 
 #[test]
 fn rinascita_3700_3280() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 680,
         max_durability: 70,
         max_progress: 5060,
@@ -17,14 +71,40 @@ fn rinascita_3700_3280() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (10492, 25, 66, 0));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 10492,
+                steps: 25,
+                duration: 66,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 219657,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 534551,
+                pareto_values: 8975468,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 144057,
+                pareto_values: 1100168,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn pactmaker_3240_3130() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 600,
         max_durability: 70,
         max_progress: 4300,
@@ -38,14 +118,40 @@ fn pactmaker_3240_3130() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (8801, 24, 65, 0));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 8801,
+                steps: 24,
+                duration: 65,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 257770,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 461697,
+                pareto_values: 6993180,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 138625,
+                pareto_values: 976320,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn pactmaker_3240_3130_heart_and_soul() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 600,
         max_durability: 70,
         max_progress: 4300,
@@ -58,14 +164,40 @@ fn pactmaker_3240_3130_heart_and_soul() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (9608, 24, 65, 0));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 9608,
+                steps: 24,
+                duration: 65,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 240388,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 917487,
+                pareto_values: 14243495,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 244938,
+                pareto_values: 1879733,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn diadochos_4021_3660() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 640,
         max_durability: 70,
         max_progress: 6600,
@@ -79,14 +211,40 @@ fn diadochos_4021_3660() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (9580, 23, 61, 0));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 9580,
+                steps: 23,
+                duration: 61,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 400293,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 497805,
+                pareto_values: 9277186,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 167591,
+                pareto_values: 1463383,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn indagator_3858_4057() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 687,
         max_durability: 70,
         max_progress: 5720,
@@ -100,14 +258,40 @@ fn indagator_3858_4057() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (12313, 27, 72, 0));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 12313,
+                steps: 27,
+                duration: 72,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 339025,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 541131,
+                pareto_values: 9295587,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 122729,
+                pareto_values: 958121,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn rarefied_tacos_de_carne_asada_4785_4758() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 646,
         max_durability: 80,
         max_progress: 6600,
@@ -121,16 +305,42 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (12000, 22, 58, 82));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 12000,
+                steps: 22,
+                duration: 58,
+                overflow_quality: 82,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 981266,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 509841,
+                pareto_values: 9860309,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 542192,
+                pareto_values: 2148769,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn stuffed_peppers_2() {
     // lv99 Rarefied Stuffed Peppers
     // 4785 CMS, 4758 Ctrl, 646 CP
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 646,
         max_durability: 80,
         max_progress: 6300,
@@ -144,16 +354,42 @@ fn stuffed_peppers_2() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (19705, 29, 79, 0));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 19705,
+                steps: 29,
+                duration: 79,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 497000,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 509652,
+                pareto_values: 9890241,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 352822,
+                pareto_values: 2763298,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn stuffed_peppers_2_heart_and_soul() {
     // lv99 Rarefied Stuffed Peppers
     // 4785 CMS, 4758 Ctrl, 646 CP
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 646,
         max_durability: 80,
         max_progress: 6300,
@@ -166,16 +402,42 @@ fn stuffed_peppers_2_heart_and_soul() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (21235, 32, 88, 0));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 21235,
+                steps: 32,
+                duration: 88,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 551562,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1016385,
+                pareto_values: 20331419,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 615894,
+                pareto_values: 5204554,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn stuffed_peppers_2_quick_innovation() {
     // lv99 Rarefied Stuffed Peppers
     // 4785 CMS, 4758 Ctrl, 646 CP
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 646,
         max_durability: 80,
         max_progress: 6300,
@@ -188,14 +450,40 @@ fn stuffed_peppers_2_quick_innovation() {
             .remove(Action::HeartAndSoul),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (19984, 30, 83, 0));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 19984,
+                steps: 30,
+                duration: 83,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 509008,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 976091,
+                pareto_values: 18985885,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 672755,
+                pareto_values: 5477064,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn rakaznar_lapidary_hammer_4462_4391() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 569,
         max_durability: 80,
         max_progress: 6600,
@@ -209,14 +497,40 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (6500, 16, 45, 556));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 6500,
+                steps: 16,
+                duration: 45,
+                overflow_quality: 556,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 704990,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 416405,
+                pareto_values: 6241593,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 387603,
+                pareto_values: 964263,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn black_star_4048_3997() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 596,
         max_durability: 40,
         max_progress: 3000,
@@ -230,14 +544,40 @@ fn black_star_4048_3997() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (5500, 12, 31, 614));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 5500,
+                steps: 12,
+                duration: 31,
+                overflow_quality: 614,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 66897,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 374059,
+                pareto_values: 1980793,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 167235,
+                pareto_values: 282243,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn claro_walnut_lumber_4900_4800() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 620,
         max_durability: 40,
         max_progress: 3000,
@@ -251,14 +591,40 @@ fn claro_walnut_lumber_4900_4800() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (11000, 14, 35, 517));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 11000,
+                steps: 14,
+                duration: 35,
+                overflow_quality: 517,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 204117,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 439151,
+                pareto_values: 2902874,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 241520,
+                pareto_values: 474397,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn rakaznar_lapidary_hammer_4900_4800() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 620,
         max_durability: 80,
         max_progress: 6600,
@@ -272,14 +638,40 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (6000, 15, 41, 15));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 6000,
+                steps: 15,
+                duration: 41,
+                overflow_quality: 15,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 459602,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 461810,
+                pareto_values: 4923125,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 370895,
+                pareto_values: 756619,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn rarefied_tacos_de_carne_asada_4966_4817() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 626,
         max_durability: 80,
         max_progress: 6600,
@@ -293,14 +685,40 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (5400, 14, 38, 317));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 5400,
+                steps: 14,
+                duration: 38,
+                overflow_quality: 317,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 509614,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 467596,
+                pareto_values: 4336012,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 390697,
+                pareto_values: 713781,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn archeo_kingdom_broadsword_4966_4914() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 745,
         max_durability: 70,
         max_progress: 7500,
@@ -314,7 +732,33 @@ fn archeo_kingdom_broadsword_4966_4914() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (8250, 18, 49, 799));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: true,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 8250,
+                steps: 18,
+                duration: 49,
+                overflow_quality: 799,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 1184796,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 581621,
+                pareto_values: 8589162,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 548119,
+                pareto_values: 1560851,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }

--- a/raphael-solver/tests/02_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/02_progress_backload_exhaustive.rs
@@ -1,9 +1,63 @@
+use expect_test::expect;
 use raphael_sim::*;
-use raphael_solver::test_utils::*;
+use raphael_solver::{AtomicFlag, MacroSolver, SolverSettings};
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+struct SolutionScore {
+    pub capped_quality: u32,
+    pub steps: u8,
+    pub duration: u8,
+    pub overflow_quality: u32,
+}
+
+fn is_progress_backloaded(settings: &SolverSettings, actions: &[Action]) -> bool {
+    let mut state = SimulationState::new(&settings.simulator_settings);
+    let mut quality_lock = None;
+    for action in actions {
+        state = state
+            .use_action(*action, Condition::Normal, &settings.simulator_settings)
+            .unwrap();
+        if state.progress != 0 && quality_lock.is_none() {
+            quality_lock = Some(state.quality);
+        }
+    }
+    quality_lock.is_none_or(|quality| state.quality == quality)
+}
+
+fn test_with_settings(
+    settings: SolverSettings,
+    expected_score: expect_test::Expect,
+    expected_runtime_stats: expect_test::Expect,
+) {
+    let mut solver = MacroSolver::new(
+        settings,
+        Box::new(|_| {}),
+        Box::new(|_| {}),
+        AtomicFlag::new(),
+    );
+    let result = solver.solve();
+    let score = result.map_or(None, |actions| {
+        let final_state =
+            SimulationState::from_macro(&settings.simulator_settings, &actions).unwrap();
+        assert!(final_state.progress >= settings.max_progress());
+        if settings.backload_progress {
+            assert!(is_progress_backloaded(&settings, &actions));
+        }
+        Some(SolutionScore {
+            capped_quality: std::cmp::min(final_state.quality, settings.max_quality()),
+            steps: actions.len() as u8,
+            duration: actions.iter().map(|action| action.time_cost()).sum(),
+            overflow_quality: final_state.quality.saturating_sub(settings.max_quality()),
+        })
+    });
+    expected_score.assert_debug_eq(&score);
+    expected_runtime_stats.assert_debug_eq(&solver.runtime_stats());
+}
 
 #[test]
 fn rinascita_3700_3280() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 680,
         max_durability: 70,
         max_progress: 5060,
@@ -17,15 +71,40 @@ fn rinascita_3700_3280() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (10492, 25, 66, 0));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 10492,
+                steps: 25,
+                duration: 66,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 219659,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1983239,
+                pareto_values: 34025256,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 815631,
+                pareto_values: 10090940,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn pactmaker_3240_3130() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 600,
         max_durability: 70,
         max_progress: 4300,
@@ -39,15 +118,40 @@ fn pactmaker_3240_3130() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (8801, 24, 65, 0));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 8801,
+                steps: 24,
+                duration: 65,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 258317,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1705998,
+                pareto_values: 26328725,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 782395,
+                pareto_values: 9193771,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn pactmaker_3240_3130_heart_and_soul() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 600,
         max_durability: 70,
         max_progress: 4300,
@@ -60,15 +164,40 @@ fn pactmaker_3240_3130_heart_and_soul() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (9608, 24, 65, 0));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 9608,
+                steps: 24,
+                duration: 65,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 240392,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 3443396,
+                pareto_values: 54661715,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 1494941,
+                pareto_values: 18435656,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn diadochos_4021_3660() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 640,
         max_durability: 70,
         max_progress: 6600,
@@ -82,15 +211,40 @@ fn diadochos_4021_3660() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (9580, 23, 61, 0));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 9580,
+                steps: 23,
+                duration: 61,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 414056,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1843549,
+                pareto_values: 34903710,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 949178,
+                pareto_values: 13682643,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn indagator_3858_4057() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 687,
         max_durability: 70,
         max_progress: 5720,
@@ -104,15 +258,40 @@ fn indagator_3858_4057() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (12313, 27, 72, 0));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 12313,
+                steps: 27,
+                duration: 72,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 339602,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 2008164,
+                pareto_values: 35350515,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 689966,
+                pareto_values: 8924833,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn rarefied_tacos_de_carne_asada_4785_4758() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 646,
         max_durability: 80,
         max_progress: 6600,
@@ -126,17 +305,42 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (12000, 22, 58, 82));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 12000,
+                steps: 22,
+                duration: 58,
+                overflow_quality: 82,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 1059731,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1887414,
+                pareto_values: 37938812,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 1299868,
+                pareto_values: 16334927,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn stuffed_peppers_2() {
     // lv99 Rarefied Stuffed Peppers
     // 4785 CMS, 4758 Ctrl, 646 CP
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 646,
         max_durability: 80,
         max_progress: 6300,
@@ -150,17 +354,42 @@ fn stuffed_peppers_2() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (19705, 29, 79, 0));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 19705,
+                steps: 29,
+                duration: 79,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 518647,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1885014,
+                pareto_values: 37351087,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 2095532,
+                pareto_values: 29062560,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn stuffed_peppers_2_heart_and_soul() {
     // lv99 Rarefied Stuffed Peppers
     // 4785 CMS, 4758 Ctrl, 646 CP
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 646,
         max_durability: 80,
         max_progress: 6300,
@@ -173,17 +402,42 @@ fn stuffed_peppers_2_heart_and_soul() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (21235, 32, 88, 0));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 21235,
+                steps: 32,
+                duration: 88,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 561960,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 3823879,
+                pareto_values: 78455720,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 4102033,
+                pareto_values: 58818959,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn stuffed_peppers_2_quick_innovation() {
     // lv99 Rarefied Stuffed Peppers
     // 4785 CMS, 4758 Ctrl, 646 CP
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 646,
         max_durability: 80,
         max_progress: 6300,
@@ -196,15 +450,40 @@ fn stuffed_peppers_2_quick_innovation() {
             .remove(Action::HeartAndSoul),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (19984, 30, 83, 0));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 19984,
+                steps: 30,
+                duration: 83,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 536120,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 3856930,
+                pareto_values: 76751405,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 4233011,
+                pareto_values: 59096571,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn rakaznar_lapidary_hammer_4462_4391() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 569,
         max_durability: 80,
         max_progress: 6600,
@@ -218,15 +497,40 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (6500, 16, 45, 556));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 6500,
+                steps: 16,
+                duration: 45,
+                overflow_quality: 556,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 706065,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1526659,
+                pareto_values: 24305982,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 511703,
+                pareto_values: 5852073,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn black_star_4048_3997() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 596,
         max_durability: 40,
         max_progress: 3000,
@@ -240,15 +544,40 @@ fn black_star_4048_3997() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (5500, 12, 31, 926));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 5500,
+                steps: 12,
+                duration: 31,
+                overflow_quality: 926,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 110050,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1362242,
+                pareto_values: 7639594,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 105081,
+                pareto_values: 699822,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn claro_walnut_lumber_4900_4800() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 620,
         max_durability: 40,
         max_progress: 3000,
@@ -262,15 +591,40 @@ fn claro_walnut_lumber_4900_4800() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (11000, 14, 35, 517));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 11000,
+                steps: 14,
+                duration: 35,
+                overflow_quality: 517,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 239933,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1566609,
+                pareto_values: 11127341,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 252537,
+                pareto_values: 1735508,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn rakaznar_lapidary_hammer_4900_4800() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 620,
         max_durability: 80,
         max_progress: 6600,
@@ -284,15 +638,40 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (6000, 15, 41, 15));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 6000,
+                steps: 15,
+                duration: 41,
+                overflow_quality: 15,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 485307,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1699729,
+                pareto_values: 19361954,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 407802,
+                pareto_values: 4038047,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn rarefied_tacos_de_carne_asada_4966_4817() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 626,
         max_durability: 80,
         max_progress: 6600,
@@ -306,15 +685,40 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (5400, 14, 38, 317));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 5400,
+                steps: 14,
+                duration: 38,
+                overflow_quality: 317,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 516281,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1720916,
+                pareto_values: 17016049,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 328824,
+                pareto_values: 3108256,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn archeo_kingdom_broadsword_4966_4914() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 745,
         max_durability: 70,
         max_progress: 7500,
@@ -328,8 +732,33 @@ fn archeo_kingdom_broadsword_4966_4914() {
             .remove(Action::QuickInnovation),
         adversarial: false,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (8250, 18, 49, 799));
-    assert!(is_progress_backloaded(&actions, &settings));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: true,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 8250,
+                steps: 18,
+                duration: 49,
+                overflow_quality: 799,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 1205580,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 2129253,
+                pareto_values: 33448907,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 822734,
+                pareto_values: 9165718,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }

--- a/raphael-solver/tests/04_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/04_adversarial_exhaustive.rs
@@ -1,5 +1,59 @@
+use expect_test::expect;
 use raphael_sim::*;
-use raphael_solver::test_utils::*;
+use raphael_solver::{AtomicFlag, MacroSolver, SolverSettings};
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+struct SolutionScore {
+    pub capped_quality: u32,
+    pub steps: u8,
+    pub duration: u8,
+    pub overflow_quality: u32,
+}
+
+fn is_progress_backloaded(settings: &SolverSettings, actions: &[Action]) -> bool {
+    let mut state = SimulationState::new(&settings.simulator_settings);
+    let mut quality_lock = None;
+    for action in actions {
+        state = state
+            .use_action(*action, Condition::Normal, &settings.simulator_settings)
+            .unwrap();
+        if state.progress != 0 && quality_lock.is_none() {
+            quality_lock = Some(state.quality);
+        }
+    }
+    quality_lock.is_none_or(|quality| state.quality == quality)
+}
+
+fn test_with_settings(
+    settings: SolverSettings,
+    expected_score: expect_test::Expect,
+    expected_runtime_stats: expect_test::Expect,
+) {
+    let mut solver = MacroSolver::new(
+        settings,
+        Box::new(|_| {}),
+        Box::new(|_| {}),
+        AtomicFlag::new(),
+    );
+    let result = solver.solve();
+    let score = result.map_or(None, |actions| {
+        let final_state =
+            SimulationState::from_macro(&settings.simulator_settings, &actions).unwrap();
+        assert!(final_state.progress >= settings.max_progress());
+        if settings.backload_progress {
+            assert!(is_progress_backloaded(&settings, &actions));
+        }
+        Some(SolutionScore {
+            capped_quality: std::cmp::min(final_state.quality, settings.max_quality()),
+            steps: actions.len() as u8,
+            duration: actions.iter().map(|action| action.time_cost()).sum(),
+            overflow_quality: final_state.quality.saturating_sub(settings.max_quality()),
+        })
+    });
+    expected_score.assert_debug_eq(&score);
+    expected_runtime_stats.assert_debug_eq(&solver.runtime_stats());
+}
 
 const SETTINGS: Settings = Settings {
     max_cp: 370,
@@ -20,7 +74,7 @@ const SETTINGS: Settings = Settings {
 fn stuffed_peppers() {
     // lv99 Rarefied Stuffed Peppers
     // 4785 CMS, 4758 Ctrl, 646 CP
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 646,
         max_durability: 80,
         max_progress: 6300,
@@ -29,16 +83,42 @@ fn stuffed_peppers() {
         base_quality: 360,
         ..SETTINGS
     };
-    let actions = solve(&settings, false, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (11400, 16, 45, 282));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: false,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 11400,
+                steps: 16,
+                duration: 45,
+                overflow_quality: 282,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 811236,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 4715101,
+                pareto_values: 77795158,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 830886,
+                pareto_values: 14689426,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn test_rare_tacos_2() {
     // lv100 Rarefied Tacos de Carne Asada
     // 4785 CMS, 4758 Ctrl, 646 CP
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 646,
         max_durability: 80,
         max_progress: 6600,
@@ -52,16 +132,42 @@ fn test_rare_tacos_2() {
             .remove(Action::QuickInnovation),
         adversarial: true,
     };
-    let actions = solve(&settings, false, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (12000, 32, 91, 138));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: false,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 12000,
+                steps: 32,
+                duration: 91,
+                overflow_quality: 138,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 1270583,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 5033261,
+                pareto_values: 135360389,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 1388863,
+                pareto_values: 31624049,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn test_mountain_chromite_ingot_no_manipulation() {
     // Mountain Chromite Ingot
     // 3076 Craftsmanship, 3106 Control, Level 90, HQ Tsai Tou Vonou
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 616,
         max_durability: 40,
         max_progress: 2000,
@@ -76,14 +182,40 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             .remove(Action::QuickInnovation),
         adversarial: true,
     };
-    let actions = solve(&settings, true, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (8200, 14, 38, 32));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: false,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 8200,
+                steps: 14,
+                duration: 38,
+                overflow_quality: 32,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 69040,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 3772420,
+                pareto_values: 33045924,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 58379,
+                pareto_values: 519966,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn test_indagator_3858_4057() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 687,
         max_durability: 70,
         max_progress: 5720,
@@ -97,14 +229,40 @@ fn test_indagator_3858_4057() {
             .remove(Action::QuickInnovation),
         adversarial: true,
     };
-    let actions = solve(&settings, false, false).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (10686, 26, 71, 0));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: false,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 10686,
+                steps: 26,
+                duration: 71,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 423088,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 5301382,
+                pareto_values: 125209173,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 675136,
+                pareto_values: 13435389,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
 
 #[test]
 fn test_rare_tacos_4628_4410() {
-    let settings = Settings {
+    let simulator_settings = Settings {
         max_cp: 675,
         max_durability: 80,
         max_progress: 6600,
@@ -119,7 +277,33 @@ fn test_rare_tacos_4628_4410() {
             .remove(Action::QuickInnovation),
         adversarial: true,
     };
-    let actions = solve(&settings, true, true).unwrap();
-    let score = get_score_quad(&settings, &actions);
-    assert_eq!(score, (11748, 31, 88, 0));
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        backload_progress: false,
+        allow_unsound_branch_pruning: false,
+    };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 11748,
+                steps: 31,
+                duration: 88,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 457250,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 5301245,
+                pareto_values: 151087149,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 319245,
+                pareto_values: 6969450,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use egui::{Align, CursorIcon, Id, Layout, TextStyle, Visuals};
 use raphael_data::{Consumable, Locale, action_name, get_initial_quality, get_job_name};
 
-use raphael_sim::{Action, ActionImpl, HeartAndSoul, Manipulation, QuickInnovation};
+use raphael_sim::{
+    Action, ActionImpl, HeartAndSoul, Manipulation, QuickInnovation, SimulationState,
+};
 
 use crate::config::{
     CrafterConfig, CustomRecipeOverridesConfiguration, QualitySource, QualityTarget,
@@ -1028,10 +1030,10 @@ fn spawn_solver(
             let mut solver_events = solver_events.lock().unwrap();
             match result {
                 Ok(actions) => {
-                    let quality =
-                        raphael_solver::test_utils::get_quality(&simulator_settings, &actions);
+                    let final_state =
+                        SimulationState::from_macro(&simulator_settings, &actions).unwrap();
                     solver_events.push_back(SolverEvent::Actions(actions));
-                    if quality >= u32::from(simulator_settings.max_quality) {
+                    if final_state.quality >= u32::from(simulator_settings.max_quality) {
                         solver_events.push_back(SolverEvent::Finished(None));
                         return;
                     }


### PR DESCRIPTION
Test for number of states and number of generates values of inner solvers (`FinishSolver`, `QualityUbSolver`, `StepLbSolver`) to better detect accidental runtime/memory-usage regressions.

The `expect-test` crate is used to test these values so that expected test values can easily be updated by running the tests with `UPDATE_EXPECT=1`. Updated test values should then be reviewed in PR.