### PR TITLE
Fix unsound `TrainedPerfection` optimization in `StepLbSolver`

### DIFF
--- a/raphael-sim/Cargo.toml
+++ b/raphael-sim/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["rlib"]
 
 [dev-dependencies]
 criterion = "0.5.1"
-rand = "0.8.5"
+rand = "0.9.1"
 
 [dependencies]
 bitfield-struct = "0.8.0"

--- a/raphael-sim/benches/bench_simulator.rs
+++ b/raphael-sim/benches/bench_simulator.rs
@@ -39,12 +39,12 @@ fn bench_use_action(c: &mut Criterion) {
 
 fn bench_tick_effects(c: &mut Criterion) {
     fn random_effects() -> Effects {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         Effects::new()
-            .with_veneration(rng.gen_range(0..=4))
-            .with_innovation(rng.gen_range(0..=4))
-            .with_manipulation(rng.gen_range(0..=8))
-            .with_waste_not(rng.gen_range(0..=8))
+            .with_veneration(rng.random_range(0..=4))
+            .with_innovation(rng.random_range(0..=4))
+            .with_manipulation(rng.random_range(0..=8))
+            .with_waste_not(rng.random_range(0..=8))
     }
     c.bench_function("tick_effects", |b| {
         b.iter_batched(random_effects, Effects::tick_down, BatchSize::SmallInput);

--- a/raphael-sim/tests/adversarial_tests.rs
+++ b/raphael-sim/tests/adversarial_tests.rs
@@ -256,7 +256,7 @@ fn test_fuzz() {
     ];
     for _ in 0..100000 {
         let actions: Vec<Action> =
-            std::iter::repeat_with(|| ACTIONS[rand::random::<usize>() % ACTIONS.len()])
+            std::iter::repeat_with(|| ACTIONS[rand::random_range(0..ACTIONS.len())])
                 .take(STEPS)
                 .collect();
         if let Ok(state) = SimulationState::from_macro(&SETTINGS, &actions) {

--- a/raphael-solver/Cargo.toml
+++ b/raphael-solver/Cargo.toml
@@ -21,7 +21,7 @@ web-time = { workspace = true }
 serde = ["dep:serde", "raphael-sim/serde"]
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = "0.9.1"
 env_logger = "0.11.5"
 expect-test = "1.5.1"
 test-case = "3.3.1"

--- a/raphael-solver/Cargo.toml
+++ b/raphael-solver/Cargo.toml
@@ -24,3 +24,4 @@ serde = ["dep:serde", "raphael-sim/serde"]
 rand = "0.8.5"
 env_logger = "0.11.5"
 expect-test = "1.5.1"
+test-case = "3.3.1"

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -537,12 +537,12 @@ fn test_issue_118() {
 
 fn random_effects(settings: &Settings) -> Effects {
     Effects::new()
-        .with_inner_quiet(rand::thread_rng().gen_range(0..=10))
-        .with_great_strides(rand::thread_rng().gen_range(0..=3))
-        .with_innovation(rand::thread_rng().gen_range(0..=4))
-        .with_veneration(rand::thread_rng().gen_range(0..=4))
-        .with_waste_not(rand::thread_rng().gen_range(0..=8))
-        .with_manipulation(rand::thread_rng().gen_range(0..=8))
+        .with_inner_quiet(rand::rng().random_range(0..=10))
+        .with_great_strides(rand::rng().random_range(0..=3))
+        .with_innovation(rand::rng().random_range(0..=4))
+        .with_veneration(rand::rng().random_range(0..=4))
+        .with_waste_not(rand::rng().random_range(0..=8))
+        .with_manipulation(rand::rng().random_range(0..=8))
         .with_quick_innovation_available(rand::random())
         .with_adversarial_guard(if settings.adversarial {
             rand::random()
@@ -558,9 +558,9 @@ fn random_effects(settings: &Settings) -> Effects {
 
 fn random_state(settings: &Settings) -> SimulationState {
     SimulationState {
-        cp: rand::thread_rng().gen_range(0..=settings.max_cp),
-        durability: rand::thread_rng().gen_range(1..=(settings.max_durability / 5)) * 5,
-        progress: rand::thread_rng().gen_range(0..u32::from(settings.max_progress)),
+        cp: rand::rng().random_range(0..=settings.max_cp),
+        durability: rand::rng().random_range(1..=(settings.max_durability / 5)) * 5,
+        progress: rand::rng().random_range(0..u32::from(settings.max_progress)),
         quality: 0,
         unreliable_quality: 0,
         effects: random_effects(settings),

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -65,7 +65,6 @@ impl StepLbSolver {
         let seed_template = Template {
             durability: settings.max_durability(),
             effects: Effects::initial(&settings.simulator_settings)
-                .with_trained_perfection_available(false)
                 .with_quick_innovation_available(false)
                 .with_heart_and_soul_available(false)
                 .with_adversarial_guard(true)

--- a/raphael-solver/src/step_lower_bound_solver/state.rs
+++ b/raphael-solver/src/step_lower_bound_solver/state.rs
@@ -36,6 +36,10 @@ impl ReducedState {
     pub fn from_state(state: SimulationState, step_budget: NonZeroU8) -> Self {
         // Optimize effects
         let mut effects = state.effects;
+        // Make it so that TrainedPerfection can be used an arbitrary amount of times instead of just once.
+        // This decreases the number of possible states, as now there are only Active/Inactive states for TrainedPerfection instead of the usual Available/Active/Unavailable.
+        // This also technically loosens the step-lb, but testing shows that rarely has any impact on the number of pruned nodes.
+        effects.set_trained_perfection_available(true);
         if effects.manipulation() > step_budget.get() - 1 {
             effects.set_manipulation(step_budget.get() - 1);
         }

--- a/raphael-solver/src/step_lower_bound_solver/state.rs
+++ b/raphael-solver/src/step_lower_bound_solver/state.rs
@@ -14,8 +14,7 @@ impl ReducedState {
         settings.allowed_actions = settings
             .allowed_actions
             .remove(Action::Observe)
-            .remove(Action::TricksOfTheTrade)
-            .remove(Action::TrainedPerfection);
+            .remove(Action::TricksOfTheTrade);
         // WasteNot2 is always better than WasteNot because there is no CP cost
         if settings.is_action_allowed::<WasteNot2>() {
             settings.allowed_actions = settings.allowed_actions.remove(Action::WasteNot);
@@ -45,7 +44,6 @@ impl ReducedState {
             // this gives a looser bound but decreases the number of states
             effects.set_waste_not(8);
         }
-        effects.set_trained_perfection_available(false);
         if effects.veneration() > step_budget.get() {
             effects.set_veneration(step_budget.get());
         }

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -10,42 +10,42 @@ use crate::{
 use super::*;
 
 fn random_effects(settings: &Settings) -> Effects {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut effects = Effects::new()
-        .with_inner_quiet(rng.gen_range(0..=10))
-        .with_great_strides(rng.gen_range(0..=3))
-        .with_innovation(rng.gen_range(0..=4))
-        .with_veneration(rng.gen_range(0..=4))
-        .with_waste_not(rng.gen_range(0..=8))
-        .with_manipulation(rng.gen_range(0..=8))
-        .with_adversarial_guard(rng.r#gen() && settings.adversarial)
-        .with_allow_quality_actions(rng.r#gen() || !settings.backload_progress);
+        .with_inner_quiet(rng.random_range(0..=10))
+        .with_great_strides(rng.random_range(0..=3))
+        .with_innovation(rng.random_range(0..=4))
+        .with_veneration(rng.random_range(0..=4))
+        .with_waste_not(rng.random_range(0..=8))
+        .with_manipulation(rng.random_range(0..=8))
+        .with_adversarial_guard(rng.random() && settings.adversarial)
+        .with_allow_quality_actions(rng.random() || !settings.backload_progress);
     if settings.is_action_allowed::<Manipulation>() {
-        effects.set_manipulation(rng.gen_range(0..=8));
+        effects.set_manipulation(rng.random_range(0..=8));
     }
     if settings.is_action_allowed::<TrainedPerfection>() {
-        effects.set_trained_perfection_available(rng.r#gen());
+        effects.set_trained_perfection_available(rng.random());
         effects
-            .set_trained_perfection_active(!effects.trained_perfection_available() && rng.r#gen());
+            .set_trained_perfection_active(!effects.trained_perfection_available() && rng.random());
     }
     if settings.is_action_allowed::<HeartAndSoul>() {
-        effects.set_heart_and_soul_available(rng.r#gen());
-        effects.set_heart_and_soul_active(!effects.heart_and_soul_available() && rng.r#gen());
+        effects.set_heart_and_soul_available(rng.random());
+        effects.set_heart_and_soul_active(!effects.heart_and_soul_available() && rng.random());
     }
     if settings.is_action_allowed::<QuickInnovation>() {
-        effects.set_quick_innovation_available(rng.r#gen());
+        effects.set_quick_innovation_available(rng.random());
     }
     effects
 }
 
 fn random_state(settings: &SolverSettings) -> SimulationState {
     SimulationState {
-        cp: rand::thread_rng().gen_range(0..=settings.max_cp()),
-        durability: rand::thread_rng()
-            .gen_range(1..=settings.max_durability())
+        cp: rand::rng().random_range(0..=settings.max_cp()),
+        durability: rand::rng()
+            .random_range(1..=settings.max_durability())
             .next_multiple_of(5),
-        progress: rand::thread_rng().gen_range(0..settings.max_progress()),
-        quality: rand::thread_rng().gen_range(0..=settings.max_quality()),
+        progress: rand::rng().random_range(0..settings.max_progress()),
+        quality: rand::rng().random_range(0..=settings.max_quality()),
         unreliable_quality: 0,
         effects: random_effects(&settings.simulator_settings),
     }

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -1,589 +1,109 @@
 use rand::Rng;
 use raphael_sim::*;
+use test_case::test_matrix;
 
 use crate::{
-    SolverSettings,
+    AtomicFlag, SolverSettings,
     actions::{FULL_SEARCH_ACTIONS, use_action_combo},
 };
 
 use super::*;
 
-fn solve(simulator_settings: Settings, actions: &[Action]) -> u8 {
-    let mut state = SimulationState::from_macro(&simulator_settings, actions).unwrap();
-    state.effects.set_combo(Combo::None);
-    let solver_settings = SolverSettings { simulator_settings };
-    StepLbSolver::new(solver_settings, Default::default())
-        .step_lower_bound(state, 0)
-        .unwrap()
-}
-
-#[test]
-fn test_01() {
-    let settings = Settings {
-        max_cp: 553,
-        max_durability: 70,
-        max_progress: 2400,
-        max_quality: 1700,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::PrudentTouch,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot2,
-            Action::Groundwork,
-            Action::Groundwork,
-            Action::Groundwork,
-            Action::PreparatoryTouch,
-        ],
-    );
-    assert_eq!(result, 5);
-}
-
-#[test]
-fn test_adversarial_01() {
-    let settings = Settings {
-        max_cp: 553,
-        max_durability: 70,
-        max_progress: 2400,
-        max_quality: 1700,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::PrudentTouch,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot2,
-            Action::Groundwork,
-            Action::Groundwork,
-            Action::Groundwork,
-            Action::PreparatoryTouch,
-        ],
-    );
-    assert_eq!(result, 6);
-}
-
-#[test]
-fn test_02() {
-    let settings = Settings {
-        max_cp: 700,
-        max_durability: 70,
-        max_progress: 2500,
-        max_quality: 5000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot,
-            Action::Groundwork,
-            Action::Groundwork,
-        ],
-    );
-    assert_eq!(result, 15);
-}
-
-#[test]
-fn test_adversarial_02() {
-    let settings = Settings {
-        max_cp: 700,
-        max_durability: 70,
-        max_progress: 2500,
-        max_quality: 5000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot,
-            Action::Groundwork,
-            Action::Groundwork,
-        ],
-    );
-    assert_eq!(result, 15);
-}
-
-#[test]
-fn test_03() {
-    let settings = Settings {
-        max_cp: 617,
-        max_durability: 60,
-        max_progress: 2120,
-        max_quality: 5000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot,
-            Action::Groundwork,
-            Action::CarefulSynthesis,
-            Action::Groundwork,
-            Action::PreparatoryTouch,
-            Action::Innovation,
-            Action::BasicTouch,
-            Action::StandardTouch,
-        ],
-    );
-    assert_eq!(result, 13);
-}
-
-#[test]
-fn test_adversarial_03() {
-    let settings = Settings {
-        max_cp: 617,
-        max_durability: 60,
-        max_progress: 2120,
-        max_quality: 5000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot,
-            Action::Groundwork,
-            Action::CarefulSynthesis,
-            Action::Groundwork,
-            Action::PreparatoryTouch,
-            Action::Innovation,
-            Action::BasicTouch,
-            Action::StandardTouch,
-        ],
-    );
-    assert_eq!(result, 13);
-}
-
-#[test]
-fn test_04() {
-    let settings = Settings {
-        max_cp: 411,
-        max_durability: 60,
-        max_progress: 1990,
-        max_quality: 5000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 19);
-}
-
-#[test]
-fn test_adversarial_04() {
-    let settings = Settings {
-        max_cp: 411,
-        max_durability: 60,
-        max_progress: 1990,
-        max_quality: 2900,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 14);
-}
-
-#[test]
-fn test_05() {
-    let settings = Settings {
-        max_cp: 450,
-        max_durability: 60,
-        max_progress: 1970,
-        max_quality: 2000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 12);
-}
-
-#[test]
-fn test_adversarial_05() {
-    let settings = Settings {
-        max_cp: 450,
-        max_durability: 60,
-        max_progress: 1970,
-        max_quality: 2000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 12);
-}
-
-#[test]
-fn test_06() {
-    let settings = Settings {
-        max_cp: 673,
-        max_durability: 60,
-        max_progress: 2345,
-        max_quality: 3500,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 16);
-}
-
-#[test]
-fn test_adversarial_06() {
-    let settings = Settings {
-        max_cp: 673,
-        max_durability: 60,
-        max_progress: 2345,
-        max_quality: 1200,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 11);
-}
-
-#[test]
-fn test_07() {
-    let settings = Settings {
-        max_cp: 673,
-        max_durability: 60,
-        max_progress: 2345,
-        max_quality: 3123,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::Reflect]);
-    assert_eq!(result, 15);
-}
-
-#[test]
-fn test_08() {
-    let settings = Settings {
-        max_cp: 32,
-        max_durability: 10,
-        max_progress: 10000,
-        max_quality: 20000,
-        base_progress: 10000,
-        base_quality: 10000,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::PrudentTouch]);
-    assert_eq!(result, 1);
-}
-
-#[test]
-fn test_09() {
-    let settings = Settings {
-        max_cp: 700,
-        max_durability: 70,
-        max_progress: 2500,
-        max_quality: 3000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::Manipulation)
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[]);
-    assert_eq!(result, 17);
-}
-
-#[test]
-fn test_10() {
-    let settings = Settings {
-        max_cp: 400,
-        max_durability: 80,
-        max_progress: 1200,
-        max_quality: 2400,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 100,
-        allowed_actions: ActionMask::all()
-            .remove(Action::Manipulation)
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[]);
-    assert_eq!(result, 11);
-}
-
-#[test]
-fn test_11() {
-    let settings = Settings {
-        max_cp: 320,
-        max_durability: 80,
-        max_progress: 1600,
-        max_quality: 2000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 100,
-        allowed_actions: ActionMask::all()
-            .remove(Action::Manipulation)
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[]);
-    assert_eq!(result, 11);
-}
-
-#[test]
-fn test_12() {
-    let settings = Settings {
-        max_cp: 320,
-        max_durability: 80,
-        max_progress: 1600,
-        max_quality: 2100,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 100,
-        allowed_actions: ActionMask::all()
-            .remove(Action::Manipulation)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[]);
-    assert_eq!(result, 11);
-}
-
 fn random_effects(settings: &Settings) -> Effects {
-    Effects::new()
-        .with_inner_quiet(rand::thread_rng().gen_range(0..=10))
-        .with_great_strides(rand::thread_rng().gen_range(0..=3))
-        .with_innovation(rand::thread_rng().gen_range(0..=4))
-        .with_veneration(rand::thread_rng().gen_range(0..=4))
-        .with_waste_not(rand::thread_rng().gen_range(0..=8))
-        .with_manipulation(rand::thread_rng().gen_range(0..=8))
-        .with_quick_innovation_available(rand::random())
-        .with_adversarial_guard(if settings.adversarial {
-            rand::random()
-        } else {
-            false
-        })
-        .with_allow_quality_actions(if settings.backload_progress {
-            rand::random()
-        } else {
-            true
-        })
+    let mut rng = rand::thread_rng();
+    let mut effects = Effects::new()
+        .with_inner_quiet(rng.gen_range(0..=10))
+        .with_great_strides(rng.gen_range(0..=3))
+        .with_innovation(rng.gen_range(0..=4))
+        .with_veneration(rng.gen_range(0..=4))
+        .with_waste_not(rng.gen_range(0..=8))
+        .with_manipulation(rng.gen_range(0..=8))
+        .with_adversarial_guard(rng.r#gen() && settings.adversarial)
+        .with_allow_quality_actions(rng.r#gen() || !settings.backload_progress);
+    if settings.is_action_allowed::<Manipulation>() {
+        effects.set_manipulation(rng.gen_range(0..=8));
+    }
+    if settings.is_action_allowed::<TrainedPerfection>() {
+        effects.set_trained_perfection_available(rng.r#gen());
+        effects
+            .set_trained_perfection_active(!effects.trained_perfection_available() && rng.r#gen());
+    }
+    if settings.is_action_allowed::<HeartAndSoul>() {
+        effects.set_heart_and_soul_available(rng.r#gen());
+        effects.set_heart_and_soul_active(!effects.heart_and_soul_available() && rng.r#gen());
+    }
+    if settings.is_action_allowed::<QuickInnovation>() {
+        effects.set_quick_innovation_available(rng.r#gen());
+    }
+    effects
 }
 
-fn random_state(settings: &Settings) -> SimulationState {
+fn random_state(settings: &SolverSettings) -> SimulationState {
     SimulationState {
-        cp: rand::thread_rng().gen_range(0..=settings.max_cp),
-        durability: rand::thread_rng().gen_range(1..=(settings.max_durability / 5)) * 5,
-        progress: rand::thread_rng().gen_range(0..u32::from(settings.max_progress)),
-        quality: 0,
+        cp: rand::thread_rng().gen_range(0..=settings.max_cp()),
+        durability: rand::thread_rng()
+            .gen_range(1..=settings.max_durability())
+            .next_multiple_of(5),
+        progress: rand::thread_rng().gen_range(0..settings.max_progress()),
+        quality: rand::thread_rng().gen_range(0..=settings.max_quality()),
         unreliable_quality: 0,
-        effects: random_effects(settings),
+        effects: random_effects(&settings.simulator_settings),
     }
     .try_into()
     .unwrap()
 }
 
-/// Test that the upper-bound solver is monotonic,
-/// i.e. the quality UB of a state is never less than the quality UB of any of its children.
-fn monotonic_fuzz_check(simulator_settings: Settings) {
-    let solver_settings = SolverSettings { simulator_settings };
-    let mut solver = StepLbSolver::new(solver_settings, Default::default());
-    for _ in 0..10000 {
-        let state = random_state(&simulator_settings);
-        let state_lower_bound = solver.step_lower_bound(state, 0).unwrap();
+/// Test that the StepLbSolver is consistent.
+/// It is consistent if the step-lb of a parent state is never greater than the step-lb of a child state.
+fn check_consistency(solver_settings: SolverSettings) {
+    let mut solver = StepLbSolver::new(solver_settings, AtomicFlag::default());
+    for _ in 0..100000 {
+        let state = random_state(&solver_settings);
+        let state_step_lb = solver.step_lower_bound(state, 0).unwrap();
         for action in FULL_SEARCH_ACTIONS {
-            let child_lower_bound = match use_action_combo(&solver_settings, state, *action) {
-                Ok(child) => match child.is_final(&simulator_settings) {
-                    false => solver.step_lower_bound(child, 0).unwrap(),
-                    true if child.progress >= u32::from(simulator_settings.max_progress)
-                        && child.quality >= u32::from(simulator_settings.max_quality) =>
-                    {
+            if let Ok(child_state) = use_action_combo(&solver_settings, state, *action) {
+                let child_step_lb = if child_state.is_final(&solver_settings.simulator_settings) {
+                    let progress_maxed = child_state.progress >= solver_settings.max_progress();
+                    let quality_maxed = child_state.quality >= solver_settings.max_quality();
+                    if progress_maxed && quality_maxed {
                         0
+                    } else {
+                        u8::MAX
                     }
-                    true => u8::MAX,
-                },
-                Err(_) => u8::MAX,
+                } else {
+                    solver.step_lower_bound(child_state, 0).unwrap()
+                };
+                if state_step_lb > child_step_lb.saturating_add(action.steps()) {
+                    dbg!(state, action, state_step_lb, child_step_lb);
+                    panic!("StepLbSolver is not consistent");
+                }
             };
-            if state_lower_bound > child_lower_bound.saturating_add(action.steps()) {
-                dbg!(state, action, state_lower_bound, child_lower_bound);
-                panic!("Parent's step lower bound is greater than child's step lower bound");
-            }
         }
     }
 }
 
-#[test]
-fn test_monotonic_normal_sim() {
-    let settings = Settings {
-        max_cp: 360,
-        max_durability: 70,
-        max_progress: 1000,
-        max_quality: 2600,
+#[test_matrix(
+    [1000, 2000],
+    [1000, 2000, 4000],
+    [20, 35, 60, 80],
+    [90, 100]
+)]
+fn consistency(max_progress: u16, max_quality: u16, max_durability: u16, job_level: u8) {
+    let simulator_settings = Settings {
+        max_progress,
+        max_quality,
+        max_durability,
+        max_cp: 1000, // max_cp does not matter for StepLbSolver
         base_progress: 100,
         base_quality: 100,
-        job_level: 100,
-        allowed_actions: ActionMask::all(),
+        job_level,
+        allowed_actions: ActionMask::all()
+            .remove(Action::TrainedEye)
+            .remove(Action::HeartAndSoul)
+            .remove(Action::QuickInnovation),
         adversarial: false,
         backload_progress: false,
     };
-    monotonic_fuzz_check(settings);
-}
-
-#[test]
-fn test_monotonic_backload_progress_sim() {
-    let settings = Settings {
-        max_cp: 360,
-        max_durability: 70,
-        max_progress: 1000,
-        max_quality: 2600,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 100,
-        allowed_actions: ActionMask::all(),
-        adversarial: false,
-        backload_progress: true,
-    };
-    monotonic_fuzz_check(settings);
-}
-
-#[test]
-fn test_monotonic_adversarial_sim() {
-    let settings = Settings {
-        max_cp: 360,
-        max_durability: 70,
-        max_progress: 1000,
-        max_quality: 2400,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 100,
-        allowed_actions: ActionMask::all(),
-        adversarial: true,
-        backload_progress: false,
-    };
-    monotonic_fuzz_check(settings);
+    let solver_settings = SolverSettings { simulator_settings };
+    check_consistency(solver_settings);
 }

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -83,24 +83,27 @@ fn check_consistency(solver_settings: SolverSettings) {
 }
 
 #[test_matrix(
-    [1000, 2000],
-    [1000, 2000, 4000],
     [20, 35, 60, 80],
-    [90, 100]
+    [false, true],
+    [false, true]
 )]
-fn consistency(max_progress: u16, max_quality: u16, max_durability: u16, job_level: u8) {
+fn consistency(max_durability: u16, heart_and_soul: bool, quick_innovation: bool) {
+    let mut allowed_actions = ActionMask::all().remove(Action::TrainedEye);
+    if !heart_and_soul {
+        allowed_actions = allowed_actions.remove(Action::HeartAndSoul);
+    }
+    if !quick_innovation {
+        allowed_actions = allowed_actions.remove(Action::QuickInnovation);
+    }
     let simulator_settings = Settings {
-        max_progress,
-        max_quality,
+        max_progress: 2000,
+        max_quality: 2000,
         max_durability,
-        max_cp: 1000, // max_cp does not matter for StepLbSolver
+        max_cp: 1000,
         base_progress: 100,
         base_quality: 100,
-        job_level,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
+        job_level: 100,
+        allowed_actions,
         adversarial: false,
         backload_progress: false,
     };

--- a/raphael-solver/src/utils/pareto_front_builder.rs
+++ b/raphael-solver/src/utils/pareto_front_builder.rs
@@ -325,7 +325,7 @@ mod tests {
 
     #[test]
     fn test_merge_fuzz() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut values_first: Vec<usize> = (1..100).collect();
         let mut values_second: Vec<usize> = (1..100).collect();
         let mut random_values = |n: usize| -> Vec<ParetoValue<_, _>> {

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -236,9 +236,9 @@ fn large_progress_quality_increase() {
                 pareto_values: 411684,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 180,
+                parallel_states: 120,
                 sequential_states: 9,
-                pareto_values: 189,
+                pareto_values: 129,
             },
         }
     "#]];
@@ -286,9 +286,9 @@ fn backload_progress_single_delicate_synthesis() {
                 pareto_values: 7205,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 174,
+                parallel_states: 116,
                 sequential_states: 0,
-                pareto_values: 174,
+                pareto_values: 116,
             },
         }
     "#]];

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -236,9 +236,9 @@ fn large_progress_quality_increase() {
                 pareto_values: 411684,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 60,
+                parallel_states: 180,
                 sequential_states: 9,
-                pareto_values: 69,
+                pareto_values: 189,
             },
         }
     "#]];
@@ -286,9 +286,9 @@ fn backload_progress_single_delicate_synthesis() {
                 pareto_values: 7205,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 74,
-                sequential_states: 1,
-                pareto_values: 75,
+                parallel_states: 174,
+                sequential_states: 0,
+                pareto_values: 174,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -345,9 +345,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_values: 36452805,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 3522350,
+                parallel_states: 2318275,
                 sequential_states: 0,
-                pareto_values: 38124099,
+                pareto_values: 24996627,
             },
         }
     "#]];
@@ -549,9 +549,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 22678028,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2403743,
+                parallel_states: 1579065,
                 sequential_states: 0,
-                pareto_values: 21413497,
+                pareto_values: 13935076,
             },
         }
     "#]];
@@ -649,9 +649,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 10548959,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 715122,
+                parallel_states: 461630,
                 sequential_states: 0,
-                pareto_values: 4372857,
+                pareto_values: 2798356,
             },
         }
     "#]];
@@ -699,9 +699,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 17986508,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2037492,
+                parallel_states: 1336246,
                 sequential_states: 0,
-                pareto_values: 15440649,
+                pareto_values: 10026036,
             },
         }
     "#]];
@@ -749,9 +749,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 15649784,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1707447,
+                parallel_states: 1118641,
                 sequential_states: 0,
-                pareto_values: 12390136,
+                pareto_values: 8025952,
             },
         }
     "#]];
@@ -799,9 +799,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 31413523,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2371873,
+                parallel_states: 1556489,
                 sequential_states: 0,
-                pareto_values: 22574022,
+                pareto_values: 14722811,
             },
         }
     "#]];
@@ -838,20 +838,20 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 594213,
+            finish_states: 594271,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 166638,
-                dropped_nodes: 421320,
-                pareto_buckets_squared_size_sum: 39840790,
+                processed_nodes: 166658,
+                dropped_nodes: 421345,
+                pareto_buckets_squared_size_sum: 39842952,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 2281658,
                 pareto_values: 23980771,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 563707,
+                parallel_states: 361555,
                 sequential_states: 0,
-                pareto_values: 4931437,
+                pareto_values: 3147923,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -345,9 +345,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_values: 36452805,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1204075,
-                sequential_states: 461195,
-                pareto_values: 18757808,
+                parallel_states: 3522350,
+                sequential_states: 0,
+                pareto_values: 38124099,
             },
         }
     "#]];
@@ -549,9 +549,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 22678028,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 824678,
-                sequential_states: 39825,
-                pareto_values: 7877496,
+                parallel_states: 2403743,
+                sequential_states: 0,
+                pareto_values: 21413497,
             },
         }
     "#]];
@@ -649,9 +649,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 10548959,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 253492,
-                sequential_states: 69776,
-                pareto_values: 2029289,
+                parallel_states: 715122,
+                sequential_states: 0,
+                pareto_values: 4372857,
             },
         }
     "#]];
@@ -699,9 +699,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 17986508,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 701246,
-                sequential_states: 24891,
-                pareto_values: 5633074,
+                parallel_states: 2037492,
+                sequential_states: 0,
+                pareto_values: 15440649,
             },
         }
     "#]];
@@ -749,9 +749,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 15649784,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 588806,
-                sequential_states: 34904,
-                pareto_values: 4648051,
+                parallel_states: 1707447,
+                sequential_states: 0,
+                pareto_values: 12390136,
             },
         }
     "#]];
@@ -799,9 +799,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 31413523,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 815384,
-                sequential_states: 211625,
-                pareto_values: 10048840,
+                parallel_states: 2371873,
+                sequential_states: 0,
+                pareto_values: 22574022,
             },
         }
     "#]];
@@ -838,20 +838,20 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 593905,
+            finish_states: 594213,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 166495,
-                dropped_nodes: 421307,
-                pareto_buckets_squared_size_sum: 39824729,
+                processed_nodes: 166638,
+                dropped_nodes: 421320,
+                pareto_buckets_squared_size_sum: 39840790,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 2281656,
-                pareto_values: 23980767,
+                states: 2281658,
+                pareto_values: 23980771,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 202141,
-                sequential_states: 115181,
-                pareto_values: 2840552,
+                parallel_states: 563707,
+                sequential_states: 0,
+                pareto_values: 4931437,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -345,9 +345,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_values: 48797927,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 3390611,
-                sequential_states: 56735,
-                pareto_values: 65914022,
+                parallel_states: 2227573,
+                sequential_states: 52022,
+                pareto_values: 43627016,
             },
         }
     "#]];
@@ -549,9 +549,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 27021469,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2309866,
-                sequential_states: 40648,
-                pareto_values: 34272829,
+                parallel_states: 1514037,
+                sequential_states: 36968,
+                pareto_values: 22609652,
             },
         }
     "#]];
@@ -649,9 +649,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 12436758,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 710022,
-                sequential_states: 24723,
-                pareto_values: 6472471,
+                parallel_states: 456982,
+                sequential_states: 22706,
+                pareto_values: 4195386,
             },
         }
     "#]];
@@ -699,9 +699,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 20254488,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1879373,
-                sequential_states: 28371,
-                pareto_values: 24379646,
+                parallel_states: 1229899,
+                sequential_states: 26205,
+                pareto_values: 16044627,
             },
         }
     "#]];
@@ -749,9 +749,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 17523599,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1696763,
-                sequential_states: 33201,
-                pareto_values: 20462711,
+                parallel_states: 1108877,
+                sequential_states: 29982,
+                pareto_values: 13457557,
             },
         }
     "#]];
@@ -799,9 +799,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 37998717,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2316964,
-                sequential_states: 45392,
-                pareto_values: 38639871,
+                parallel_states: 1517488,
+                sequential_states: 41602,
+                pareto_values: 25547360,
             },
         }
     "#]];
@@ -838,20 +838,20 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 867642,
+            finish_states: 867728,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1886860,
-                dropped_nodes: 12370796,
-                pareto_buckets_squared_size_sum: 186143428,
+                processed_nodes: 1887006,
+                dropped_nodes: 12371425,
+                pareto_buckets_squared_size_sum: 186147222,
             },
             quality_ub_stats: QualityUbSolverStats {
                 states: 2042647,
                 pareto_values: 34781645,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 613018,
-                sequential_states: 27377,
-                pareto_values: 9454622,
+                parallel_states: 386882,
+                sequential_states: 24974,
+                pareto_values: 6100754,
             },
         }
     "#]];
@@ -946,9 +946,9 @@ fn ceviche_4900_4800_no_quality() {
                 pareto_values: 25597,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 11437,
-                sequential_states: 372,
-                pareto_values: 11809,
+                parallel_states: 7478,
+                sequential_states: 382,
+                pareto_values: 7860,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -345,9 +345,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_values: 48797927,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1163038,
-                sequential_states: 677847,
-                pareto_values: 37191535,
+                parallel_states: 3390611,
+                sequential_states: 56735,
+                pareto_values: 65914022,
             },
         }
     "#]];
@@ -549,9 +549,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 27021469,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 795829,
-                sequential_states: 237294,
-                pareto_values: 15920727,
+                parallel_states: 2309866,
+                sequential_states: 40648,
+                pareto_values: 34272829,
             },
         }
     "#]];
@@ -649,9 +649,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 12436758,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 253040,
-                sequential_states: 65034,
-                pareto_values: 2847486,
+                parallel_states: 710022,
+                sequential_states: 24723,
+                pareto_values: 6472471,
             },
         }
     "#]];
@@ -699,9 +699,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 20254488,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 649474,
-                sequential_states: 38378,
-                pareto_values: 8958110,
+                parallel_states: 1879373,
+                sequential_states: 28371,
+                pareto_values: 24379646,
             },
         }
     "#]];
@@ -749,9 +749,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 17523599,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 587886,
-                sequential_states: 106998,
-                pareto_values: 8543687,
+                parallel_states: 1696763,
+                sequential_states: 33201,
+                pareto_values: 20462711,
             },
         }
     "#]];
@@ -799,9 +799,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 37998717,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 799476,
-                sequential_states: 237978,
-                pareto_values: 17725982,
+                parallel_states: 2316964,
+                sequential_states: 45392,
+                pareto_values: 38639871,
             },
         }
     "#]];
@@ -838,20 +838,20 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 867536,
+            finish_states: 867642,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1886441,
-                dropped_nodes: 12369594,
-                pareto_buckets_squared_size_sum: 186115309,
+                processed_nodes: 1886860,
+                dropped_nodes: 12370796,
+                pareto_buckets_squared_size_sum: 186143428,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 2042638,
-                pareto_values: 34781603,
+                states: 2042647,
+                pareto_values: 34781645,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 226115,
-                sequential_states: 142163,
-                pareto_values: 5539521,
+                parallel_states: 613018,
+                sequential_states: 27377,
+                pareto_values: 9454622,
             },
         }
     "#]];
@@ -946,9 +946,9 @@ fn ceviche_4900_4800_no_quality() {
                 pareto_values: 25597,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 3968,
-                sequential_states: 397,
-                pareto_values: 4365,
+                parallel_states: 11437,
+                sequential_states: 372,
+                pareto_values: 11809,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -108,9 +108,9 @@ fn stuffed_peppers() {
                 pareto_values: 77746538,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2159241,
-                sequential_states: 38649,
-                pareto_values: 32217461,
+                parallel_states: 1414006,
+                sequential_states: 35540,
+                pareto_values: 21195110,
             },
         }
     "#]];
@@ -160,9 +160,9 @@ fn test_rare_tacos_2() {
                 pareto_values: 135274246,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 3387311,
-                sequential_states: 50398,
-                pareto_values: 65874722,
+                parallel_states: 2225633,
+                sequential_states: 46877,
+                pareto_values: 43594150,
             },
         }
     "#]];
@@ -314,9 +314,9 @@ fn test_rare_tacos_4628_4410() {
                 pareto_values: 151000601,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 632644,
-                sequential_states: 34044,
-                pareto_values: 13119718,
+                parallel_states: 420784,
+                sequential_states: 31396,
+                pareto_values: 8949978,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -108,9 +108,9 @@ fn stuffed_peppers() {
                 pareto_values: 77746538,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 745235,
-                sequential_states: 293513,
-                pareto_values: 16121880,
+                parallel_states: 2159241,
+                sequential_states: 38649,
+                pareto_values: 32217461,
             },
         }
     "#]];
@@ -160,9 +160,9 @@ fn test_rare_tacos_2() {
                 pareto_values: 135274246,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1161678,
-                sequential_states: 554278,
-                pareto_values: 34687800,
+                parallel_states: 3387311,
+                sequential_states: 50398,
+                pareto_values: 65874722,
             },
         }
     "#]];
@@ -314,9 +314,9 @@ fn test_rare_tacos_4628_4410() {
                 pareto_values: 151000601,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 211860,
-                sequential_states: 141643,
-                pareto_values: 7219619,
+                parallel_states: 632644,
+                sequential_states: 34044,
+                pareto_values: 13119718,
             },
         }
     "#]];


### PR DESCRIPTION
Removed all snapshot tests for the `StepLbSolver`. The snapshot tests were previously in place to see how the step lower-bound changes when changing the `StepLbSolver`. That is no longer needed since added snapshot tests for the solver as a whole, because the step-lb tightness can be indirectly tracked by the number of visited nodes in the search phase.

Added a test matrix to check that the `StepLbSolver` is consistent and admissible across a wide range of configurations. This test was previously only done for one configuration. Because of this, the unsound `TrainedPerfection` optimization was not detected.

The `StepLbSolver` previously optimized `TrainedPerfection` by always setting `trained_perfection_available=false`, essentially forbidding the use of `TrainedPerfection` in the `StepLbSolver`. The fixed optimization instead always sets `trained_perfection_available=true`, making it possible to use `TrainedPerfection` an arbitrary amount of times instead of just once.

`TrainedPerfection` is now also included in the precompute templates. This results in fewer states being computed sequentially, but more states being computed overall.