### PR TITLE
Move `backload_progress` logic into simulator

### DIFF
--- a/raphael-bindings/src/lib.rs
+++ b/raphael-bindings/src/lib.rs
@@ -137,11 +137,9 @@ impl From<SolveArgs> for SolverSettings {
             job_level: value.job_level,
             allowed_actions: ActionMask::from_bits(value.action_mask),
             adversarial: value.adversarial,
-        };
-        Self {
-            simulator_settings,
             backload_progress: value.backload_progress,
-        }
+        };
+        Self { simulator_settings }
     }
 }
 

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -304,14 +304,10 @@ pub fn execute(args: &SolveArgs) {
             base_quality_override: Some(args.override_base_increases[2]),
         })
     };
-    let mut settings = get_game_settings(
-        recipe,
-        custom_recipe_overrides,
-        crafter_stats,
-        food,
-        potion,
-        args.adversarial,
-    );
+    let mut settings =
+        get_game_settings(recipe, custom_recipe_overrides, crafter_stats, food, potion);
+    settings.adversarial = args.adversarial;
+    settings.backload_progress = args.backload_progress;
 
     let target_quality = match args.target_quality {
         Some(target) => target.clamp(0, settings.max_quality),
@@ -340,7 +336,6 @@ pub fn execute(args: &SolveArgs) {
 
     let solver_settings = SolverSettings {
         simulator_settings: settings,
-        backload_progress: args.backload_progress,
     };
 
     let mut solver = MacroSolver::new(

--- a/raphael-data/src/lib.rs
+++ b/raphael-data/src/lib.rs
@@ -79,7 +79,6 @@ pub fn get_game_settings(
     crafter_stats: CrafterStats,
     food: Option<Consumable>,
     potion: Option<Consumable>,
-    adversarial: bool,
 ) -> Settings {
     let rlvl = if recipe.max_level_scaling != 0 {
         let job_level = std::cmp::min(recipe.max_level_scaling, crafter_stats.level);
@@ -136,7 +135,8 @@ pub fn get_game_settings(
             },
             job_level: crafter_stats.level,
             allowed_actions,
-            adversarial,
+            adversarial: false,
+            backload_progress: false,
         },
         None => Settings {
             max_cp: cp as _,
@@ -147,7 +147,8 @@ pub fn get_game_settings(
             base_quality: base_quality as u16,
             job_level: crafter_stats.level,
             allowed_actions,
-            adversarial,
+            adversarial: false,
+            backload_progress: false,
         },
     }
 }

--- a/raphael-data/tests/test_get_game_settings.rs
+++ b/raphael-data/tests/test_get_game_settings.rs
@@ -34,7 +34,7 @@ fn test_roast_chicken() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -50,6 +50,7 @@ fn test_roast_chicken() {
                 .remove(Action::HeartAndSoul)
                 .remove(Action::QuickInnovation),
             adversarial: false,
+            backload_progress: false,
         }
     );
 }
@@ -70,7 +71,7 @@ fn test_turali_pineapple_ponzecake() {
         heart_and_soul: true,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -85,6 +86,7 @@ fn test_turali_pineapple_ponzecake() {
                 .remove(Action::TrainedEye)
                 .remove(Action::QuickInnovation),
             adversarial: false,
+            backload_progress: false,
         }
     );
     let initial_quality = get_initial_quality(crafter_stats, recipe, [0, 1, 0, 0, 0, 0]);
@@ -104,7 +106,7 @@ fn test_smaller_water_otter_hardware() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -121,6 +123,7 @@ fn test_smaller_water_otter_hardware() {
                 .remove(Action::HeartAndSoul)
                 .remove(Action::QuickInnovation),
             adversarial: false,
+            backload_progress: false,
         }
     );
 }
@@ -138,7 +141,7 @@ fn test_grade_8_tincture() {
         heart_and_soul: true,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -152,6 +155,7 @@ fn test_grade_8_tincture() {
             // Trained Eye is available
             allowed_actions: ActionMask::all().remove(Action::QuickInnovation),
             adversarial: false,
+            backload_progress: false,
         }
     );
 }
@@ -172,7 +176,7 @@ fn test_claro_walnut_spinning_wheel() {
         heart_and_soul: false,
         quick_innovation: true,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -187,6 +191,7 @@ fn test_claro_walnut_spinning_wheel() {
                 .remove(Action::TrainedEye)
                 .remove(Action::HeartAndSoul),
             adversarial: false,
+            backload_progress: false,
         }
     );
 }
@@ -203,7 +208,7 @@ fn test_habitat_chair_lv100() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -219,6 +224,7 @@ fn test_habitat_chair_lv100() {
                 .remove(Action::HeartAndSoul)
                 .remove(Action::QuickInnovation),
             adversarial: false,
+            backload_progress: false,
         }
     );
 }
@@ -236,7 +242,7 @@ fn test_habitat_chair_lv97() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -252,6 +258,7 @@ fn test_habitat_chair_lv97() {
                 .remove(Action::HeartAndSoul)
                 .remove(Action::QuickInnovation),
             adversarial: false,
+            backload_progress: false,
         }
     );
 }
@@ -269,7 +276,7 @@ fn test_habitat_chair_lv98() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -285,6 +292,7 @@ fn test_habitat_chair_lv98() {
                 .remove(Action::HeartAndSoul)
                 .remove(Action::QuickInnovation),
             adversarial: false,
+            backload_progress: false,
         }
     );
 }
@@ -302,7 +310,7 @@ fn test_standard_indurate_rings_lv93() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -318,6 +326,7 @@ fn test_standard_indurate_rings_lv93() {
                 .remove(Action::HeartAndSoul)
                 .remove(Action::QuickInnovation),
             adversarial: false,
+            backload_progress: false,
         }
     );
 }
@@ -335,7 +344,7 @@ fn test_lunar_alloy_ingots_lv90() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -351,6 +360,7 @@ fn test_lunar_alloy_ingots_lv90() {
                 .remove(Action::HeartAndSoul)
                 .remove(Action::QuickInnovation),
             adversarial: false,
+            backload_progress: false,
         }
     );
 }
@@ -368,7 +378,7 @@ fn test_standard_high_density_fiberboard_lv91() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -384,6 +394,7 @@ fn test_standard_high_density_fiberboard_lv91() {
                 .remove(Action::HeartAndSoul)
                 .remove(Action::QuickInnovation),
             adversarial: false,
+            backload_progress: false,
         }
     );
 }
@@ -400,7 +411,7 @@ fn test_lunar_alloy_ingots_lv10() {
         heart_and_soul: false,
         quick_innovation: false,
     };
-    let settings = get_game_settings(recipe, None, crafter_stats, None, None, false);
+    let settings = get_game_settings(recipe, None, crafter_stats, None, None);
     assert_eq!(
         settings,
         Settings {
@@ -416,6 +427,7 @@ fn test_lunar_alloy_ingots_lv10() {
                 .remove(Action::HeartAndSoul)
                 .remove(Action::QuickInnovation),
             adversarial: false,
+            backload_progress: false,
         }
     );
 }

--- a/raphael-sim/benches/bench_simulator.rs
+++ b/raphael-sim/benches/bench_simulator.rs
@@ -13,6 +13,7 @@ fn bench_use_action(c: &mut Criterion) {
         job_level: 100,
         allowed_actions: ActionMask::all(),
         adversarial: false,
+        backload_progress: false,
     };
     let state = SimulationState::new(&settings);
 

--- a/raphael-sim/src/effects.rs
+++ b/raphael-sim/src/effects.rs
@@ -18,18 +18,17 @@ pub struct Effects {
     #[bits(4)]
     pub manipulation: u8,
 
-    pub adversarial_guard: bool,
     pub trained_perfection_available: bool,
     pub heart_and_soul_available: bool,
     pub quick_innovation_available: bool,
     pub trained_perfection_active: bool,
     pub heart_and_soul_active: bool,
 
+    pub adversarial_guard: bool,
+    pub allow_quality_actions: bool,
+
     #[bits(2)]
     pub combo: Combo,
-
-    #[bits(1)]
-    _padding: u8,
 }
 
 impl Effects {
@@ -37,6 +36,7 @@ impl Effects {
     pub fn initial(settings: &Settings) -> Self {
         Self::new()
             .with_adversarial_guard(settings.adversarial)
+            .with_allow_quality_actions(true)
             .with_trained_perfection_available(
                 settings.is_action_allowed::<crate::actions::TrainedPerfection>(),
             )

--- a/raphael-sim/src/settings.rs
+++ b/raphael-sim/src/settings.rs
@@ -12,6 +12,8 @@ pub struct Settings {
     pub job_level: u8,
     pub allowed_actions: ActionMask,
     pub adversarial: bool,
+    /// If `backload_progress` is set, after using any action that increases Progress, the simulator will forbid the use of actions that directly increase Quality.
+    pub backload_progress: bool,
 }
 
 impl Settings {

--- a/raphael-sim/src/state.rs
+++ b/raphael-sim/src/state.rs
@@ -96,15 +96,6 @@ impl SimulationState {
 
         state.cp -= A::cp_cost(self, settings, condition);
 
-        let progress_increase = A::progress_increase(self, settings, condition);
-        state.progress += progress_increase;
-        if progress_increase != 0 {
-            state.effects = state
-                .effects
-                .with_muscle_memory(0)
-                .with_allow_quality_actions(!settings.backload_progress);
-        }
-
         let quality_increase = A::quality_increase(self, settings, condition);
         if !state.effects.allow_quality_actions() && quality_increase != 0 {
             return Err("Forbidden by backload_progress setting");
@@ -134,6 +125,15 @@ impl SimulationState {
             state
                 .effects
                 .set_inner_quiet(std::cmp::min(10, state.effects.inner_quiet() + 1));
+        }
+
+        let progress_increase = A::progress_increase(self, settings, condition);
+        state.progress += progress_increase;
+        if progress_increase != 0 {
+            state.effects = state
+                .effects
+                .with_muscle_memory(0)
+                .with_allow_quality_actions(!settings.backload_progress);
         }
 
         if state.is_final(settings) {

--- a/raphael-sim/src/state.rs
+++ b/raphael-sim/src/state.rs
@@ -104,14 +104,14 @@ impl SimulationState {
 
         let quality_increase = A::quality_increase(self, settings, condition);
         if settings.adversarial {
-            let adversarial_quality_increase = if state.effects.guard() != 0 {
+            let adversarial_quality_increase = if state.effects.adversarial_guard() {
                 quality_increase
             } else {
                 A::quality_increase(self, settings, Condition::Poor)
             };
-            if state.effects.guard() == 0 && adversarial_quality_increase == 0 {
+            if !state.effects.adversarial_guard() && adversarial_quality_increase == 0 {
                 state.unreliable_quality = 0;
-            } else if state.effects.guard() != 0 && adversarial_quality_increase != 0 {
+            } else if state.effects.adversarial_guard() && adversarial_quality_increase != 0 {
                 state.quality += adversarial_quality_increase;
                 state.unreliable_quality = 0;
             } else if adversarial_quality_increase != 0 {
@@ -142,7 +142,7 @@ impl SimulationState {
         }
 
         if settings.adversarial && quality_increase != 0 {
-            state.effects.set_guard(1);
+            state.effects.set_adversarial_guard(true);
         }
 
         A::transform_post(&mut state, settings, condition);

--- a/raphael-sim/tests/action_tests.rs
+++ b/raphael-sim/tests/action_tests.rs
@@ -631,7 +631,7 @@ fn test_heart_and_soul() {
     match state {
         Ok(state) => {
             assert_eq!(state.effects.combo(), Combo::None); // combo is removed
-            assert_eq!(state.effects.guard(), 1); // guard is unaffected because condition is not re-rolled
+            assert!(state.effects.adversarial_guard()); // condition is not re-rolled
             assert_eq!(state.effects.manipulation(), 7); // effects are not ticked
             assert_eq!(state.effects.heart_and_soul_available(), false);
             assert_eq!(state.effects.heart_and_soul_active(), true);
@@ -701,7 +701,7 @@ fn test_quick_innovation() {
     match state {
         Ok(state) => {
             assert_eq!(state.effects.combo(), Combo::None); // combo is removed
-            assert_eq!(state.effects.guard(), 1); // guard is unaffected because condition is not re-rolled
+            assert!(state.effects.adversarial_guard()); // condition is not re-rolled
             assert_eq!(state.effects.manipulation(), 7); // effects are not ticked
             assert_eq!(state.effects.innovation(), 1);
         }

--- a/raphael-sim/tests/action_tests.rs
+++ b/raphael-sim/tests/action_tests.rs
@@ -10,6 +10,7 @@ const SETTINGS: Settings = Settings {
     job_level: 100,
     allowed_actions: ActionMask::all(),
     adversarial: false,
+    backload_progress: false,
 };
 
 /// Returns the 4 primary stats of a state:
@@ -207,19 +208,15 @@ fn test_byregots_blessing() {
         "Cannot use Byregot's Blessing when Inner Quiet is 0."
     );
     // Quality efficiency scales with inner quiet
-    let initial_state = SimulationState {
-        effects: Effects::new().with_inner_quiet(5),
-        ..SimulationState::new(&SETTINGS)
-    };
+    let mut initial_state = SimulationState::new(&SETTINGS);
+    initial_state.effects.set_inner_quiet(5);
     let state = initial_state
         .use_action(Action::ByregotsBlessing, Condition::Normal, &SETTINGS)
         .unwrap();
     assert_eq!(primary_stats(&state, &SETTINGS), (0, 300, 10, 24));
     assert_eq!(state.effects.inner_quiet(), 0);
-    let initial_state = SimulationState {
-        effects: Effects::new().with_inner_quiet(10),
-        ..SimulationState::new(&SETTINGS)
-    };
+    let mut initial_state = SimulationState::new(&SETTINGS);
+    initial_state.effects.set_inner_quiet(10);
     let state = initial_state
         .use_action(Action::ByregotsBlessing, Condition::Normal, &SETTINGS)
         .unwrap();
@@ -244,10 +241,8 @@ fn test_precise_touch() {
     assert_eq!(primary_stats(&state, &SETTINGS), (0, 225, 10, 18));
     assert_eq!(state.effects.inner_quiet(), 2);
     // Can use when Heart and Soul is active
-    let initial_state = SimulationState {
-        effects: Effects::new().with_heart_and_soul_active(true),
-        ..SimulationState::new(&SETTINGS)
-    };
+    let mut initial_state = SimulationState::new(&SETTINGS);
+    initial_state.effects.set_heart_and_soul_active(true);
     let state = initial_state
         .use_action(Action::PreciseTouch, Condition::Normal, &SETTINGS)
         .unwrap();
@@ -255,10 +250,8 @@ fn test_precise_touch() {
     assert_eq!(state.effects.inner_quiet(), 2);
     assert_eq!(state.effects.heart_and_soul_active(), false);
     // Heart and Soul effect isn't consumed when condition is Good or Excellent
-    let initial_state = SimulationState {
-        effects: Effects::new().with_heart_and_soul_active(true),
-        ..SimulationState::new(&SETTINGS)
-    };
+    let mut initial_state = SimulationState::new(&SETTINGS);
+    initial_state.effects.set_heart_and_soul_active(true);
     let state = initial_state
         .use_action(Action::PreciseTouch, Condition::Good, &SETTINGS)
         .unwrap();

--- a/raphael-sim/tests/adversarial_tests.rs
+++ b/raphael-sim/tests/adversarial_tests.rs
@@ -9,6 +9,7 @@ const SETTINGS: Settings = Settings {
     job_level: 100,
     allowed_actions: ActionMask::all(),
     adversarial: true,
+    backload_progress: false,
 };
 
 /// Calculate the minimum achievable Quality across all possible Condition rolls

--- a/raphael-sim/tests/backload_progress_tests.rs
+++ b/raphael-sim/tests/backload_progress_tests.rs
@@ -48,3 +48,11 @@ fn test_quality_actions_forbidden() {
     let result = state.use_action(Action::BasicTouch, Condition::Normal, &SETTINGS);
     assert_eq!(result, Err("Forbidden by backload_progress setting"));
 }
+
+#[test]
+/// Test that Delicate Synthesis can be used under `backload_progress`.
+/// It is the only action that increases Progress and Quality at the same time.
+fn test_delicate_synthesis() {
+    let state = SimulationState::from_macro(&SETTINGS, &[Action::DelicateSynthesis]).unwrap();
+    assert_eq!(state.effects.allow_quality_actions(), false);
+}

--- a/raphael-sim/tests/backload_progress_tests.rs
+++ b/raphael-sim/tests/backload_progress_tests.rs
@@ -1,0 +1,50 @@
+use raphael_sim::{Action, ActionMask, Condition, Settings, SimulationState};
+
+const SETTINGS: Settings = Settings {
+    max_cp: 500,
+    max_durability: 80,
+    max_progress: 2000,
+    max_quality: 2000,
+    base_progress: 100,
+    base_quality: 100,
+    job_level: 100,
+    allowed_actions: ActionMask::all(),
+    adversarial: true,
+    backload_progress: true,
+};
+
+#[test]
+/// Test that effects are updated correctly under `backload_progress` after using a Progress-increasing action:
+/// - Effects that only influence Quality should be removed.
+/// - The `allow_quality_actions` effect must be `false`.
+fn test_effects() {
+    let mut state = SimulationState::new(&SETTINGS);
+    state.unreliable_quality = 100;
+    state.effects.set_inner_quiet(2);
+    state.effects.set_innovation(2);
+    state.effects.set_great_strides(2);
+    state.effects.set_adversarial_guard(true);
+    state.effects.set_quick_innovation_available(true);
+    let state = state
+        .use_action(Action::MuscleMemory, Condition::Normal, &SETTINGS)
+        .unwrap();
+    assert_eq!(state.unreliable_quality, 0);
+    assert_eq!(state.effects.inner_quiet(), 0);
+    assert_eq!(state.effects.innovation(), 0);
+    assert_eq!(state.effects.great_strides(), 0);
+    assert_eq!(state.effects.adversarial_guard(), false);
+    assert_eq!(state.effects.quick_innovation_available(), false);
+    assert_eq!(state.effects.allow_quality_actions(), false);
+}
+
+#[test]
+/// Test that Quality-increasing actions are forbidden under `backload_progress` after using a Progress-increasing action.
+fn test_quality_actions_forbidden() {
+    let state = SimulationState::from_macro(
+        &SETTINGS,
+        &[Action::MuscleMemory, Action::Observe, Action::Observe],
+    )
+    .unwrap();
+    let result = state.use_action(Action::BasicTouch, Condition::Normal, &SETTINGS);
+    assert_eq!(result, Err("Forbidden by backload_progress setting"));
+}

--- a/raphael-sim/tests/backload_progress_tests.rs
+++ b/raphael-sim/tests/backload_progress_tests.rs
@@ -42,11 +42,19 @@ fn test_effects() {
 fn test_quality_actions_forbidden() {
     let state = SimulationState::from_macro(
         &SETTINGS,
-        &[Action::MuscleMemory, Action::Observe, Action::Observe],
+        &[Action::Reflect, Action::BasicSynthesis, Action::Observe],
     )
     .unwrap();
     let result = state.use_action(Action::BasicTouch, Condition::Normal, &SETTINGS);
     assert_eq!(result, Err("Forbidden by backload_progress setting"));
+    let result = state.use_action(Action::PreciseTouch, Condition::Good, &SETTINGS);
+    assert_eq!(result, Err("Forbidden by backload_progress setting"));
+    // Using a Progress-action resets Inner Quiet.
+    let result = state.use_action(Action::ByregotsBlessing, Condition::Normal, &SETTINGS);
+    assert_eq!(
+        result,
+        Err("Cannot use Byregot's Blessing when Inner Quiet is 0.")
+    );
 }
 
 #[test]

--- a/raphael-sim/tests/effect_tests.rs
+++ b/raphael-sim/tests/effect_tests.rs
@@ -10,6 +10,7 @@ const SETTINGS: Settings = Settings {
     job_level: 100,
     allowed_actions: ActionMask::all(),
     adversarial: false,
+    backload_progress: false,
 };
 
 /// Returns the 4 primary stats of a state:

--- a/raphael-sim/tests/simulator_tests.rs
+++ b/raphael-sim/tests/simulator_tests.rs
@@ -35,6 +35,7 @@ fn test_level_requirement() {
         job_level: 50,
         allowed_actions: ActionMask::all(),
         adversarial: false,
+        backload_progress: false,
     };
     let error = SimulationState::new(&settings)
         .use_action(Action::ImmaculateMend, Condition::Normal, &settings)
@@ -56,6 +57,7 @@ fn test_random_926ae85b() {
         job_level: 10,
         allowed_actions: ActionMask::all(),
         adversarial: false,
+        backload_progress: false,
     };
     let actions = [
         Action::BasicSynthesis,
@@ -84,6 +86,7 @@ fn test_random_3c721e47() {
         job_level: 85,
         allowed_actions: ActionMask::all(),
         adversarial: false,
+        backload_progress: false,
     };
     let actions = [
         Action::MuscleMemory,
@@ -116,6 +119,7 @@ fn test_random_3ba90d3a() {
         job_level: 81,
         allowed_actions: ActionMask::all(),
         adversarial: false,
+        backload_progress: false,
     };
     let actions = [
         Action::Veneration,
@@ -151,6 +155,7 @@ fn test_random_bce2650c() {
         job_level: 90,
         allowed_actions: ActionMask::all(),
         adversarial: false,
+        backload_progress: false,
     };
     let actions = [
         Action::MuscleMemory,
@@ -201,6 +206,7 @@ fn test_ingame_be9fc5c2() {
         job_level: 90,
         allowed_actions: ActionMask::all(),
         adversarial: false,
+        backload_progress: false,
     };
     let states = simulate(
         &settings,
@@ -272,6 +278,7 @@ fn test_ingame_d11d9c68() {
         job_level: 94,
         allowed_actions: ActionMask::all(),
         adversarial: false,
+        backload_progress: false,
     };
     let actions = [
         Action::Reflect,
@@ -327,6 +334,7 @@ fn test_ingame_f9f0dac7() {
         job_level: 100,
         allowed_actions: ActionMask::all(),
         adversarial: true,
+        backload_progress: false,
     };
     let actions = [
         Action::Reflect,
@@ -413,6 +421,7 @@ fn test_ingame_4866545e() {
         job_level: 100,
         allowed_actions: ActionMask::all(),
         adversarial: false,
+        backload_progress: false,
     };
     let actions = [
         Action::Reflect,

--- a/raphael-solver/examples/macro_solver_example.rs
+++ b/raphael-solver/examples/macro_solver_example.rs
@@ -22,12 +22,10 @@ fn main() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
-    };
-
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+
+    let solver_settings = SolverSettings { simulator_settings };
 
     let mut solver = MacroSolver::new(
         solver_settings,

--- a/raphael-solver/src/actions.rs
+++ b/raphael-solver/src/actions.rs
@@ -160,13 +160,6 @@ pub const QUALITY_ONLY_SEARCH_ACTIONS: &[ActionCombo] = &[
     ActionCombo::Single(Action::TrainedPerfection),
 ];
 
-pub fn is_progress_only_state(settings: &SolverSettings, state: &SimulationState) -> bool {
-    if settings.backload_progress && state.progress != 0 {
-        return true;
-    }
-    false
-}
-
 pub fn use_action_combo(
     settings: &SolverSettings,
     mut state: SimulationState,
@@ -174,15 +167,6 @@ pub fn use_action_combo(
 ) -> Result<SimulationState, &'static str> {
     for action in action_combo.actions() {
         state = state.use_action(*action, Condition::Normal, &settings.simulator_settings)?;
-    }
-    if is_progress_only_state(settings, &state) {
-        // strip all quality-only data
-        state.unreliable_quality = 0;
-        state.effects.set_inner_quiet(0);
-        state.effects.set_innovation(0);
-        state.effects.set_great_strides(0);
-        state.effects.set_adversarial_guard(false);
-        state.effects.set_quick_innovation_available(false);
     }
     state.effects.set_combo(Combo::None);
     Ok(state)

--- a/raphael-solver/src/actions.rs
+++ b/raphael-solver/src/actions.rs
@@ -181,7 +181,7 @@ pub fn use_action_combo(
         state.effects.set_inner_quiet(0);
         state.effects.set_innovation(0);
         state.effects.set_great_strides(0);
-        state.effects.set_guard(0);
+        state.effects.set_adversarial_guard(false);
         state.effects.set_quick_innovation_available(false);
     }
     state.effects.set_combo(Combo::None);

--- a/raphael-solver/src/finish_solver.rs
+++ b/raphael-solver/src/finish_solver.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
     SolverSettings,
-    actions::{FULL_SEARCH_ACTIONS, use_action_combo},
+    actions::{PROGRESS_ONLY_SEARCH_ACTIONS, use_action_combo},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -21,6 +21,7 @@ impl ReducedState {
             cp: state.cp,
             effects: state
                 .effects
+                .with_allow_quality_actions(false)
                 .with_inner_quiet(0)
                 .with_innovation(0)
                 .with_great_strides(0)
@@ -65,7 +66,7 @@ impl FinishSolver {
             Some(max_progress) => *max_progress,
             None => {
                 let mut max_progress = 0;
-                for action in FULL_SEARCH_ACTIONS {
+                for action in PROGRESS_ONLY_SEARCH_ACTIONS {
                     if let Ok(new_state) =
                         use_action_combo(&self.settings, state.to_state(), *action)
                     {

--- a/raphael-solver/src/finish_solver.rs
+++ b/raphael-solver/src/finish_solver.rs
@@ -24,7 +24,7 @@ impl ReducedState {
                 .with_inner_quiet(0)
                 .with_innovation(0)
                 .with_great_strides(0)
-                .with_guard(0)
+                .with_adversarial_guard(false)
                 .with_quick_innovation_available(false),
         }
     }

--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -26,7 +26,6 @@ pub enum SolverException {
 #[derive(Clone, Copy, Debug)]
 pub struct SolverSettings {
     pub simulator_settings: raphael_sim::Settings,
-    pub backload_progress: bool,
 }
 
 impl SolverSettings {

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -2,8 +2,7 @@ use raphael_sim::*;
 
 use super::search_queue::SearchScore;
 use crate::actions::{
-    ActionCombo, FULL_SEARCH_ACTIONS, PROGRESS_ONLY_SEARCH_ACTIONS, is_progress_only_state,
-    use_action_combo,
+    ActionCombo, FULL_SEARCH_ACTIONS, PROGRESS_ONLY_SEARCH_ACTIONS, use_action_combo,
 };
 use crate::macro_solver::fast_lower_bound::fast_lower_bound;
 use crate::macro_solver::search_queue::SearchQueue;
@@ -130,10 +129,9 @@ impl<'a> MacroSolver<'a> {
                 (self.progress_callback)(popped);
             }
 
-            let progress_only = is_progress_only_state(&self.settings, &state);
-            let search_actions = match progress_only {
-                true => PROGRESS_ONLY_SEARCH_ACTIONS,
-                false => FULL_SEARCH_ACTIONS,
+            let search_actions = match state.effects.allow_quality_actions() {
+                false => PROGRESS_ONLY_SEARCH_ACTIONS,
+                true => FULL_SEARCH_ACTIONS,
             };
 
             for action in search_actions {

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -54,7 +54,6 @@ impl QualityUbSolver {
                     .with_heart_and_soul_available(false)
                     .with_combo(Combo::None),
                 compressed_unreliable_quality: 0,
-                progress_only: false,
             },
             required_cp: 0,
         };
@@ -68,7 +67,6 @@ impl QualityUbSolver {
             let state = ReducedState {
                 cp: self.settings.max_cp(),
                 compressed_unreliable_quality: node.template.compressed_unreliable_quality,
-                progress_only: node.template.progress_only,
                 effects: node.template.effects,
             };
             for &action in FULL_SEARCH_ACTIONS {
@@ -80,7 +78,6 @@ impl QualityUbSolver {
                         template: Template {
                             effects: new_state.effects,
                             compressed_unreliable_quality: new_state.compressed_unreliable_quality,
-                            progress_only: new_state.progress_only,
                         },
                         required_cp: node.required_cp + used_cp,
                     };
@@ -115,7 +112,6 @@ impl QualityUbSolver {
                         Some(ReducedState {
                             cp: cp + self.durability_cost,
                             compressed_unreliable_quality: template.compressed_unreliable_quality,
-                            progress_only: template.progress_only,
                             effects: template.effects,
                         })
                     } else {
@@ -219,9 +215,9 @@ impl QualityUbSolver {
             return Err(SolverException::Interrupted);
         }
         self.pareto_front_builder.push_empty();
-        let search_actions = match state.progress_only {
-            true => PROGRESS_ONLY_SEARCH_ACTIONS,
-            false => FULL_SEARCH_ACTIONS,
+        let search_actions = match state.effects.allow_quality_actions() {
+            false => PROGRESS_ONLY_SEARCH_ACTIONS,
+            true => FULL_SEARCH_ACTIONS,
         };
         for &action in search_actions {
             self.build_child_front(state, action)?;
@@ -312,7 +308,6 @@ fn durability_cost(settings: &Settings) -> u16 {
 struct Template {
     effects: Effects,
     compressed_unreliable_quality: u8,
-    progress_only: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/raphael-solver/src/quality_upper_bound_solver/state.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/state.rs
@@ -1,6 +1,6 @@
 use crate::{
     SolverSettings,
-    actions::{ActionCombo, is_progress_only_state, use_action_combo},
+    actions::{ActionCombo, use_action_combo},
 };
 
 use raphael_sim::*;
@@ -9,7 +9,6 @@ use raphael_sim::*;
 pub struct ReducedState {
     pub cp: u16,
     pub compressed_unreliable_quality: u8,
-    pub progress_only: bool,
     pub effects: Effects,
 }
 
@@ -40,19 +39,15 @@ impl ReducedState {
         settings: &SolverSettings,
         durability_cost: u16,
     ) -> Option<Self> {
-        let progress_only = is_progress_only_state(settings, state);
         let used_durability_cost =
             (settings.max_durability() - state.durability) / 5 * durability_cost;
         if used_durability_cost > state.cp {
             return None;
         }
-        let compressed_unreliable_quality = if progress_only {
-            0
-        } else {
-            state
-                .unreliable_quality
-                .div_ceil(2 * settings.base_quality()) as u8
-        };
+        let compressed_unreliable_quality = state
+            .unreliable_quality
+            .div_ceil(2 * settings.base_quality())
+            as u8;
         let effects = {
             let great_strides_active = state.effects.great_strides() != 0;
             state
@@ -62,7 +57,6 @@ impl ReducedState {
         Some(Self {
             cp: state.cp - used_durability_cost,
             compressed_unreliable_quality,
-            progress_only,
             effects,
         })
     }
@@ -83,15 +77,6 @@ impl ReducedState {
         self.cp < 2 * durability_cost
     }
 
-    fn strip_quality_attributes(&mut self) {
-        self.compressed_unreliable_quality = 0;
-        self.effects.set_inner_quiet(0);
-        self.effects.set_innovation(0);
-        self.effects.set_great_strides(0);
-        self.effects.set_adversarial_guard(false);
-        self.effects.set_quick_innovation_available(false);
-    }
-
     pub fn use_action(
         &self,
         action: ActionCombo,
@@ -103,16 +88,11 @@ impl ReducedState {
                 Action::MasterMend | Action::ImmaculateMend | Action::Manipulation,
             ) => None,
             _ => {
-                let progress_only = self.progress_only;
                 let state = self.to_simulation_state(settings);
                 match use_action_combo(settings, state, action) {
                     Ok(state) => {
-                        let mut solver_state =
+                        let solver_state =
                             Self::from_simulation_state_inner(&state, settings, durability_cost)?;
-                        if progress_only || solver_state.progress_only {
-                            solver_state.progress_only = true;
-                            solver_state.strip_quality_attributes();
-                        }
                         Some((solver_state, state.progress, state.quality))
                     }
                     Err(_) => None,

--- a/raphael-solver/src/quality_upper_bound_solver/state.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/state.rs
@@ -88,7 +88,7 @@ impl ReducedState {
         self.effects.set_inner_quiet(0);
         self.effects.set_innovation(0);
         self.effects.set_great_strides(0);
-        self.effects.set_guard(0);
+        self.effects.set_adversarial_guard(false);
         self.effects.set_quick_innovation_available(false);
     }
 

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -486,8 +486,8 @@ fn test_issue_113() {
     solver.precompute(simulator_settings.max_cp);
     let expected_runtime_stats = expect![[r#"
         QualityUbSolverStats {
-            states: 5764187,
-            pareto_values: 209923334,
+            states: 5759474,
+            pareto_values: 209671685,
         }
     "#]];
     expected_runtime_stats.assert_debug_eq(&solver.runtime_stats());
@@ -518,8 +518,8 @@ fn test_issue_118() {
     solver.precompute(simulator_settings.max_cp);
     let expected_runtime_stats = expect![[r#"
         QualityUbSolverStats {
-            states: 3388741,
-            pareto_values: 36810126,
+            states: 3374869,
+            pareto_values: 36634616,
         }
     "#]];
     expected_runtime_stats.assert_debug_eq(&solver.runtime_stats());
@@ -534,11 +534,7 @@ fn random_effects(adversarial: bool) -> Effects {
         .with_waste_not(rand::thread_rng().gen_range(0..=8))
         .with_manipulation(rand::thread_rng().gen_range(0..=8))
         .with_quick_innovation_available(rand::random())
-        .with_guard(if adversarial {
-            rand::thread_rng().gen_range(0..=1)
-        } else {
-            0
-        })
+        .with_adversarial_guard(if adversarial { rand::random() } else { false })
 }
 
 fn random_state(settings: &Settings) -> SimulationState {

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -12,10 +12,7 @@ use super::QualityUbSolver;
 fn solve(simulator_settings: Settings, actions: &[Action]) -> u32 {
     let mut state = SimulationState::from_macro(&simulator_settings, actions).unwrap();
     state.effects.set_combo(Combo::None);
-    let solver_settings = SolverSettings {
-        simulator_settings,
-        backload_progress: false,
-    };
+    let solver_settings = SolverSettings { simulator_settings };
     let mut solver = QualityUbSolver::new(solver_settings, Default::default());
     solver.quality_upper_bound(state).unwrap()
 }
@@ -35,6 +32,7 @@ fn test_01() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -68,6 +66,7 @@ fn test_adversarial_01() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -101,6 +100,7 @@ fn test_02() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -131,6 +131,7 @@ fn test_adversarial_02() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -161,6 +162,7 @@ fn test_03() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -196,6 +198,7 @@ fn test_adversarial_03() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -231,6 +234,7 @@ fn test_04() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 2075);
@@ -251,6 +255,7 @@ fn test_adversarial_04() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 1888);
@@ -271,6 +276,7 @@ fn test_05() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 2000);
@@ -291,6 +297,7 @@ fn test_adversarial_05() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 2000);
@@ -311,6 +318,7 @@ fn test_06() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 4438);
@@ -331,6 +339,7 @@ fn test_adversarial_06() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 3745);
@@ -351,6 +360,7 @@ fn test_07() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::Reflect]);
     assert_eq!(result, 4449);
@@ -371,6 +381,7 @@ fn test_08() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::PrudentTouch]);
     assert_eq!(result, 10000);
@@ -392,6 +403,7 @@ fn test_09() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[]);
     assert_eq!(result, 4079);
@@ -413,6 +425,7 @@ fn test_10() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[]);
     assert_eq!(result, 3929);
@@ -434,6 +447,7 @@ fn test_11() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[]);
     assert_eq!(result, 2481);
@@ -455,6 +469,7 @@ fn test_manipulation_refund() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::Manipulation]);
     assert_eq!(result, 4975);
@@ -477,11 +492,9 @@ fn test_issue_113() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let mut solver = QualityUbSolver::new(solver_settings, Default::default());
     solver.precompute(simulator_settings.max_cp);
     let expected_runtime_stats = expect![[r#"
@@ -508,11 +521,9 @@ fn test_issue_118() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let mut solver = QualityUbSolver::new(solver_settings, Default::default());
     solver.precompute(simulator_settings.max_cp);
     solver.precompute(simulator_settings.max_cp);
@@ -527,6 +538,7 @@ fn test_issue_118() {
 
 fn random_effects(adversarial: bool) -> Effects {
     Effects::new()
+        .with_allow_quality_actions(true)
         .with_inner_quiet(rand::thread_rng().gen_range(0..=10))
         .with_great_strides(rand::thread_rng().gen_range(0..=3))
         .with_innovation(rand::thread_rng().gen_range(0..=4))
@@ -553,10 +565,7 @@ fn random_state(settings: &Settings) -> SimulationState {
 /// Test that the upper-bound solver is monotonic,
 /// i.e. the quality UB of a state is never less than the quality UB of any of its children.
 fn monotonic_fuzz_check(simulator_settings: Settings) {
-    let solver_settings = SolverSettings {
-        simulator_settings,
-        backload_progress: false,
-    };
+    let solver_settings = SolverSettings { simulator_settings };
     let mut solver = QualityUbSolver::new(solver_settings, Default::default());
     solver.precompute(simulator_settings.max_cp);
     for _ in 0..100000 {
@@ -593,6 +602,7 @@ fn test_monotonic_normal_sim() {
         job_level: 100,
         allowed_actions: ActionMask::all(),
         adversarial: false,
+        backload_progress: false,
     };
     monotonic_fuzz_check(settings);
 }
@@ -610,6 +620,7 @@ fn test_monotonic_adversarial_sim() {
         job_level: 100,
         allowed_actions: ActionMask::all(),
         adversarial: true,
+        backload_progress: false,
     };
     monotonic_fuzz_check(settings);
 }

--- a/raphael-solver/src/step_lower_bound_solver/state.rs
+++ b/raphael-solver/src/step_lower_bound_solver/state.rs
@@ -100,9 +100,9 @@ impl ReducedState {
                 .with_innovation(0)
                 .with_great_strides(0)
                 .with_quick_innovation_available(false)
-                .with_guard(1)
+                .with_adversarial_guard(true)
         } else {
-            effects.with_guard(1)
+            effects.with_adversarial_guard(true)
         }
     }
 }

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -11,10 +11,7 @@ use super::*;
 fn solve(simulator_settings: Settings, actions: &[Action]) -> u8 {
     let mut state = SimulationState::from_macro(&simulator_settings, actions).unwrap();
     state.effects.set_combo(Combo::None);
-    let solver_settings = SolverSettings {
-        simulator_settings,
-        backload_progress: false,
-    };
+    let solver_settings = SolverSettings { simulator_settings };
     StepLbSolver::new(solver_settings, Default::default())
         .step_lower_bound(state, 0)
         .unwrap()
@@ -35,6 +32,7 @@ fn test_01() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -68,6 +66,7 @@ fn test_adversarial_01() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -101,6 +100,7 @@ fn test_02() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -131,6 +131,7 @@ fn test_adversarial_02() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -161,6 +162,7 @@ fn test_03() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -196,6 +198,7 @@ fn test_adversarial_03() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(
         settings,
@@ -231,6 +234,7 @@ fn test_04() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 19);
@@ -251,6 +255,7 @@ fn test_adversarial_04() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 14);
@@ -271,6 +276,7 @@ fn test_05() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 12);
@@ -291,6 +297,7 @@ fn test_adversarial_05() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 12);
@@ -311,6 +318,7 @@ fn test_06() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 16);
@@ -331,6 +339,7 @@ fn test_adversarial_06() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::MuscleMemory]);
     assert_eq!(result, 11);
@@ -351,6 +360,7 @@ fn test_07() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::Reflect]);
     assert_eq!(result, 15);
@@ -371,6 +381,7 @@ fn test_08() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[Action::PrudentTouch]);
     assert_eq!(result, 1);
@@ -392,6 +403,7 @@ fn test_09() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[]);
     assert_eq!(result, 17);
@@ -413,6 +425,7 @@ fn test_10() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[]);
     assert_eq!(result, 11);
@@ -434,6 +447,7 @@ fn test_11() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[]);
     assert_eq!(result, 11);
@@ -454,6 +468,7 @@ fn test_12() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
+        backload_progress: false,
     };
     let result = solve(settings, &[]);
     assert_eq!(result, 11);
@@ -461,6 +476,7 @@ fn test_12() {
 
 fn random_effects(adversarial: bool) -> Effects {
     Effects::new()
+        .with_allow_quality_actions(true)
         .with_inner_quiet(rand::thread_rng().gen_range(0..=10))
         .with_great_strides(rand::thread_rng().gen_range(0..=3))
         .with_innovation(rand::thread_rng().gen_range(0..=4))
@@ -487,10 +503,7 @@ fn random_state(settings: &Settings) -> SimulationState {
 /// Test that the upper-bound solver is monotonic,
 /// i.e. the quality UB of a state is never less than the quality UB of any of its children.
 fn monotonic_fuzz_check(simulator_settings: Settings) {
-    let solver_settings = SolverSettings {
-        simulator_settings,
-        backload_progress: false,
-    };
+    let solver_settings = SolverSettings { simulator_settings };
     let mut solver = StepLbSolver::new(solver_settings, Default::default());
     for _ in 0..10000 {
         let state = random_state(&simulator_settings);
@@ -528,6 +541,7 @@ fn test_monotonic_normal_sim() {
         job_level: 100,
         allowed_actions: ActionMask::all(),
         adversarial: false,
+        backload_progress: false,
     };
     monotonic_fuzz_check(settings);
 }
@@ -544,6 +558,7 @@ fn test_monotonic_adversarial_sim() {
         job_level: 100,
         allowed_actions: ActionMask::all(),
         adversarial: true,
+        backload_progress: false,
     };
     monotonic_fuzz_check(settings);
 }

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -474,9 +474,8 @@ fn test_12() {
     assert_eq!(result, 11);
 }
 
-fn random_effects(adversarial: bool) -> Effects {
+fn random_effects(settings: &Settings) -> Effects {
     Effects::new()
-        .with_allow_quality_actions(true)
         .with_inner_quiet(rand::thread_rng().gen_range(0..=10))
         .with_great_strides(rand::thread_rng().gen_range(0..=3))
         .with_innovation(rand::thread_rng().gen_range(0..=4))
@@ -484,7 +483,16 @@ fn random_effects(adversarial: bool) -> Effects {
         .with_waste_not(rand::thread_rng().gen_range(0..=8))
         .with_manipulation(rand::thread_rng().gen_range(0..=8))
         .with_quick_innovation_available(rand::random())
-        .with_adversarial_guard(if adversarial { rand::random() } else { false })
+        .with_adversarial_guard(if settings.adversarial {
+            rand::random()
+        } else {
+            false
+        })
+        .with_allow_quality_actions(if settings.backload_progress {
+            rand::random()
+        } else {
+            true
+        })
 }
 
 fn random_state(settings: &Settings) -> SimulationState {
@@ -494,7 +502,7 @@ fn random_state(settings: &Settings) -> SimulationState {
         progress: rand::thread_rng().gen_range(0..u32::from(settings.max_progress)),
         quality: 0,
         unreliable_quality: 0,
-        effects: random_effects(settings.adversarial),
+        effects: random_effects(settings),
     }
     .try_into()
     .unwrap()
@@ -542,6 +550,23 @@ fn test_monotonic_normal_sim() {
         allowed_actions: ActionMask::all(),
         adversarial: false,
         backload_progress: false,
+    };
+    monotonic_fuzz_check(settings);
+}
+
+#[test]
+fn test_monotonic_backload_progress_sim() {
+    let settings = Settings {
+        max_cp: 360,
+        max_durability: 70,
+        max_progress: 1000,
+        max_quality: 2600,
+        base_progress: 100,
+        base_quality: 100,
+        job_level: 100,
+        allowed_actions: ActionMask::all(),
+        adversarial: false,
+        backload_progress: true,
     };
     monotonic_fuzz_check(settings);
 }

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -468,11 +468,7 @@ fn random_effects(adversarial: bool) -> Effects {
         .with_waste_not(rand::thread_rng().gen_range(0..=8))
         .with_manipulation(rand::thread_rng().gen_range(0..=8))
         .with_quick_innovation_available(rand::random())
-        .with_guard(if adversarial {
-            rand::thread_rng().gen_range(0..=1)
-        } else {
-            0
-        })
+        .with_adversarial_guard(if adversarial { rand::random() } else { false })
 }
 
 fn random_state(settings: &Settings) -> SimulationState {

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -220,3 +220,47 @@ fn large_progress_quality_increase() {
     "#]];
     test_with_settings(solver_settings, expected_score, expected_runtime_stats);
 }
+
+#[test]
+fn backload_progress_single_delicate_synthesis() {
+    let simulator_settings = Settings {
+        max_cp: 100,
+        max_durability: 20,
+        max_progress: 100,
+        max_quality: 100,
+        base_progress: 100,
+        base_quality: 100,
+        job_level: 100,
+        allowed_actions: ActionMask::all()
+            .remove(Action::TrainedEye)
+            .remove(Action::HeartAndSoul)
+            .remove(Action::QuickInnovation),
+        adversarial: false,
+        backload_progress: true,
+    };
+    let solver_settings = SolverSettings { simulator_settings };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 100,
+                steps: 1,
+                duration: 3,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 15,
+            quality_ub_stats: QualityUbSolverStats {
+                states: 13641,
+                pareto_values: 11167,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 9,
+                pareto_values: 9,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
+}

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -41,7 +41,7 @@ fn test_with_settings(
         let final_state =
             SimulationState::from_macro(&settings.simulator_settings, &actions).unwrap();
         assert!(final_state.progress >= settings.max_progress());
-        if settings.backload_progress {
+        if settings.simulator_settings.backload_progress {
             assert!(is_progress_backloaded(&settings, &actions));
         }
         Some(SolutionScore {
@@ -70,11 +70,9 @@ fn unsolvable() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         None
     "#]];
@@ -109,11 +107,9 @@ fn zero_quality() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -155,11 +151,9 @@ fn max_quality() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -198,11 +192,9 @@ fn large_progress_quality_increase() {
         job_level: 100,
         allowed_actions: ActionMask::all(),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -78,7 +78,7 @@ fn unsolvable() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 4042,
+            finish_states: 2864,
             quality_ub_stats: QualityUbSolverStats {
                 states: 0,
                 pareto_values: 0,
@@ -122,7 +122,7 @@ fn zero_quality() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1867,
+            finish_states: 1660,
             quality_ub_stats: QualityUbSolverStats {
                 states: 52001,
                 pareto_values: 91291,
@@ -166,7 +166,7 @@ fn max_quality() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 239513,
+            finish_states: 236825,
             quality_ub_stats: QualityUbSolverStats {
                 states: 878613,
                 pareto_values: 6272058,
@@ -207,7 +207,7 @@ fn large_progress_quality_increase() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 65,
+            finish_states: 24,
             quality_ub_stats: QualityUbSolverStats {
                 states: 412810,
                 pareto_values: 407290,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -88,11 +88,11 @@ fn rinascita_3700_3280() {
             finish_states: 194540,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1983239,
-                pareto_values: 31442076,
+                pareto_values: 32414516,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 815631,
-                pareto_values: 6393486,
+                pareto_values: 10090940,
             },
         }
     "#]];
@@ -132,11 +132,11 @@ fn pactmaker_3240_3130() {
             finish_states: 259052,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1705998,
-                pareto_values: 23884627,
+                pareto_values: 24826260,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 782395,
-                pareto_values: 5573585,
+                pareto_values: 9193771,
             },
         }
     "#]];
@@ -174,12 +174,12 @@ fn pactmaker_3240_3130_heart_and_soul() {
         MacroSolverStats {
             finish_states: 213985,
             quality_ub_stats: QualityUbSolverStats {
-                states: 3443391,
-                pareto_values: 50223795,
+                states: 3443396,
+                pareto_values: 51945038,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1494941,
-                pareto_values: 11742609,
+                pareto_values: 18435656,
             },
         }
     "#]];
@@ -219,11 +219,11 @@ fn diadochos_4021_3660() {
             finish_states: 405309,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1843549,
-                pareto_values: 31682429,
+                pareto_values: 32873770,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 949178,
-                pareto_values: 8268405,
+                pareto_values: 13682643,
             },
         }
     "#]];
@@ -263,11 +263,11 @@ fn indagator_3858_4057() {
             finish_states: 339028,
             quality_ub_stats: QualityUbSolverStats {
                 states: 2008164,
-                pareto_values: 32425015,
+                pareto_values: 33517257,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 689966,
-                pareto_values: 5392645,
+                pareto_values: 8924833,
             },
         }
     "#]];
@@ -304,14 +304,14 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 997046,
+            finish_states: 1059087,
             quality_ub_stats: QualityUbSolverStats {
-                states: 1886216,
-                pareto_values: 34885845,
+                states: 1887414,
+                pareto_values: 36405757,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1312401,
-                pareto_values: 9884827,
+                states: 1299860,
+                pareto_values: 16334806,
             },
         }
     "#]];
@@ -350,14 +350,14 @@ fn stuffed_peppers_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 522246,
+            finish_states: 523249,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1885014,
-                pareto_values: 34998486,
+                pareto_values: 36229672,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 2166828,
-                pareto_values: 17907386,
+                states: 2095532,
+                pareto_values: 29062560,
             },
         }
     "#]];
@@ -398,11 +398,11 @@ fn stuffed_peppers_2_heart_and_soul() {
             finish_states: 540013,
             quality_ub_stats: QualityUbSolverStats {
                 states: 3823879,
-                pareto_values: 74276531,
+                pareto_values: 76383179,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 4146485,
-                pareto_values: 37088159,
+                states: 4102033,
+                pareto_values: 58818959,
             },
         }
     "#]];
@@ -440,14 +440,14 @@ fn stuffed_peppers_2_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 541240,
+            finish_states: 542405,
             quality_ub_stats: QualityUbSolverStats {
                 states: 3856930,
-                pareto_values: 72262381,
+                pareto_values: 74832825,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 4381407,
-                pareto_values: 36478178,
+                states: 4233011,
+                pareto_values: 59096571,
             },
         }
     "#]];
@@ -487,11 +487,11 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             finish_states: 614119,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1526659,
-                pareto_values: 21279680,
+                pareto_values: 22673054,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 511706,
-                pareto_values: 3577155,
+                states: 511703,
+                pareto_values: 5852073,
             },
         }
     "#]];
@@ -522,20 +522,20 @@ fn black_star_4048_3997() {
                 capped_quality: 5500,
                 steps: 12,
                 duration: 31,
-                overflow_quality: 614,
+                overflow_quality: 926,
             },
         )
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 106276,
+            finish_states: 141279,
             quality_ub_stats: QualityUbSolverStats {
-                states: 1359478,
-                pareto_values: 6561452,
+                states: 1362322,
+                pareto_values: 7045910,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 107222,
-                pareto_values: 494567,
+                states: 105081,
+                pareto_values: 699822,
             },
         }
     "#]];
@@ -572,14 +572,14 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 308592,
+            finish_states: 309050,
             quality_ub_stats: QualityUbSolverStats {
-                states: 1566592,
-                pareto_values: 9719522,
+                states: 1566609,
+                pareto_values: 10547981,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 252613,
-                pareto_values: 1072779,
+                states: 252537,
+                pareto_values: 1735508,
             },
         }
     "#]];
@@ -616,14 +616,14 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 331374,
+            finish_states: 386246,
             quality_ub_stats: QualityUbSolverStats {
-                states: 1699205,
-                pareto_values: 16791482,
+                states: 1699729,
+                pareto_values: 17982105,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 372870,
-                pareto_values: 2265396,
+                states: 407802,
+                pareto_values: 4038047,
             },
         }
     "#]];
@@ -662,12 +662,12 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
         MacroSolverStats {
             finish_states: 431469,
             quality_ub_stats: QualityUbSolverStats {
-                states: 1721504,
-                pareto_values: 14506897,
+                states: 1721505,
+                pareto_values: 15645407,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 328824,
-                pareto_values: 1852181,
+                pareto_values: 3108256,
             },
         }
     "#]];
@@ -704,14 +704,14 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1147908,
+            finish_states: 1152788,
             quality_ub_stats: QualityUbSolverStats {
-                states: 2129245,
-                pareto_values: 29712851,
+                states: 2129253,
+                pareto_values: 31409098,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 821908,
-                pareto_values: 5505040,
+                states: 822734,
+                pareto_values: 9165718,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -41,7 +41,7 @@ fn test_with_settings(
         let final_state =
             SimulationState::from_macro(&settings.simulator_settings, &actions).unwrap();
         assert!(final_state.progress >= settings.max_progress());
-        if settings.backload_progress {
+        if settings.simulator_settings.backload_progress {
             assert!(is_progress_backloaded(&settings, &actions));
         }
         Some(SolutionScore {
@@ -70,11 +70,9 @@ fn rinascita_3700_3280() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -87,14 +85,14 @@ fn rinascita_3700_3280() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 219659,
+            finish_states: 194540,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1983239,
-                pareto_values: 34025256,
+                pareto_values: 31442076,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 815631,
-                pareto_values: 10090940,
+                pareto_values: 6393486,
             },
         }
     "#]];
@@ -116,11 +114,9 @@ fn pactmaker_3240_3130() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -133,14 +129,14 @@ fn pactmaker_3240_3130() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 258317,
+            finish_states: 259052,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1705998,
-                pareto_values: 26328725,
+                pareto_values: 23884627,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 782395,
-                pareto_values: 9193771,
+                pareto_values: 5573585,
             },
         }
     "#]];
@@ -161,11 +157,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
             .remove(Action::TrainedEye)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -178,14 +172,14 @@ fn pactmaker_3240_3130_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 240392,
+            finish_states: 213985,
             quality_ub_stats: QualityUbSolverStats {
-                states: 3443396,
-                pareto_values: 54661715,
+                states: 3443391,
+                pareto_values: 50223795,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1494941,
-                pareto_values: 18435656,
+                pareto_values: 11742609,
             },
         }
     "#]];
@@ -207,11 +201,9 @@ fn diadochos_4021_3660() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -224,14 +216,14 @@ fn diadochos_4021_3660() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 414056,
+            finish_states: 405309,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1843549,
-                pareto_values: 34903710,
+                pareto_values: 31682429,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 949178,
-                pareto_values: 13682643,
+                pareto_values: 8268405,
             },
         }
     "#]];
@@ -253,11 +245,9 @@ fn indagator_3858_4057() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -270,14 +260,14 @@ fn indagator_3858_4057() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 339602,
+            finish_states: 339028,
             quality_ub_stats: QualityUbSolverStats {
                 states: 2008164,
-                pareto_values: 35350515,
+                pareto_values: 32425015,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 689966,
-                pareto_values: 8924833,
+                pareto_values: 5392645,
             },
         }
     "#]];
@@ -299,11 +289,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -316,14 +304,14 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1059731,
+            finish_states: 997046,
             quality_ub_stats: QualityUbSolverStats {
-                states: 1887414,
-                pareto_values: 37938812,
+                states: 1886216,
+                pareto_values: 34885845,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1299868,
-                pareto_values: 16334927,
+                states: 1312401,
+                pareto_values: 9884827,
             },
         }
     "#]];
@@ -347,11 +335,9 @@ fn stuffed_peppers_2() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -364,14 +350,14 @@ fn stuffed_peppers_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 518647,
+            finish_states: 522246,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1885014,
-                pareto_values: 37351087,
+                pareto_values: 34998486,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 2095532,
-                pareto_values: 29062560,
+                states: 2166828,
+                pareto_values: 17907386,
             },
         }
     "#]];
@@ -394,11 +380,9 @@ fn stuffed_peppers_2_heart_and_soul() {
             .remove(Action::TrainedEye)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -411,14 +395,14 @@ fn stuffed_peppers_2_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 561960,
+            finish_states: 540013,
             quality_ub_stats: QualityUbSolverStats {
                 states: 3823879,
-                pareto_values: 78455720,
+                pareto_values: 74276531,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 4102033,
-                pareto_values: 58818959,
+                states: 4146485,
+                pareto_values: 37088159,
             },
         }
     "#]];
@@ -441,11 +425,9 @@ fn stuffed_peppers_2_quick_innovation() {
             .remove(Action::TrainedEye)
             .remove(Action::HeartAndSoul),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -458,14 +440,14 @@ fn stuffed_peppers_2_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 536120,
+            finish_states: 541240,
             quality_ub_stats: QualityUbSolverStats {
                 states: 3856930,
-                pareto_values: 76751405,
+                pareto_values: 72262381,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 4233011,
-                pareto_values: 59096571,
+                states: 4381407,
+                pareto_values: 36478178,
             },
         }
     "#]];
@@ -487,11 +469,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -504,14 +484,14 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 706065,
+            finish_states: 614119,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1526659,
-                pareto_values: 24305982,
+                pareto_values: 21279680,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 511703,
-                pareto_values: 5852073,
+                states: 511706,
+                pareto_values: 3577155,
             },
         }
     "#]];
@@ -533,31 +513,29 @@ fn black_star_4048_3997() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
                 capped_quality: 5500,
                 steps: 12,
                 duration: 31,
-                overflow_quality: 926,
+                overflow_quality: 614,
             },
         )
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 110050,
+            finish_states: 106276,
             quality_ub_stats: QualityUbSolverStats {
-                states: 1362242,
-                pareto_values: 7639594,
+                states: 1359478,
+                pareto_values: 6561452,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 105081,
-                pareto_values: 699822,
+                states: 107222,
+                pareto_values: 494567,
             },
         }
     "#]];
@@ -579,11 +557,9 @@ fn claro_walnut_lumber_4900_4800() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -596,14 +572,14 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 239933,
+            finish_states: 308592,
             quality_ub_stats: QualityUbSolverStats {
-                states: 1566609,
-                pareto_values: 11127341,
+                states: 1566592,
+                pareto_values: 9719522,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 252537,
-                pareto_values: 1735508,
+                states: 252613,
+                pareto_values: 1072779,
             },
         }
     "#]];
@@ -625,11 +601,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -642,14 +616,14 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 485307,
+            finish_states: 331374,
             quality_ub_stats: QualityUbSolverStats {
-                states: 1699729,
-                pareto_values: 19361954,
+                states: 1699205,
+                pareto_values: 16791482,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 407802,
-                pareto_values: 4038047,
+                states: 372870,
+                pareto_values: 2265396,
             },
         }
     "#]];
@@ -671,11 +645,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -688,14 +660,14 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 516281,
+            finish_states: 431469,
             quality_ub_stats: QualityUbSolverStats {
-                states: 1720916,
-                pareto_values: 17016049,
+                states: 1721504,
+                pareto_values: 14506897,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 328824,
-                pareto_values: 3108256,
+                pareto_values: 1852181,
             },
         }
     "#]];
@@ -717,11 +689,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: true,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -734,14 +704,14 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1205580,
+            finish_states: 1147908,
             quality_ub_stats: QualityUbSolverStats {
-                states: 2129253,
-                pareto_values: 33448907,
+                states: 2129245,
+                pareto_values: 29712851,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 822734,
-                pareto_values: 9165718,
+                states: 821908,
+                pareto_values: 5505040,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -41,7 +41,7 @@ fn test_with_settings(
         let final_state =
             SimulationState::from_macro(&settings.simulator_settings, &actions).unwrap();
         assert!(final_state.progress >= settings.max_progress());
-        if settings.backload_progress {
+        if settings.simulator_settings.backload_progress {
             assert!(is_progress_backloaded(&settings, &actions));
         }
         Some(SolutionScore {
@@ -70,11 +70,9 @@ fn rinascita_3700_3280() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -87,7 +85,7 @@ fn rinascita_3700_3280() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 286068,
+            finish_states: 285758,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1982938,
                 pareto_values: 45486067,
@@ -116,11 +114,9 @@ fn pactmaker_3240_3130() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -133,7 +129,7 @@ fn pactmaker_3240_3130() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 285099,
+            finish_states: 291621,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1707402,
                 pareto_values: 34644852,
@@ -161,11 +157,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
             .remove(Action::TrainedEye)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -178,7 +172,7 @@ fn pactmaker_3240_3130_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 240392,
+            finish_states: 213985,
             quality_ub_stats: QualityUbSolverStats {
                 states: 3455899,
                 pareto_values: 73184655,
@@ -207,11 +201,9 @@ fn diadochos_4021_3660() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -224,7 +216,7 @@ fn diadochos_4021_3660() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 470600,
+            finish_states: 463963,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1847123,
                 pareto_values: 46078953,
@@ -253,11 +245,9 @@ fn indagator_3858_4057() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -270,7 +260,7 @@ fn indagator_3858_4057() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 359128,
+            finish_states: 365439,
             quality_ub_stats: QualityUbSolverStats {
                 states: 2008872,
                 pareto_values: 46441910,
@@ -299,11 +289,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -316,7 +304,7 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 2080695,
+            finish_states: 2235346,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1901560,
                 pareto_values: 48784449,
@@ -347,11 +335,9 @@ fn stuffed_peppers_2() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -364,7 +350,7 @@ fn stuffed_peppers_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 764711,
+            finish_states: 832985,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1902638,
                 pareto_values: 48583224,
@@ -394,11 +380,9 @@ fn stuffed_peppers_2_heart_and_soul() {
             .remove(Action::TrainedEye)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -411,7 +395,7 @@ fn stuffed_peppers_2_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 789565,
+            finish_states: 745899,
             quality_ub_stats: QualityUbSolverStats {
                 states: 3867407,
                 pareto_values: 101951274,
@@ -441,11 +425,9 @@ fn stuffed_peppers_2_quick_innovation() {
             .remove(Action::TrainedEye)
             .remove(Action::HeartAndSoul),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -458,7 +440,7 @@ fn stuffed_peppers_2_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 792774,
+            finish_states: 868507,
             quality_ub_stats: QualityUbSolverStats {
                 states: 3944524,
                 pareto_values: 100829366,
@@ -487,11 +469,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -504,7 +484,7 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1213044,
+            finish_states: 1210870,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1520329,
                 pareto_values: 27010078,
@@ -533,11 +513,9 @@ fn black_star_4048_3997() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -550,7 +528,7 @@ fn black_star_4048_3997() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 42765,
+            finish_states: 45131,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1337547,
                 pareto_values: 7808651,
@@ -579,11 +557,9 @@ fn claro_walnut_lumber_4900_4800() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -596,7 +572,7 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 79185,
+            finish_states: 106547,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1522551,
                 pareto_values: 12435109,
@@ -625,11 +601,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -642,7 +616,7 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 365164,
+            finish_states: 285461,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1684933,
                 pareto_values: 20239095,
@@ -671,11 +645,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -688,7 +660,7 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 714672,
+            finish_states: 671767,
             quality_ub_stats: QualityUbSolverStats {
                 states: 1711194,
                 pareto_values: 17518103,
@@ -717,11 +689,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: false,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -734,7 +704,7 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 970963,
+            finish_states: 863245,
             quality_ub_stats: QualityUbSolverStats {
                 states: 2099391,
                 pareto_values: 37985636,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -101,8 +101,8 @@ fn stuffed_peppers() {
         MacroSolverStats {
             finish_states: 811236,
             quality_ub_stats: QualityUbSolverStats {
-                states: 4715101,
-                pareto_values: 77795158,
+                states: 4711180,
+                pareto_values: 77733317,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 830886,
@@ -149,8 +149,8 @@ fn test_rare_tacos_2() {
         MacroSolverStats {
             finish_states: 1270583,
             quality_ub_stats: QualityUbSolverStats {
-                states: 5033261,
-                pareto_values: 135360389,
+                states: 5029860,
+                pareto_values: 135247581,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1388863,
@@ -198,8 +198,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
         MacroSolverStats {
             finish_states: 69040,
             quality_ub_stats: QualityUbSolverStats {
-                states: 3772420,
-                pareto_values: 33045924,
+                states: 3768152,
+                pareto_values: 33008292,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 58379,
@@ -244,8 +244,8 @@ fn test_indagator_3858_4057() {
         MacroSolverStats {
             finish_states: 423088,
             quality_ub_stats: QualityUbSolverStats {
-                states: 5301382,
-                pareto_values: 125209173,
+                states: 5297705,
+                pareto_values: 125105998,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 675136,
@@ -291,8 +291,8 @@ fn test_rare_tacos_4628_4410() {
         MacroSolverStats {
             finish_states: 457250,
             quality_ub_stats: QualityUbSolverStats {
-                states: 5301245,
-                pareto_values: 151087149,
+                states: 5297728,
+                pareto_values: 150961583,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 319245,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -41,7 +41,7 @@ fn test_with_settings(
         let final_state =
             SimulationState::from_macro(&settings.simulator_settings, &actions).unwrap();
         assert!(final_state.progress >= settings.max_progress());
-        if settings.backload_progress {
+        if settings.simulator_settings.backload_progress {
             assert!(is_progress_backloaded(&settings, &actions));
         }
         Some(SolutionScore {
@@ -68,6 +68,7 @@ const SETTINGS: Settings = Settings {
         .remove(Action::HeartAndSoul)
         .remove(Action::QuickInnovation),
     adversarial: true,
+    backload_progress: false,
 };
 
 #[test]
@@ -83,10 +84,7 @@ fn stuffed_peppers() {
         base_quality: 360,
         ..SETTINGS
     };
-    let solver_settings = SolverSettings {
-        simulator_settings,
-        backload_progress: false,
-    };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -99,14 +97,14 @@ fn stuffed_peppers() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 811236,
+            finish_states: 878840,
             quality_ub_stats: QualityUbSolverStats {
-                states: 4711180,
-                pareto_values: 77733317,
+                states: 4711174,
+                pareto_values: 77733312,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 830886,
-                pareto_values: 14689426,
+                states: 830988,
+                pareto_values: 14691059,
             },
         }
     "#]];
@@ -130,11 +128,9 @@ fn test_rare_tacos_2() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -147,14 +143,14 @@ fn test_rare_tacos_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1270583,
+            finish_states: 1374764,
             quality_ub_stats: QualityUbSolverStats {
                 states: 5029860,
-                pareto_values: 135247581,
+                pareto_values: 135247584,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1388863,
-                pareto_values: 31624049,
+                states: 1388877,
+                pareto_values: 31624257,
             },
         }
     "#]];
@@ -179,11 +175,9 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -196,7 +190,7 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 69040,
+            finish_states: 75525,
             quality_ub_stats: QualityUbSolverStats {
                 states: 3768152,
                 pareto_values: 33008292,
@@ -225,11 +219,9 @@ fn test_indagator_3858_4057() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -242,7 +234,7 @@ fn test_indagator_3858_4057() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 423088,
+            finish_states: 449529,
             quality_ub_stats: QualityUbSolverStats {
                 states: 5297705,
                 pareto_values: 125105998,
@@ -272,11 +264,9 @@ fn test_rare_tacos_4628_4410() {
             .remove(Action::HeartAndSoul)
             .remove(Action::QuickInnovation),
         adversarial: true,
-    };
-    let solver_settings = SolverSettings {
-        simulator_settings,
         backload_progress: false,
     };
+    let solver_settings = SolverSettings { simulator_settings };
     let expected_score = expect![[r#"
         Some(
             SolutionScore {
@@ -289,14 +279,14 @@ fn test_rare_tacos_4628_4410() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 457250,
+            finish_states: 501199,
             quality_ub_stats: QualityUbSolverStats {
                 states: 5297728,
                 pareto_values: 150961583,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 319245,
-                pareto_values: 6969450,
+                states: 319267,
+                pareto_values: 6969733,
             },
         }
     "#]];

--- a/src/widgets/recipe_select.rs
+++ b/src/widgets/recipe_select.rs
@@ -132,7 +132,6 @@ impl<'a> RecipeSelect<'a> {
             *self.crafter_config.active_stats(),
             self.selected_food,
             self.selected_potion,
-            false,
         );
         let use_base_increase_overrides = self
             .custom_recipe_overrides_config
@@ -309,7 +308,6 @@ impl Widget for RecipeSelect<'_> {
                                     *self.crafter_config.active_stats(),
                                     self.selected_food,
                                     self.selected_potion,
-                                    false,
                                 );
 
                                 self.recipe_config.recipe.req_craftsmanship = 0;


### PR DESCRIPTION
The logic for `backload_progress` is currently duplicated across many inner solvers. Moving it to the simulator ensures that there is a single source of truth for this logic.

The `backload_progress` option has been moved from `raphael_solver::SolverSettings` to `raphael_sim::Settings`.

Introduces a new `allow_quality_actions` effect that is initially `true` and is only reset by the simulator if `backload_progress` is set.