### PR TITLE
 Add argument to specify if the recipe is expert to `--custom-recipe` in CLI

### DIFF
--- a/raphael-cli/Cargo.toml
+++ b/raphael-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raphael-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [dependencies]

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -16,8 +16,8 @@ pub struct SolveArgs {
     #[arg(short, long, /*required_unless_present_any(["recipe_id, custom_recipe"]),*/ conflicts_with = "custom_recipe")]
     pub item_id: Option<u32>,
 
-    /// Custom recipe. Base progress/quality are optional but must both be specified if one is provided, in which case, rlvl, crafstamnship, and control are ignored
-    #[arg(long, num_args = 4, value_names = ["RLVL", "PROGRESS", "QUALITY", "DURABILITY"], /*required_unless_present_any(["recipe_id", "item_id"])*/)]
+    /// Custom recipe. <EXPERT> must be >0 if the custom recipe is expert, 0 otherwise
+    #[arg(long, num_args = 5, value_names = ["RLVL", "PROGRESS", "QUALITY", "DURABILITY", "EXPERT"], /*required_unless_present_any(["recipe_id", "item_id"])*/)]
     pub custom_recipe: Vec<u16>,
 
     /// Overrides base progress/quality, i.e. "progress/quality per 100% efficiency". rlvl, crafstamnship, and control are ignored if this argument is provided
@@ -184,7 +184,7 @@ pub fn execute(args: &SolveArgs) {
             durability_factor: 0,
             material_factor: 0,
             ingredients: Default::default(),
-            is_expert: false,
+            is_expert: args.custom_recipe[4] != 0,
             req_craftsmanship: 0,
             req_control: 0,
         }

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -16,8 +16,8 @@ pub struct SolveArgs {
     #[arg(short, long, /*required_unless_present_any(["recipe_id, custom_recipe"]),*/ conflicts_with = "custom_recipe")]
     pub item_id: Option<u32>,
 
-    /// Custom recipe. <EXPERT> must be >0 if the custom recipe is expert, 0 otherwise
-    #[arg(long, num_args = 5, value_names = ["RLVL", "PROGRESS", "QUALITY", "DURABILITY", "EXPERT"], /*required_unless_present_any(["recipe_id", "item_id"])*/)]
+    /// Custom recipe. <EXPERT> is optional and must be >0 if the custom recipe is expert, if 0 or not provided, the recipe is assumed to not be an expert recipe
+    #[arg(long, num_args = 4..=5, value_names = ["RLVL", "PROGRESS", "QUALITY", "DURABILITY", "EXPERT"], /*required_unless_present_any(["recipe_id", "item_id"])*/)]
     pub custom_recipe: Vec<u16>,
 
     /// Overrides base progress/quality, i.e. "progress/quality per 100% efficiency". rlvl, crafstamnship, and control are ignored if this argument is provided
@@ -184,7 +184,10 @@ pub fn execute(args: &SolveArgs) {
             durability_factor: 0,
             material_factor: 0,
             ingredients: Default::default(),
-            is_expert: args.custom_recipe[4] != 0,
+            is_expert: match args.custom_recipe.get(4) {
+                Some(value) => *value != 0,
+                None => false,
+            },
             req_craftsmanship: 0,
             req_control: 0,
         }


### PR DESCRIPTION
Adds an optional 5th part to `--custom-recipe` to specify if the custom recipe is expert. Previously `is_expert` was always set to `false` for custom recipes.

The specific implementation was chosen for the following reasons:
* Adding a separate argument to the CLI to force the recipe to be considered expert might cause the user to overlook it in the help text and/or forget it (/ to remove it) when specifying a command
* How custom recipes are specified would need to change if the solver is extended to account for expert-exclusive conditions, so the simplest approach was chosen
* For most use cases it is not necessary to specify if the custom recipe is expert, so having it optional allows for shorter commands and it additionally does not break previously used ones

Additionally, while updating the help text for the `--custom-recipe` argument, I removed a leftover portion from the `--custom-recipe` help text that was no longer applicable
 
**Example:** (Note that rlvl 640 does not correspond to a recipe level that is used by expert recipes)
```
$ cargo run --release --package raphael-cli -- solve --custom-recipe 640 100 10000 80 --stats 5400 4900 630
Recipe ID: 0
Progress: 500/100
Quality: 10000/10000
Durability: 60/80
Steps: 2
Duration: 6 seconds

Actions:
TrainedEye
BasicSynthesis
```

```
$ cargo run --release --package raphael-cli -- solve --custom-recipe 640 100 10000 80 1 --stats 5400 4900 630
Recipe ID: 0
Progress: 625/100
Quality: 10648/10000
Durability: 0/80
Steps: 8
Duration: 21 seconds

Actions:
Reflect
PreparatoryTouch
GreatStrides
Innovation
PreparatoryTouch
GreatStrides
PreparatoryTouch
DelicateSynthesi
```
