### PR TITLE
Add app settings menu

### DIFF
--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,12 +1,5 @@
 [build]
 dist = "distrib"
-pattern_script = """
-<script type="module">
-    import init, { initThreadPool } from '{base}{js}';
-    await init('{base}{wasm}');
-    await initThreadPool(navigator.hardwareConcurrency);
-</script>
-"""
 
 [serve]
 headers = { "Cross-Origin-Embedder-Policy" = "require-corp", "Cross-Origin-Opener-Policy" = "same-origin" }

--- a/src/app.rs
+++ b/src/app.rs
@@ -284,6 +284,7 @@ impl eframe::App for MacroSolverApp {
                     egui::containers::menu::Bar::new().ui(ui, |ui| {
                         ui.label(egui::RichText::new("Raphael  |  FFXIV Crafting Solver").strong());
                         ui.label(format!("v{}", env!("CARGO_PKG_VERSION")));
+                        self.draw_app_config_menu_button(ui, ctx);
 
                         egui::ComboBox::from_id_salt("LOCALE")
                             .selected_text(format!("{}", self.locale))
@@ -334,10 +335,7 @@ impl eframe::App for MacroSolverApp {
                             )
                             .open_in_new_tab(true),
                         );
-                        // Allocate space to make sure the top bar has space for the menu button
-                        ui.allocate_space(egui::Vec2::new(5.0, 0.0));
                         ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                            self.draw_app_config_menu_button(ui, ctx);
                             egui::warn_if_debug_build(ui);
                         });
                     });
@@ -500,7 +498,9 @@ impl MacroSolverApp {
     }
 
     fn draw_app_config_menu_button(&mut self, ui: &mut egui::Ui, ctx: &egui::Context) {
-        egui::containers::menu::MenuButton::new("⚙")
+        ui.add_enabled_ui(true, |ui| {
+            ui.reset_style();
+            egui::containers::menu::MenuButton::new("⚙ Settings")
             .config(
                 egui::containers::menu::MenuConfig::default()
                     .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside),
@@ -587,6 +587,7 @@ impl MacroSolverApp {
                     );
                 }
             });
+        });
     }
 
     fn draw_simulator_widget(&mut self, ui: &mut egui::Ui) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -514,7 +514,7 @@ impl MacroSolverApp {
                     ui.horizontal(|ui| {
                         ui.style_mut().spacing.item_spacing.x = 4.0;
                         ui.add_enabled_ui(zoom_percentage > 20, |ui| {
-                            if ui.button("-").clicked() {
+                            if ui.button(egui::RichText::new("-").monospace()).clicked() {
                                 zoom_percentage -= 10;
                             }
                         });
@@ -524,7 +524,7 @@ impl MacroSolverApp {
                             }
                         });
                         ui.add_enabled_ui(zoom_percentage < 500, |ui| {
-                            if ui.button("+").clicked() {
+                            if ui.button(egui::RichText::new("+").monospace()).clicked() {
                                 zoom_percentage += 10;
                             }
                         });
@@ -545,7 +545,7 @@ impl MacroSolverApp {
                 egui::global_theme_preference_buttons(ui);
                 ui.separator();
 
-                ui.label("Maximum # threads for solver");
+                ui.label("Max solver threads");
                 ui.add_enabled(!thread_pool::initialization_attempted(), |ui: &mut egui::Ui| {
                     ui.horizontal(|ui| {
                         ui.radio_value(&mut self.app_config.num_threads, 0, "Auto");

--- a/src/app.rs
+++ b/src/app.rs
@@ -513,35 +513,37 @@ impl MacroSolverApp {
                 ui.horizontal(|ui| {
                     ui.label("Zoom");
 
-                    let zoom_percentage = &mut self.app_config.zoom_percentage;
+                    let mut zoom_percentage = (ctx.zoom_factor() * 100.0).round() as u16;
                     ui.horizontal(|ui| {
                         ui.style_mut().spacing.item_spacing.x = 4.0;
-                        ui.add_enabled_ui(*zoom_percentage > 20, |ui| {
+                        ui.add_enabled_ui(zoom_percentage > 20, |ui| {
                             if ui.button("-").clicked() {
-                                *zoom_percentage -= 10;
+                                zoom_percentage -= 10;
                             }
                         });
-                        ui.add_enabled_ui(*zoom_percentage != 100, |ui| {
+                        ui.add_enabled_ui(zoom_percentage != 100, |ui| {
                             if ui.button("Reset").clicked() {
-                                *zoom_percentage = 100;
+                                zoom_percentage = 100;
                             }
                         });
-                        ui.add_enabled_ui(*zoom_percentage < 500, |ui| {
+                        ui.add_enabled_ui(zoom_percentage < 500, |ui| {
                             if ui.button("+").clicked() {
-                                *zoom_percentage += 10;
+                                zoom_percentage += 10;
                             }
                         });
                     });
 
                     ui.add(
-                        egui::DragValue::new(zoom_percentage)
+                        egui::DragValue::new(&mut zoom_percentage)
                             .range(20..=500)
                             .suffix("%")
                             // dragging would cause the UI scale to jump arround erratically
                             .speed(0.0)
                             .update_while_editing(false),
                     );
-                    ctx.set_zoom_factor(f32::from(*zoom_percentage) * 0.01);
+
+                    self.app_config.zoom_percentage = zoom_percentage;
+                    ctx.set_zoom_factor(f32::from(zoom_percentage) * 0.01);
                 });
                 ui.horizontal(|ui| {
                     let theme_preference = &mut self.app_config.theme_preference;

--- a/src/app.rs
+++ b/src/app.rs
@@ -549,7 +549,7 @@ impl MacroSolverApp {
 
                 ui.label("Maximum # threads for solver");
                 ui.add_enabled(!THREAD_POOL_INIT.is_completed(), |ui: &mut egui::Ui| {
-                    let mut response = ui.horizontal(|ui| {
+                    ui.horizontal(|ui| {
                         ui.radio_value(&mut self.app_config.num_threads, 0, "Auto");
                         let manual_selected = self.app_config.num_threads != 0;
                         if ui.radio(manual_selected, "Manual").clicked()
@@ -575,14 +575,21 @@ impl MacroSolverApp {
                                     }
                                 }),
                         );
-                    }).response;
+                    }).response
+                });
+                if THREAD_POOL_INIT.is_completed() {
                     #[cfg(target_arch = "wasm32")]
                     let app_restart_text = "Reload the page";
                     #[cfg(not(target_arch = "wasm32"))]
                     let app_restart_text = "Restart the app";
-                    response = response.on_disabled_hover_text(egui::RichText::new(format!("⚠ Unavailable after the solver was started.\n{} to be able to edit again.", app_restart_text)).color(ui.visuals().warn_fg_color));
-                    response
-                });
+                    ui.label(
+                    egui::RichText::new(
+                            format!("⚠ Unavailable after the solver was started.\n{} to be able to edit again.", app_restart_text),
+                        )
+                        .small()
+                        .color(ui.visuals().warn_fg_color),
+                    );
+                }
             });
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -72,6 +72,7 @@ impl MacroSolverApp {
         let ui_config = load(cc, "UI_CONFIG", UIConfiguration::default());
         cc.egui_ctx
             .set_zoom_factor(f32::from(ui_config.zoom_percentage) * 0.01);
+        cc.egui_ctx.set_theme(ui_config.theme_preference);
 
         cc.egui_ctx.all_styles_mut(|style| {
             style.visuals.interact_cursor = Some(CursorIcon::PointingHand);

--- a/src/app.rs
+++ b/src/app.rs
@@ -74,7 +74,6 @@ impl MacroSolverApp {
         let app_config = load(cc, "APP_CONFIG", AppConfig::default());
         cc.egui_ctx
             .set_zoom_factor(f32::from(app_config.zoom_percentage) * 0.01);
-        cc.egui_ctx.set_theme(app_config.theme_preference);
 
         cc.egui_ctx.all_styles_mut(|style| {
             style.visuals.interact_cursor = Some(CursorIcon::PointingHand);
@@ -545,18 +544,7 @@ impl MacroSolverApp {
                     self.app_config.zoom_percentage = zoom_percentage;
                     ctx.set_zoom_factor(f32::from(zoom_percentage) * 0.01);
                 });
-                ui.horizontal(|ui| {
-                    let theme_preference = &mut self.app_config.theme_preference;
-                    ui.selectable_value(theme_preference, egui::ThemePreference::Light, "☀ Light");
-                    ui.selectable_value(theme_preference, egui::ThemePreference::Dark, "🌙 Dark");
-                    ui.selectable_value(
-                        theme_preference,
-                        egui::ThemePreference::System,
-                        "🖥 System",
-                    );
-
-                    ctx.set_theme(*theme_preference);
-                });
+                egui::global_theme_preference_buttons(ui);
                 ui.separator();
 
                 ui.label("Maximum # threads for solver");

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,6 @@ pub enum QualitySource {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct AppConfig {
     pub zoom_percentage: u16,
-    pub theme_preference: egui::ThemePreference,
     pub num_threads: usize,
 }
 
@@ -18,7 +17,6 @@ impl Default for AppConfig {
     fn default() -> Self {
         Self {
             zoom_percentage: 100,
-            theme_preference: egui::ThemePreference::System,
             num_threads: 0,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,11 @@ pub enum QualitySource {
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+pub struct UIConfiguration {
+    pub theme_preference: egui::ThemePreference,
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 pub struct CustomRecipeOverridesConfiguration {
     pub use_custom_recipe: bool,
     pub custom_recipe_overrides: CustomRecipeOverrides,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,16 +8,18 @@ pub enum QualitySource {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct UIConfiguration {
+pub struct AppConfig {
     pub zoom_percentage: u16,
     pub theme_preference: egui::ThemePreference,
+    pub num_threads: usize,
 }
 
-impl Default for UIConfiguration {
+impl Default for AppConfig {
     fn default() -> Self {
         Self {
             zoom_percentage: 100,
             theme_preference: egui::ThemePreference::System,
+            num_threads: 0,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ impl Default for UIConfiguration {
     fn default() -> Self {
         Self {
             zoom_percentage: 100,
-            theme_preference: egui::ThemePreference::default(),
+            theme_preference: egui::ThemePreference::System,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,9 +7,19 @@ pub enum QualitySource {
     Value(u16),
 }
 
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct UIConfiguration {
+    pub zoom_percentage: u16,
     pub theme_preference: egui::ThemePreference,
+}
+
+impl Default for UIConfiguration {
+    fn default() -> Self {
+        Self {
+            zoom_percentage: 100,
+            theme_preference: egui::ThemePreference::default(),
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,9 @@ mod config;
 mod widgets;
 
 #[cfg(target_arch = "wasm32")]
-pub static OOM_PANIC_OCCURED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+pub static OOM_PANIC_OCCURED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+#[cfg(target_arch = "wasm32")]
+pub static THREAD_POOL_IS_INITIALIZED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,9 @@ mod app;
 pub use app::MacroSolverApp;
 
 mod config;
+mod thread_pool;
 mod widgets;
 
 #[cfg(target_arch = "wasm32")]
 pub static OOM_PANIC_OCCURED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
-#[cfg(target_arch = "wasm32")]
-pub static THREAD_POOL_IS_INITIALIZED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -1,0 +1,74 @@
+static THREAD_POOL_INIT: std::sync::Once = std::sync::Once::new();
+
+#[cfg(target_arch = "wasm32")]
+static THREAD_POOL_IS_INITIALIZED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+pub fn attempt_initialization(num_threads: usize) {
+    THREAD_POOL_INIT.call_once(|| {
+        initialize(num_threads);
+    });
+}
+
+pub fn initialization_attempted() -> bool {
+    THREAD_POOL_INIT.is_completed()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn initialize(num_threads: usize) {
+    match rayon::ThreadPoolBuilder::new()
+        .num_threads(num_threads)
+        .build_global()
+    {
+        Ok(()) => log::debug!(
+            "Created global thread pool with num_threads = {}",
+            num_threads
+        ),
+        Err(error) => log::debug!(
+            "Creation of global thread pool failed with error = {:?}",
+            error
+        ),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn initialize(num_threads: usize) {
+    let num_threads = if num_threads == 0 {
+        default_size()
+    } else {
+        num_threads
+    };
+    let future = wasm_bindgen_futures::JsFuture::from(crate::init_thread_pool(num_threads));
+    wasm_bindgen_futures::spawn_local(async move {
+        let result = future.await;
+        log::debug!(
+            "Initialized Pool with num_threads = {}, result = {:?}",
+            num_threads,
+            result
+        );
+        THREAD_POOL_IS_INITIALIZED.store(true, std::sync::atomic::Ordering::Relaxed);
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn default_size() -> usize {
+    std::thread::available_parallelism()
+        .unwrap_or(std::num::NonZero::new(8).unwrap())
+        .into()
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn default_size() -> usize {
+    let window = web_sys::window().unwrap();
+    window.navigator().hardware_concurrency() as usize
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn is_initialized() -> bool {
+    THREAD_POOL_INIT.is_completed()
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn is_initialized() -> bool {
+    THREAD_POOL_IS_INITIALIZED.load(std::sync::atomic::Ordering::Relaxed)
+}


### PR DESCRIPTION
Adds a menu to the top bar for app settings. Included are settings for UI zoom, theme preference, and solver thread limit.
Since the web version's `rayon` thread pool was previously created on startup via JavaScript and the native version's thread pool was only implicitly created, the changes are roughly evenly split between the new UI code and code managing the thread pool creation.

Closes #110, closes #160, closes #164.

**Caveats:**
* Using the zoom shortcuts in a browser doesn't use the new zoom config. It seems like all ways of removing the default behavior of those shortcut were removed, likely because of accessibility reasons
* There is a delay of at least one frame before the first solve starts and it is not possible to change the thread count when the first solve is initiated (since the global thread pool can't be modified after creation). Both of these aspects are the result of trying to keep the code for both the web and native versions as consistent/equivalent as possible

**Preview of the UI changes:**
![image](https://github.com/user-attachments/assets/2a1a5a13-0852-4376-b018-68722d4301d9)

![image](https://github.com/user-attachments/assets/0bbbfbe5-adc1-4ef0-8a79-993bf687fabc)
