### PR TITLE
Optimize low quality recipes

### DIFF
--- a/raphael-sim/src/effects.rs
+++ b/raphael-sim/src/effects.rs
@@ -34,9 +34,7 @@ pub struct Effects {
 impl Effects {
     /// Effects at synthesis begin
     pub fn initial(settings: &Settings) -> Self {
-        Self::new()
-            .with_adversarial_guard(settings.adversarial)
-            .with_allow_quality_actions(true)
+        let effects = Self::new()
             .with_trained_perfection_available(
                 settings.is_action_allowed::<crate::actions::TrainedPerfection>(),
             )
@@ -46,7 +44,14 @@ impl Effects {
             .with_quick_innovation_available(
                 settings.is_action_allowed::<crate::actions::QuickInnovation>(),
             )
-            .with_combo(Combo::SynthesisBegin)
+            .with_combo(Combo::SynthesisBegin);
+        if settings.max_quality == 0 {
+            effects
+        } else {
+            effects
+                .with_adversarial_guard(settings.adversarial)
+                .with_allow_quality_actions(true)
+        }
     }
 
     pub fn tick_down(&mut self) {

--- a/raphael-sim/src/effects.rs
+++ b/raphael-sim/src/effects.rs
@@ -34,7 +34,9 @@ pub struct Effects {
 impl Effects {
     /// Effects at synthesis begin
     pub fn initial(settings: &Settings) -> Self {
-        let effects = Self::new()
+        Self::new()
+            .with_adversarial_guard(settings.adversarial)
+            .with_allow_quality_actions(true)
             .with_trained_perfection_available(
                 settings.is_action_allowed::<crate::actions::TrainedPerfection>(),
             )
@@ -44,14 +46,7 @@ impl Effects {
             .with_quick_innovation_available(
                 settings.is_action_allowed::<crate::actions::QuickInnovation>(),
             )
-            .with_combo(Combo::SynthesisBegin);
-        if settings.max_quality == 0 {
-            effects
-        } else {
-            effects
-                .with_adversarial_guard(settings.adversarial)
-                .with_allow_quality_actions(true)
-        }
+            .with_combo(Combo::SynthesisBegin)
     }
 
     pub fn tick_down(&mut self) {

--- a/raphael-sim/src/state.rs
+++ b/raphael-sim/src/state.rs
@@ -133,9 +133,7 @@ impl SimulationState {
             state.effects.set_muscle_memory(0);
         }
 
-        if (progress_increase != 0 && settings.backload_progress)
-            || state.quality >= u32::from(settings.max_quality)
-        {
+        if progress_increase != 0 && settings.backload_progress {
             state.effects.set_allow_quality_actions(false);
         }
 
@@ -161,17 +159,22 @@ impl SimulationState {
             .set_combo(A::combo(&state, settings, condition));
 
         if !state.effects.allow_quality_actions() {
-            state.unreliable_quality = 0;
-            state.effects = state
-                .effects
-                .with_inner_quiet(0)
-                .with_innovation(0)
-                .with_great_strides(0)
-                .with_quick_innovation_available(false)
-                .with_adversarial_guard(false)
+            state.strip_quality_effects();
         }
 
         Ok(state)
+    }
+
+    pub fn strip_quality_effects(&mut self) {
+        self.unreliable_quality = 0;
+        self.effects = self
+            .effects
+            .with_inner_quiet(0)
+            .with_innovation(0)
+            .with_great_strides(0)
+            .with_quick_innovation_available(false)
+            .with_adversarial_guard(false)
+            .with_allow_quality_actions(false)
     }
 
     pub fn use_action(

--- a/raphael-sim/src/state.rs
+++ b/raphael-sim/src/state.rs
@@ -129,11 +129,14 @@ impl SimulationState {
 
         let progress_increase = A::progress_increase(self, settings, condition);
         state.progress += progress_increase;
-        if progress_increase != 0 {
-            state.effects = state
-                .effects
-                .with_muscle_memory(0)
-                .with_allow_quality_actions(!settings.backload_progress);
+        if progress_increase != 0 && state.effects.muscle_memory() != 0 {
+            state.effects.set_muscle_memory(0);
+        }
+
+        if (progress_increase != 0 && settings.backload_progress)
+            || state.quality >= u32::from(settings.max_quality)
+        {
+            state.effects.set_allow_quality_actions(false);
         }
 
         if state.is_final(settings) {

--- a/raphael-solver/src/actions.rs
+++ b/raphael-solver/src/actions.rs
@@ -167,6 +167,9 @@ pub fn use_action_combo(
 ) -> Result<SimulationState, &'static str> {
     for action in action_combo.actions() {
         state = state.use_action(*action, Condition::Normal, &settings.simulator_settings)?;
+        if state.effects.allow_quality_actions() && state.quality >= settings.max_quality() {
+            state.strip_quality_effects();
+        }
     }
     state.effects.set_combo(Combo::None);
     Ok(state)

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -78,7 +78,11 @@ impl<'a> MacroSolver<'a> {
         );
 
         let _total_time = ScopedTimer::new("Total Time");
-        let initial_state = SimulationState::new(&self.settings.simulator_settings);
+
+        let mut initial_state = SimulationState::new(&self.settings.simulator_settings);
+        if initial_state.quality >= self.settings.max_quality() {
+            initial_state.strip_quality_effects();
+        }
 
         let timer = ScopedTimer::new("Finish Solver");
         if !self.finish_solver.can_finish(&initial_state) {
@@ -93,7 +97,7 @@ impl<'a> MacroSolver<'a> {
             },
             || {
                 let _timer = ScopedTimer::new("Step LB Solver");
-                let mut seed_state = SimulationState::new(&self.settings.simulator_settings);
+                let mut seed_state = initial_state;
                 seed_state.effects.set_combo(Combo::None);
                 self.step_lb_solver.step_lower_bound(seed_state, 0)
             },

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -46,9 +46,15 @@ impl QualityUbSolver {
         let mut templates = rustc_hash::FxHashMap::<Template, u16>::default();
         let mut queue = std::collections::BinaryHeap::<Node>::default();
 
+        let mut initial_state = SimulationState::new(&self.settings.simulator_settings);
+        if initial_state.quality >= self.settings.max_quality() {
+            initial_state.strip_quality_effects();
+        }
+
         let initial_node = Node {
             template: Template {
-                effects: Effects::initial(&self.settings.simulator_settings)
+                effects: initial_state
+                    .effects
                     .with_trained_perfection_available(false)
                     .with_quick_innovation_available(false)
                     .with_heart_and_soul_available(false)

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -136,8 +136,8 @@ fn zero_quality() {
                 pareto_values: 91291,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 25627,
-                pareto_values: 230025,
+                states: 25649,
+                pareto_values: 230047,
             },
         }
     "#]];
@@ -174,18 +174,18 @@ fn max_quality() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 236825,
+            finish_states: 225965,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 4890,
-                dropped_nodes: 56054,
+                processed_nodes: 4310,
+                dropped_nodes: 49847,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 878613,
-                pareto_values: 6272058,
+                states: 886827,
+                pareto_values: 6280212,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 107515,
-                pareto_values: 963403,
+                states: 107635,
+                pareto_values: 957332,
             },
         }
     "#]];
@@ -219,18 +219,18 @@ fn large_progress_quality_increase() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 24,
+            finish_states: 21,
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 0,
-                dropped_nodes: 23,
+                dropped_nodes: 20,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 412810,
-                pareto_values: 407290,
+                states: 108276,
+                pareto_values: 107604,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 13,
-                pareto_values: 13,
+                states: 10,
+                pareto_values: 10,
             },
         }
     "#]];
@@ -273,12 +273,12 @@ fn backload_progress_single_delicate_synthesis() {
                 dropped_nodes: 14,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 13641,
-                pareto_values: 11167,
+                states: 7918,
+                pareto_values: 7036,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 9,
-                pareto_values: 9,
+                states: 8,
+                pareto_values: 8,
             },
         }
     "#]];

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -225,8 +225,8 @@ fn large_progress_quality_increase() {
                 dropped_nodes: 20,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 108276,
-                pareto_values: 107604,
+                states: 76819,
+                pareto_values: 76399,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 10,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -779,7 +779,7 @@ fn archeo_kingdom_broadsword_4966_4914() {
 }
 
 #[test]
-fn test_hardened_survey_plank_5558_5216() {
+fn hardened_survey_plank_5558_5216() {
     let simulator_settings = Settings {
         max_cp: 753,
         max_durability: 20,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -324,18 +324,18 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1059087,
+            finish_states: 1058580,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 43656,
-                dropped_nodes: 170466,
+                processed_nodes: 43613,
+                dropped_nodes: 170325,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 1887414,
                 pareto_values: 36405757,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1299860,
-                pareto_values: 16334806,
+                states: 1299515,
+                pareto_values: 16330476,
             },
         }
     "#]];
@@ -520,18 +520,18 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 614119,
+            finish_states: 611357,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 272,
-                dropped_nodes: 2819,
+                processed_nodes: 264,
+                dropped_nodes: 2709,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 1526659,
                 pareto_values: 22673054,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 511703,
-                pareto_values: 5852073,
+                states: 509551,
+                pareto_values: 5828451,
             },
         }
     "#]];
@@ -562,24 +562,24 @@ fn black_star_4048_3997() {
                 capped_quality: 5500,
                 steps: 12,
                 duration: 31,
-                overflow_quality: 926,
+                overflow_quality: 707,
             },
         )
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 141279,
+            finish_states: 142034,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 9943,
-                dropped_nodes: 121522,
+                processed_nodes: 9786,
+                dropped_nodes: 111208,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1362322,
-                pareto_values: 7045910,
+                states: 1362371,
+                pareto_values: 7046032,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 105081,
-                pareto_values: 699822,
+                states: 104859,
+                pareto_values: 698545,
             },
         }
     "#]];
@@ -616,18 +616,18 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 309050,
+            finish_states: 304569,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 27329,
-                dropped_nodes: 423050,
+                processed_nodes: 26929,
+                dropped_nodes: 408090,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 1566609,
                 pareto_values: 10547981,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 252537,
-                pareto_values: 1735508,
+                states: 252200,
+                pareto_values: 1733705,
             },
         }
     "#]];
@@ -664,18 +664,18 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 386246,
+            finish_states: 392193,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 332,
-                dropped_nodes: 4638,
+                processed_nodes: 343,
+                dropped_nodes: 4446,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 1699729,
                 pareto_values: 17982105,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 407802,
-                pareto_values: 4038047,
+                states: 407200,
+                pareto_values: 4030925,
             },
         }
     "#]];
@@ -712,18 +712,18 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 431469,
+            finish_states: 425362,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1061,
-                dropped_nodes: 16009,
+                processed_nodes: 1028,
+                dropped_nodes: 13686,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 1721505,
                 pareto_values: 15645407,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 328824,
-                pareto_values: 3108256,
+                states: 325880,
+                pareto_values: 3077886,
             },
         }
     "#]];
@@ -760,18 +760,18 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1152788,
+            finish_states: 1134858,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 16232,
-                dropped_nodes: 245587,
+                processed_nodes: 15989,
+                dropped_nodes: 236124,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 2129253,
                 pareto_values: 31409098,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 822734,
-                pareto_values: 9165718,
+                states: 819210,
+                pareto_values: 9120335,
             },
         }
     "#]];
@@ -808,18 +808,18 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 594019,
+            finish_states: 593852,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 167590,
-                dropped_nodes: 432496,
+                processed_nodes: 167452,
+                dropped_nodes: 432060,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 2280397,
                 pareto_values: 23971582,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 295232,
-                pareto_values: 2741420,
+                states: 295245,
+                pareto_values: 2741338,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -326,16 +326,16 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
         MacroSolverStats {
             finish_states: 2235346,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1222687,
-                dropped_nodes: 7658862,
+                processed_nodes: 1222641,
+                dropped_nodes: 7658550,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 1901560,
                 pareto_values: 48784449,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1620921,
-                pareto_values: 35840138,
+                states: 1622394,
+                pareto_values: 35839860,
             },
         }
     "#]];
@@ -520,18 +520,18 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1210870,
+            finish_states: 1210688,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 19075,
-                dropped_nodes: 278726,
+                processed_nodes: 18982,
+                dropped_nodes: 277204,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1520329,
-                pareto_values: 27010078,
+                states: 1525676,
+                pareto_values: 27015425,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 747281,
-                pareto_values: 13767633,
+                states: 749510,
+                pareto_values: 13760404,
             },
         }
     "#]];
@@ -568,18 +568,18 @@ fn black_star_4048_3997() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 45131,
+            finish_states: 44568,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1455,
-                dropped_nodes: 21846,
+                processed_nodes: 1443,
+                dropped_nodes: 21507,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1337547,
-                pareto_values: 7808651,
+                states: 1344217,
+                pareto_values: 7815321,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 84390,
-                pareto_values: 850694,
+                states: 84652,
+                pareto_values: 850801,
             },
         }
     "#]];
@@ -616,18 +616,18 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 106547,
+            finish_states: 106424,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 7125,
-                dropped_nodes: 139730,
+                processed_nodes: 7115,
+                dropped_nodes: 139169,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 1522551,
                 pareto_values: 12435109,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 225680,
-                pareto_values: 2235033,
+                states: 225872,
+                pareto_values: 2235160,
             },
         }
     "#]];
@@ -664,18 +664,18 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 285461,
+            finish_states: 285458,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 72,
-                dropped_nodes: 1441,
+                processed_nodes: 71,
+                dropped_nodes: 1434,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1684933,
-                pareto_values: 20239095,
+                states: 1694421,
+                pareto_values: 20248583,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 331083,
-                pareto_values: 5695325,
+                states: 331102,
+                pareto_values: 5695344,
             },
         }
     "#]];
@@ -712,18 +712,18 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 671767,
+            finish_states: 664547,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 6264,
-                dropped_nodes: 126129,
+                processed_nodes: 6149,
+                dropped_nodes: 117817,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 1711194,
                 pareto_values: 17518103,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 432596,
-                pareto_values: 6611324,
+                states: 433569,
+                pareto_values: 6585102,
             },
         }
     "#]];
@@ -760,18 +760,18 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 863245,
+            finish_states: 862184,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 7131,
-                dropped_nodes: 141686,
+                processed_nodes: 7124,
+                dropped_nodes: 141310,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 2099391,
-                pareto_values: 37985636,
+                states: 2107358,
+                pareto_values: 37993603,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 793368,
-                pareto_values: 15975235,
+                states: 794894,
+                pareto_values: 15973671,
             },
         }
     "#]];
@@ -808,18 +808,18 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 864643,
+            finish_states: 864640,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1855695,
-                dropped_nodes: 12311365,
+                processed_nodes: 1855660,
+                dropped_nodes: 12311239,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 2041117,
                 pareto_values: 34763925,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 342999,
-                pareto_values: 5334773,
+                states: 343345,
+                pareto_values: 5335105,
             },
         }
     "#]];
@@ -856,18 +856,18 @@ fn ceviche_4900_4800_no_quality() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 2814571,
+            finish_states: 1577600,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3070799,
-                dropped_nodes: 41522104,
+                processed_nodes: 106671,
+                dropped_nodes: 445477,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1659552,
-                pareto_values: 1655856,
+                states: 24753,
+                pareto_values: 24713,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1193,
-                pareto_values: 1193,
+                states: 52,
+                pareto_values: 52,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -779,7 +779,7 @@ fn archeo_kingdom_broadsword_4966_4914() {
 }
 
 #[test]
-fn test_hardened_survey_plank_5558_5216() {
+fn hardened_survey_plank_5558_5216() {
     let simulator_settings = Settings {
         max_cp: 753,
         max_durability: 20,
@@ -820,6 +820,54 @@ fn test_hardened_survey_plank_5558_5216() {
             step_lb_stats: StepLbSolverStats {
                 states: 342999,
                 pareto_values: 5334773,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
+}
+
+#[test]
+fn ceviche_4900_4800_no_quality() {
+    let simulator_settings = Settings {
+        max_cp: 620,
+        max_durability: 70,
+        max_progress: 8050,
+        max_quality: 0, // 0% quality target
+        base_progress: 261,
+        base_quality: 266,
+        job_level: 100,
+        allowed_actions: ActionMask::all()
+            .remove(Action::TrainedEye)
+            .remove(Action::HeartAndSoul)
+            .remove(Action::QuickInnovation),
+        adversarial: false,
+        backload_progress: false,
+    };
+    let solver_settings = SolverSettings { simulator_settings };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 0,
+                steps: 8,
+                duration: 22,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 2814571,
+            search_queue_stats: SearchQueueStats {
+                processed_nodes: 3070799,
+                dropped_nodes: 41522104,
+            },
+            quality_ub_stats: QualityUbSolverStats {
+                states: 1659552,
+                pareto_values: 1655856,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states: 1193,
+                pareto_values: 1193,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -97,18 +97,18 @@ fn stuffed_peppers() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 878840,
+            finish_states: 878625,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 85020,
-                dropped_nodes: 1601394,
+                processed_nodes: 85013,
+                dropped_nodes: 1600850,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 4711174,
-                pareto_values: 77733312,
+                states: 4715168,
+                pareto_values: 77737306,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 830988,
-                pareto_values: 14691059,
+                states: 831904,
+                pareto_values: 14690343,
             },
         }
     "#]];
@@ -157,8 +157,8 @@ fn test_rare_tacos_2() {
                 pareto_values: 135247584,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1388877,
-                pareto_values: 31624257,
+                states: 1388879,
+                pareto_values: 31624259,
             },
         }
     "#]];
@@ -198,18 +198,18 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 75525,
+            finish_states: 75462,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 31377,
-                dropped_nodes: 348653,
+                processed_nodes: 31373,
+                dropped_nodes: 348447,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 3768152,
-                pareto_values: 33008292,
+                states: 3768978,
+                pareto_values: 33009118,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 58379,
-                pareto_values: 519966,
+                states: 58450,
+                pareto_values: 520010,
             },
         }
     "#]];


### PR DESCRIPTION
Set `allow_quality_actions=false` after a state has reached max quality. This could theoretically break the "optimal overflow quality" guarantee, but this is IMO a worthy trade-off, and none of the current tests have regressed their score, so hopefully that case is rare (if it even exists).

Fixes #149.