### PR TITLE
Detect OOM for web version

### DIFF
--- a/.cargo/config_wasm.toml
+++ b/.cargo/config_wasm.toml
@@ -1,2 +1,9 @@
+
+[build]
+target = "wasm32-unknown-unknown"
+
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg=web_sys_unstable_apis", "-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--max-memory=4294967296"]
+
 [unstable]
 build-std = ["panic_abort", "std"]

--- a/.cargo/config_wasm.toml
+++ b/.cargo/config_wasm.toml
@@ -3,6 +3,7 @@
 target = "wasm32-unknown-unknown"
 
 [target.wasm32-unknown-unknown]
+# web_sys unstable APIs needed for copy to clipboard functionality
 rustflags = ["--cfg=web_sys_unstable_apis", "-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--max-memory=4294967296"]
 
 [unstable]

--- a/cloudflare-deploy.sh
+++ b/cloudflare-deploy.sh
@@ -28,6 +28,6 @@ curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-
 cargo-binstall --no-confirm --locked trunk
 
 # web_sys unstable APIs needed for copy to clipboard functionality
-export RUSTFLAGS="--cfg=web_sys_unstable_apis -Ctarget-feature=+atomics,+bulk-memory -Clink-arg=--max-memory=4294967296"
+#export RUSTFLAGS="--cfg=web_sys_unstable_apis -Ctarget-feature=+atomics,+bulk-memory -Clink-arg=--max-memory=4294967296"
 
 trunk build index.html --release

--- a/cloudflare-deploy.sh
+++ b/cloudflare-deploy.sh
@@ -27,7 +27,4 @@ curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-
 # install trunk
 cargo-binstall --no-confirm --locked trunk
 
-# web_sys unstable APIs needed for copy to clipboard functionality
-#export RUSTFLAGS="--cfg=web_sys_unstable_apis -Ctarget-feature=+atomics,+bulk-memory -Clink-arg=--max-memory=4294967296"
-
 trunk build index.html --release

--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -21,6 +21,8 @@ pub enum SolverException {
     NoSolution,
     Interrupted,
     InternalError(String),
+    #[cfg(target_arch = "wasm32")]
+    AllocError,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/serve-web.sh
+++ b/serve-web.sh
@@ -2,7 +2,6 @@
 
 set -exo pipefail
 
-#export RUSTFLAGS="--cfg=web_sys_unstable_apis -Ctarget-feature=+atomics,+bulk-memory -Clink-arg=--max-memory=4294967296"
 export BASE_URL="http://localhost:8080"
 
 # Requires nightly toolchain, rust-src component, and wasm32-unknown-unkown target

--- a/serve-web.sh
+++ b/serve-web.sh
@@ -2,7 +2,7 @@
 
 set -exo pipefail
 
-export RUSTFLAGS="--cfg=web_sys_unstable_apis -Ctarget-feature=+atomics,+bulk-memory -Clink-arg=--max-memory=4294967296"
+#export RUSTFLAGS="--cfg=web_sys_unstable_apis -Ctarget-feature=+atomics,+bulk-memory -Clink-arg=--max-memory=4294967296"
 export BASE_URL="http://localhost:8080"
 
 # Requires nightly toolchain, rust-src component, and wasm32-unknown-unkown target

--- a/src/app.rs
+++ b/src/app.rs
@@ -181,7 +181,7 @@ impl eframe::App for MacroSolverApp {
         }
 
         #[cfg(target_arch = "wasm32")]
-        if crate::ATOMIC_STATUS.load(std::sync::atomic::Ordering::Relaxed) == crate::OOM_STATUS {
+        if crate::OOM_PANIC_OCCURED.load(std::sync::atomic::Ordering::Relaxed) {
             self.solver_error = Some(SolverException::AllocError);
         }
         if let Some(error) = self.solver_error.clone() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -212,7 +212,8 @@ impl eframe::App for MacroSolverApp {
                         ui.separator();
                         ui.label("The solver reached the 4GB memory limit of 32-bit web assembly and crashed.");
                         ui.label("Consider enabling fewer memory intensive options.\n");
-                        ui.label("Alternatively, a native version is available from the release page on GitHub:");
+                        ui.label("Alternatively, a native version is available from the release page on GitHub.");
+                        ui.label("The native version doesn't have the 4GB limit, in addition to better performance.");
                         ui.add(
                             egui::Hyperlink::from_label_and_url(
                                 "View latest release on GitHub",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,8 @@ pub use app::MacroSolverApp;
 
 mod config;
 mod widgets;
+
+#[cfg(target_arch = "wasm32")]
+pub const OOM_STATUS: usize = usize::MAX;
+#[cfg(target_arch = "wasm32")]
+pub static ATOMIC_STATUS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,4 @@ mod config;
 mod widgets;
 
 #[cfg(target_arch = "wasm32")]
-pub const OOM_STATUS: usize = usize::MAX;
-#[cfg(target_arch = "wasm32")]
-pub static ATOMIC_STATUS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+pub static OOM_PANIC_OCCURED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@
 // This attribute is ignored for all other platforms
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+#![cfg_attr(target_arch = "wasm32", feature(alloc_error_hook))]
+
 #[cfg(all(target_os = "windows", not(debug_assertions)))]
 fn init_logging() {
     // Ensure app storage folder exists
@@ -67,6 +69,11 @@ fn main() -> eframe::Result<()> {
 
 #[cfg(target_arch = "wasm32")]
 fn main() {
+    fn custom_alloc_error_hook(_layout: std::alloc::Layout) {
+        raphael_xiv::ATOMIC_STATUS.store(usize::MAX, std::sync::atomic::Ordering::Relaxed);
+    }
+    std::alloc::set_alloc_error_hook(custom_alloc_error_hook);
+
     init_logging();
 
     fn get_canvas() -> Option<web_sys::HtmlCanvasElement> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> eframe::Result<()> {
 #[cfg(target_arch = "wasm32")]
 fn main() {
     fn custom_alloc_error_hook(_layout: std::alloc::Layout) {
-        raphael_xiv::ATOMIC_STATUS.store(usize::MAX, std::sync::atomic::Ordering::Relaxed);
+        raphael_xiv::OOM_PANIC_OCCURED.store(true, std::sync::atomic::Ordering::Relaxed);
     }
     std::alloc::set_alloc_error_hook(custom_alloc_error_hook);
 


### PR DESCRIPTION
Adds code that detects if the web version ran out of memory and displays this in the error modal dialog.
Additionally, I changed the `.cargo/config_wasm.toml` to include the target and rustflags so that they can be used when testing the web version locally, without having to set them manually. The build scripts are updated accordingly.

Closes #112 

**Preview of the UI changes:**
![image](https://github.com/user-attachments/assets/37edfcfb-ffb6-4c66-9487-698073303990)
