### PR TITLE
Branchless effects ticking

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
 [alias]
 tr = "test --package raphael-solver --test * -- -Z unstable-options --report-time"
-rr = "run --release --package raphael-solver --example macro_solver_example"
+rr = "run --profile release-with-debug --package raphael-solver --example macro_solver_example"
 ud = "run --package raphael-data-updater"

--- a/raphael-sim/src/actions.rs
+++ b/raphael-sim/src/actions.rs
@@ -817,19 +817,18 @@ impl Combo {
     pub const fn into_bits(self) -> u8 {
         match self {
             Self::None => 0,
-            Self::SynthesisBegin => 1,
-            Self::BasicTouch => 2,
-            Self::StandardTouch => 3,
+            Self::BasicTouch => 1,
+            Self::StandardTouch => 2,
+            Self::SynthesisBegin => 3,
         }
     }
 
     pub const fn from_bits(value: u8) -> Self {
         match value {
             0 => Self::None,
-            1 => Self::SynthesisBegin,
-            2 => Self::BasicTouch,
-            3 => Self::StandardTouch,
-            _ => Self::None,
+            1 => Self::BasicTouch,
+            2 => Self::StandardTouch,
+            _ => Self::SynthesisBegin,
         }
     }
 }

--- a/raphael-sim/src/effects.rs
+++ b/raphael-sim/src/effects.rs
@@ -50,25 +50,11 @@ impl Effects {
     }
 
     pub fn tick_down(&mut self) {
-        let mut effect_tick = 0;
-        if self.waste_not() != 0 {
-            effect_tick |= const { Self::from_bits(0).with_waste_not(1).into_bits() };
-        }
-        if self.innovation() != 0 {
-            effect_tick |= const { Self::from_bits(0).with_innovation(1).into_bits() };
-        }
-        if self.veneration() != 0 {
-            effect_tick |= const { Self::from_bits(0).with_veneration(1).into_bits() };
-        }
-        if self.great_strides() != 0 {
-            effect_tick |= const { Self::from_bits(0).with_great_strides(1).into_bits() };
-        }
-        if self.muscle_memory() != 0 {
-            effect_tick |= const { Self::from_bits(0).with_muscle_memory(1).into_bits() };
-        }
-        if self.manipulation() != 0 {
-            effect_tick |= const { Self::from_bits(0).with_manipulation(1).into_bits() };
-        }
+        let mask_0 = self.0 & MASK_0;
+        let mask_1 = (self.0 & MASK_1) >> 1;
+        let mask_2 = (self.0 & MASK_2) >> 2;
+        let mask_3 = (self.0 & MASK_3) >> 3;
+        let effect_tick = mask_0 | mask_1 | mask_2 | mask_3;
         self.0 -= effect_tick;
         if self.combo() != Combo::SynthesisBegin {
             // Guard does not wear off because the first condition is guaranteed to be Normal
@@ -76,3 +62,34 @@ impl Effects {
         }
     }
 }
+
+const MASK_0: u32 = Effects::new()
+    .with_waste_not(1)
+    .with_innovation(1)
+    .with_veneration(1)
+    .with_great_strides(1)
+    .with_muscle_memory(1)
+    .with_manipulation(1)
+    .into_bits();
+
+const MASK_1: u32 = Effects::new()
+    .with_waste_not(2)
+    .with_innovation(2)
+    .with_veneration(2)
+    .with_great_strides(2)
+    .with_muscle_memory(2)
+    .with_manipulation(2)
+    .into_bits();
+
+const MASK_2: u32 = Effects::new()
+    .with_waste_not(4)
+    .with_innovation(4)
+    .with_veneration(4)
+    .with_muscle_memory(4)
+    .with_manipulation(4)
+    .into_bits();
+
+const MASK_3: u32 = Effects::new()
+    .with_waste_not(8)
+    .with_manipulation(8)
+    .into_bits();


### PR DESCRIPTION
Makes `Effects::tick_down` completely branchless, improving performance.

Criterion benchmark:

```
# BEFORE
tick_effects            time:   [1.2526 ns 1.2538 ns 1.2554 ns]

# AFTER
tick_effects            time:   [367.90 ps 368.85 ps 370.25 ps]
                        change: [-70.848% -70.558% -70.183%] (p = 0.00 < 0.05)
                        Performance has improved.
```