### PR TITLE
Switch renderer to `wgpu` for native

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,16 @@ raphael-data = { workspace = true, features = ["serde"] }
 # This revision includes the fix for tab-navigating over disabled widgets.
 # Switch back to version number once new egui version is released.
 egui = { git = "https://github.com/emilk/egui.git", rev = "6a8ee29" }
-eframe = { git = "https://github.com/emilk/egui.git", rev = "6a8ee29", features = [
+# Default features of `eframe` include the "glow" renderer which is not needed if "wgpu" is enabled.
+# To avoid including both in the binary, default features have to be disabled
+eframe = { git = "https://github.com/emilk/egui.git", rev = "6a8ee29", default-features = false, features = [
+    "accesskit", # default
+    "default_fonts", # default
+    "wayland", # default
+    "web_screen_reader", # default
+    "x11", # default
     "persistence",
+    "wgpu",
 ] }
 egui_extras = { git = "https://github.com/emilk/egui.git", rev = "6a8ee29", features = [
     "http",
@@ -72,6 +80,7 @@ wasm-bindgen-rayon = { version = "1.2", features = ["no-bundler"] }
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1.7"
 web-sys = "0.3"
+wgpu = { version = "*", features = ["webgpu", "webgl"] }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,19 +46,8 @@ raphael-solver = { workspace = true, features = ["serde"] }
 raphael-data = { workspace = true, features = ["serde"] }
 
 # This revision includes the fix for tab-navigating over disabled widgets.
-# Switch back to version number once new egui version is released.
+# Switch back to version number once new egui version is released. Same for `eframe` further down
 egui = { git = "https://github.com/emilk/egui.git", rev = "6a8ee29" }
-# Default features of `eframe` include the "glow" renderer which is not needed if "wgpu" is enabled.
-# To avoid including both in the binary, default features have to be disabled
-eframe = { git = "https://github.com/emilk/egui.git", rev = "6a8ee29", default-features = false, features = [
-    "accesskit", # default
-    "default_fonts", # default
-    "wayland", # default
-    "web_screen_reader", # default
-    "x11", # default
-    "persistence",
-    "wgpu",
-] }
 egui_extras = { git = "https://github.com/emilk/egui.git", rev = "6a8ee29", features = [
     "http",
     "webp",
@@ -74,13 +63,26 @@ semver = "1.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.11.5"
 ehttp = { version = "0.5.0", features = ["json"] }
+# Default features of `eframe` include the "glow" renderer which is not needed if "wgpu" is enabled.
+# To avoid including both in the binary, default features have to be disabled
+eframe = { git = "https://github.com/emilk/egui.git", rev = "6a8ee29", default-features = false, features = [
+    "accesskit", # default
+    "default_fonts", # default
+    "wayland", # default
+    "web_screen_reader", # default
+    "x11", # default
+    "persistence",
+    "wgpu",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-rayon = { version = "1.2", features = ["no-bundler"] }
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1.7"
 web-sys = "0.3"
-wgpu = { version = "*", features = ["webgpu", "webgl"] }
+eframe = { git = "https://github.com/emilk/egui.git", rev = "6a8ee29", features = [
+    "persistence",
+]}
 
 [profile.release]
 opt-level = 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,10 @@ fn main() -> eframe::Result<()> {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([400.0, 300.0])
             .with_min_inner_size([300.0, 220.0]),
+        wgpu_options: eframe::egui_wgpu::WgpuConfiguration {
+            present_mode: eframe::wgpu::PresentMode::AutoNoVsync,
+            ..Default::default()
+        },
         ..Default::default()
     };
     eframe::run_native(


### PR DESCRIPTION
Switches the renderer `eframe` uses from the default, `glow`, to `wgpu`. This circumvents an issue reported on the Discord server, where on specific setups the initialization of `glow`s OpenGL backend seems to hang indefinitely.
As an added bonus, `wgpu` supports different backends, e.g. Vulkan, WebGPU, and Metal, that should offer greater performance and future compatibility. OpenGL/WebGL are still supported. The native version seems to default to Vulkan on Linux & Windows and Metal on MacOS. (The environment variable `WGPU_BACKEND` can be used to override the backend.)

**Caveats:**
- Allowing both WebGL and WebGPU for the web version seems to increase the size of the resulting binary quite a bit. The uncompressed wasm file goes from ~8MB to ~11MB. So the change should maybe be made native specific
- The native version's log is "spammed" by `wgpu` components at startup when `RUST_LOG` is set to `debug`

**TODO:**
- [x] Test different setups to make sure there is no (obvious) regression. Linux was basically not yet tested
- [x] Look into excessive VRR flicker on my desktop setup (probably caused by the default `PresentMode`)