### PR TITLE
Fix inconsistent `QualityUbSolver` for configurations with low `max_durability` 

### DIFF
--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -15,6 +15,9 @@ pub use macro_solver::MacroSolver;
 mod utils;
 pub use utils::AtomicFlag;
 
+#[cfg(test)]
+pub mod test_utils;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum SolverException {

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -32,6 +32,8 @@ impl QualityUbSolver {
     pub fn new(mut settings: SolverSettings, interrupt_signal: utils::AtomicFlag) -> Self {
         let durability_cost = durability_cost(&settings.simulator_settings);
         settings.simulator_settings.max_cp += durability_cost * (settings.max_durability() / 5);
+        // max_durability needs to be high enough so that no action combo fails due to missing durability.
+        settings.simulator_settings.max_durability = 100;
         Self {
             settings,
             interrupt_signal,

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -32,8 +32,6 @@ impl QualityUbSolver {
     pub fn new(mut settings: SolverSettings, interrupt_signal: utils::AtomicFlag) -> Self {
         let durability_cost = durability_cost(&settings.simulator_settings);
         settings.simulator_settings.max_cp += durability_cost * (settings.max_durability() / 5);
-        // max_durability needs to be high enough so that no action combo fails due to missing durability.
-        settings.simulator_settings.max_durability = 100;
         Self {
             settings,
             interrupt_signal,

--- a/raphael-solver/src/quality_upper_bound_solver/state.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/state.rs
@@ -5,6 +5,9 @@ use crate::{
 
 use raphael_sim::*;
 
+/// A high enough value to make sure that no action combo fails due to missing durability.
+const MAX_DURABILITY: u16 = 100;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ReducedState {
     pub cp: u16,
@@ -30,7 +33,7 @@ impl ReducedState {
             state.effects.set_trained_perfection_available(false);
         }
         state.cp += refunded_durability * durability_cost;
-        state.durability = settings.max_durability();
+        state.durability = MAX_DURABILITY;
         Self::from_simulation_state_inner(&state, settings, durability_cost).unwrap()
     }
 
@@ -39,8 +42,7 @@ impl ReducedState {
         settings: &SolverSettings,
         durability_cost: u16,
     ) -> Option<Self> {
-        let used_durability_cost =
-            (settings.max_durability() - state.durability) / 5 * durability_cost;
+        let used_durability_cost = (MAX_DURABILITY - state.durability) / 5 * durability_cost;
         if used_durability_cost > state.cp {
             return None;
         }
@@ -63,7 +65,7 @@ impl ReducedState {
 
     fn to_simulation_state(self, settings: &SolverSettings) -> SimulationState {
         SimulationState {
-            durability: settings.max_durability(),
+            durability: MAX_DURABILITY,
             cp: self.cp,
             progress: 0,
             quality: 0,

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -1,9 +1,9 @@
-use rand::Rng;
 use raphael_sim::*;
 
 use crate::{
     SolverSettings,
     actions::{FULL_SEARCH_ACTIONS, use_action_combo},
+    test_utils::*,
 };
 
 use super::QualityUbSolver;
@@ -14,442 +14,6 @@ fn solve(simulator_settings: Settings, actions: &[Action]) -> u32 {
     let solver_settings = SolverSettings { simulator_settings };
     let mut solver = QualityUbSolver::new(solver_settings, Default::default());
     solver.quality_upper_bound(state).unwrap()
-}
-
-#[test]
-fn test_01() {
-    let settings = Settings {
-        max_cp: 553,
-        max_durability: 70,
-        max_progress: 2400,
-        max_quality: 20000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::PrudentTouch,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot2,
-            Action::Groundwork,
-            Action::Groundwork,
-            Action::Groundwork,
-            Action::PreparatoryTouch,
-        ],
-    );
-    assert_eq!(result, 3352);
-}
-
-#[test]
-fn test_adversarial_01() {
-    let settings = Settings {
-        max_cp: 553,
-        max_durability: 70,
-        max_progress: 2400,
-        max_quality: 20000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::PrudentTouch,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot2,
-            Action::Groundwork,
-            Action::Groundwork,
-            Action::Groundwork,
-            Action::PreparatoryTouch,
-        ],
-    );
-    assert_eq!(result, 2955);
-}
-
-#[test]
-fn test_02() {
-    let settings = Settings {
-        max_cp: 700,
-        max_durability: 70,
-        max_progress: 2500,
-        max_quality: 5000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot,
-            Action::Groundwork,
-            Action::Groundwork,
-        ],
-    );
-    assert_eq!(result, 4693);
-}
-
-#[test]
-fn test_adversarial_02() {
-    let settings = Settings {
-        max_cp: 700,
-        max_durability: 70,
-        max_progress: 2500,
-        max_quality: 5000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot,
-            Action::Groundwork,
-            Action::Groundwork,
-        ],
-    );
-    assert_eq!(result, 3975);
-}
-
-#[test]
-fn test_03() {
-    let settings = Settings {
-        max_cp: 617,
-        max_durability: 60,
-        max_progress: 2120,
-        max_quality: 5000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot,
-            Action::Groundwork,
-            Action::CarefulSynthesis,
-            Action::Groundwork,
-            Action::PreparatoryTouch,
-            Action::Innovation,
-            Action::BasicTouch,
-            Action::StandardTouch,
-        ],
-    );
-    assert_eq!(result, 4004);
-}
-
-#[test]
-fn test_adversarial_03() {
-    let settings = Settings {
-        max_cp: 617,
-        max_durability: 60,
-        max_progress: 2120,
-        max_quality: 5000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(
-        settings,
-        &[
-            Action::MuscleMemory,
-            Action::Manipulation,
-            Action::Veneration,
-            Action::WasteNot,
-            Action::Groundwork,
-            Action::CarefulSynthesis,
-            Action::Groundwork,
-            Action::PreparatoryTouch,
-            Action::Innovation,
-            Action::BasicTouch,
-            Action::StandardTouch,
-        ],
-    );
-    assert_eq!(result, 3376);
-}
-
-#[test]
-fn test_04() {
-    let settings = Settings {
-        max_cp: 411,
-        max_durability: 60,
-        max_progress: 1990,
-        max_quality: 5000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 2075);
-}
-
-#[test]
-fn test_adversarial_04() {
-    let settings = Settings {
-        max_cp: 411,
-        max_durability: 60,
-        max_progress: 1990,
-        max_quality: 5000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 1888);
-}
-
-#[test]
-fn test_05() {
-    let settings = Settings {
-        max_cp: 450,
-        max_durability: 60,
-        max_progress: 1970,
-        max_quality: 2000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 2000);
-}
-
-#[test]
-fn test_adversarial_05() {
-    let settings = Settings {
-        max_cp: 450,
-        max_durability: 60,
-        max_progress: 1970,
-        max_quality: 2000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 2000);
-}
-
-#[test]
-fn test_06() {
-    let settings = Settings {
-        max_cp: 673,
-        max_durability: 60,
-        max_progress: 2345,
-        max_quality: 8000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 4438);
-}
-
-#[test]
-fn test_adversarial_06() {
-    let settings = Settings {
-        max_cp: 673,
-        max_durability: 60,
-        max_progress: 2345,
-        max_quality: 8000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::MuscleMemory]);
-    assert_eq!(result, 3745);
-}
-
-#[test]
-fn test_07() {
-    let settings = Settings {
-        max_cp: 673,
-        max_durability: 60,
-        max_progress: 2345,
-        max_quality: 8000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::Reflect]);
-    assert_eq!(result, 4449);
-}
-
-#[test]
-fn test_08() {
-    let settings = Settings {
-        max_cp: 32,
-        max_durability: 10,
-        max_progress: 10000,
-        max_quality: 20000,
-        base_progress: 10000,
-        base_quality: 10000,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[Action::PrudentTouch]);
-    assert_eq!(result, 10000);
-}
-
-#[test]
-fn test_09() {
-    let settings = Settings {
-        max_cp: 700,
-        max_durability: 70,
-        max_progress: 2500,
-        max_quality: 40000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 90,
-        allowed_actions: ActionMask::all()
-            .remove(Action::Manipulation)
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[]);
-    assert_eq!(result, 4079);
-}
-
-#[test]
-fn test_10() {
-    let settings = Settings {
-        max_cp: 400,
-        max_durability: 80,
-        max_progress: 1200,
-        max_quality: 24000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 100,
-        allowed_actions: ActionMask::all()
-            .remove(Action::Manipulation)
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[]);
-    assert_eq!(result, 3929);
-}
-
-#[test]
-fn test_11() {
-    let settings = Settings {
-        max_cp: 320,
-        max_durability: 80,
-        max_progress: 1600,
-        max_quality: 24000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 100,
-        allowed_actions: ActionMask::all()
-            .remove(Action::Manipulation)
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: false,
-        backload_progress: false,
-    };
-    let result = solve(settings, &[]);
-    assert_eq!(result, 2481);
 }
 
 #[test]
@@ -474,55 +38,22 @@ fn test_manipulation_refund() {
     assert_eq!(result, 4975);
 }
 
-fn random_effects(settings: &Settings) -> Effects {
-    Effects::new()
-        .with_inner_quiet(rand::rng().random_range(0..=10))
-        .with_great_strides(rand::rng().random_range(0..=3))
-        .with_innovation(rand::rng().random_range(0..=4))
-        .with_veneration(rand::rng().random_range(0..=4))
-        .with_waste_not(rand::rng().random_range(0..=8))
-        .with_manipulation(rand::rng().random_range(0..=8))
-        .with_quick_innovation_available(rand::random())
-        .with_adversarial_guard(if settings.adversarial {
-            rand::random()
-        } else {
-            false
-        })
-        .with_allow_quality_actions(if settings.backload_progress {
-            rand::random()
-        } else {
-            true
-        })
-}
-
-fn random_state(settings: &Settings) -> SimulationState {
-    SimulationState {
-        cp: rand::rng().random_range(0..=settings.max_cp),
-        durability: rand::rng().random_range(1..=(settings.max_durability / 5)) * 5,
-        progress: rand::rng().random_range(0..u32::from(settings.max_progress)),
-        quality: 0,
-        unreliable_quality: 0,
-        effects: random_effects(settings),
-    }
-    .try_into()
-    .unwrap()
-}
-
-/// Test that the upper-bound solver is monotonic,
-/// i.e. the quality UB of a state is never less than the quality UB of any of its children.
-fn monotonic_fuzz_check(simulator_settings: Settings) {
-    let solver_settings = SolverSettings { simulator_settings };
+/// Test that the QualityUbSolver is consistent and admissible.
+/// It is consistent if the step-lb of a parent state is never greater than the step-lb of a child state.
+/// It is admissible if the quality-ub of a state is never less than the quality of a reachable final state.
+fn check_consistency(solver_settings: SolverSettings) {
     let mut solver = QualityUbSolver::new(solver_settings, Default::default());
     solver.precompute();
+    let mut rng = rand::rng();
     for _ in 0..100000 {
-        let state = random_state(&simulator_settings);
+        let state = random_state(&solver_settings, &mut rng);
         let state_upper_bound = solver.quality_upper_bound(state).unwrap();
         for action in FULL_SEARCH_ACTIONS {
             let child_upper_bound = match use_action_combo(&solver_settings, state, *action) {
-                Ok(child) => match child.is_final(&simulator_settings) {
+                Ok(child) => match child.is_final(&solver_settings.simulator_settings) {
                     false => solver.quality_upper_bound(child).unwrap(),
-                    true if child.progress >= u32::from(simulator_settings.max_progress) => {
-                        std::cmp::min(u32::from(simulator_settings.max_quality), child.quality)
+                    true if child.progress >= u32::from(solver_settings.max_progress()) => {
+                        std::cmp::min(u32::from(solver_settings.max_quality()), child.quality)
                     }
                     true => 0,
                 },
@@ -536,54 +67,23 @@ fn monotonic_fuzz_check(simulator_settings: Settings) {
     }
 }
 
-#[test]
-fn test_monotonic_normal_sim() {
-    let settings = Settings {
-        max_cp: 360,
-        max_durability: 70,
-        max_progress: 1000,
-        max_quality: 20000,
+#[test_case::test_matrix(
+    [20, 60, 80],
+    [REGULAR_ACTIONS, NO_MANIPULATION, WITH_SPECIALIST_ACTIONS]
+)]
+fn consistency(max_durability: u16, allowed_actions: ActionMask) {
+    let simulator_settings = Settings {
+        max_progress: 2000,
+        max_quality: 2000,
+        max_durability,
+        max_cp: 1000,
         base_progress: 100,
         base_quality: 100,
         job_level: 100,
-        allowed_actions: ActionMask::all(),
+        allowed_actions,
         adversarial: false,
         backload_progress: false,
     };
-    monotonic_fuzz_check(settings);
-}
-
-#[test]
-fn test_monotonic_backload_progress_sim() {
-    let settings = Settings {
-        max_cp: 360,
-        max_durability: 70,
-        max_progress: 1000,
-        max_quality: 20000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 100,
-        allowed_actions: ActionMask::all(),
-        adversarial: false,
-        backload_progress: true,
-    };
-    monotonic_fuzz_check(settings);
-}
-
-#[ignore = "Adversarial mode is not monotonic due to unreliable quality rounding"]
-#[test]
-fn test_monotonic_adversarial_sim() {
-    let settings = Settings {
-        max_cp: 360,
-        max_durability: 70,
-        max_progress: 1000,
-        max_quality: 20000,
-        base_progress: 100,
-        base_quality: 100,
-        job_level: 100,
-        allowed_actions: ActionMask::all(),
-        adversarial: true,
-        backload_progress: false,
-    };
-    monotonic_fuzz_check(settings);
+    let solver_settings = SolverSettings { simulator_settings };
+    check_consistency(solver_settings);
 }

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -1,4 +1,3 @@
-use expect_test::expect;
 use rand::Rng;
 use raphael_sim::*;
 
@@ -473,66 +472,6 @@ fn test_manipulation_refund() {
     };
     let result = solve(settings, &[Action::Manipulation]);
     assert_eq!(result, 4975);
-}
-
-#[test]
-fn test_issue_113() {
-    // Ceremonial Gunblade
-    // 5428/5236/645 + HQ Ceviche + HQ Cunning Tisane
-    let simulator_settings = Settings {
-        max_cp: 768,
-        max_durability: 70,
-        max_progress: 9000,
-        max_quality: 18700,
-        base_progress: 297,
-        base_quality: 288,
-        job_level: 100,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let solver_settings = SolverSettings { simulator_settings };
-    let mut solver = QualityUbSolver::new(solver_settings, Default::default());
-    solver.precompute();
-    let expected_runtime_stats = expect![[r#"
-        QualityUbSolverStats {
-            states: 5766907,
-            pareto_values: 210329518,
-        }
-    "#]];
-    expected_runtime_stats.assert_debug_eq(&solver.runtime_stats());
-}
-
-#[test]
-fn test_issue_118() {
-    let simulator_settings = Settings {
-        max_cp: 614,
-        max_durability: 20,
-        max_progress: 2310,
-        max_quality: 8400,
-        base_progress: 205,
-        base_quality: 240,
-        job_level: 100,
-        allowed_actions: ActionMask::all()
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
-        adversarial: true,
-        backload_progress: false,
-    };
-    let solver_settings = SolverSettings { simulator_settings };
-    let mut solver = QualityUbSolver::new(solver_settings, Default::default());
-    solver.precompute();
-    let expected_runtime_stats = expect![[r#"
-        QualityUbSolverStats {
-            states: 3375064,
-            pareto_values: 36637277,
-        }
-    "#]];
-    expected_runtime_stats.assert_debug_eq(&solver.runtime_stats());
 }
 
 fn random_effects(settings: &Settings) -> Effects {

--- a/raphael-solver/src/test_utils.rs
+++ b/raphael-solver/src/test_utils.rs
@@ -1,0 +1,54 @@
+use raphael_sim::*;
+
+use crate::SolverSettings;
+
+pub const REGULAR_ACTIONS: ActionMask = ActionMask::all()
+    .remove(Action::TrainedEye)
+    .remove(Action::HeartAndSoul)
+    .remove(Action::QuickInnovation);
+pub const NO_MANIPULATION: ActionMask = REGULAR_ACTIONS.remove(Action::Manipulation);
+pub const WITH_SPECIALIST_ACTIONS: ActionMask = REGULAR_ACTIONS
+    .add(Action::HeartAndSoul)
+    .add(Action::QuickInnovation);
+
+fn random_effects(settings: &Settings, rng: &mut impl rand::Rng) -> Effects {
+    let mut effects = Effects::new()
+        .with_inner_quiet(rng.random_range(0..=10))
+        .with_great_strides(rng.random_range(0..=3))
+        .with_innovation(rng.random_range(0..=4))
+        .with_veneration(rng.random_range(0..=4))
+        .with_waste_not(rng.random_range(0..=8))
+        .with_adversarial_guard(rng.random() && settings.adversarial)
+        .with_allow_quality_actions(rng.random() || !settings.backload_progress);
+    if settings.is_action_allowed::<Manipulation>() {
+        effects.set_manipulation(rng.random_range(0..=8));
+    }
+    if settings.is_action_allowed::<TrainedPerfection>() {
+        effects.set_trained_perfection_available(rng.random());
+        effects
+            .set_trained_perfection_active(!effects.trained_perfection_available() && rng.random());
+    }
+    if settings.is_action_allowed::<HeartAndSoul>() {
+        effects.set_heart_and_soul_available(rng.random());
+        effects.set_heart_and_soul_active(!effects.heart_and_soul_available() && rng.random());
+    }
+    if settings.is_action_allowed::<QuickInnovation>() {
+        effects.set_quick_innovation_available(rng.random());
+    }
+    effects
+}
+
+pub fn random_state(settings: &SolverSettings, rng: &mut impl rand::Rng) -> SimulationState {
+    SimulationState {
+        cp: rng.random_range(0..=settings.max_cp()),
+        durability: rng
+            .random_range(1..=settings.max_durability())
+            .next_multiple_of(5),
+        progress: rng.random_range(0..settings.max_progress()),
+        quality: rng.random_range(0..=settings.max_quality()),
+        unreliable_quality: 0,
+        effects: random_effects(&settings.simulator_settings, rng),
+    }
+    .try_into()
+    .unwrap()
+}

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -85,7 +85,8 @@ fn unsolvable() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 0,
+                parallel_states: 0,
+                sequential_states: 0,
                 pareto_values: 0,
             },
             step_lb_stats: StepLbSolverStats {
@@ -135,7 +136,8 @@ fn zero_quality() {
                 pareto_buckets_squared_size_sum: 141,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 63388,
+                parallel_states: 60311,
+                sequential_states: 3077,
                 pareto_values: 172523,
             },
             step_lb_stats: StepLbSolverStats {
@@ -185,7 +187,8 @@ fn max_quality() {
                 pareto_buckets_squared_size_sum: 32640,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 898686,
+                parallel_states: 830760,
+                sequential_states: 67926,
                 pareto_values: 6304450,
             },
             step_lb_stats: StepLbSolverStats {
@@ -232,7 +235,8 @@ fn large_progress_quality_increase() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 413424,
+                parallel_states: 412085,
+                sequential_states: 1339,
                 pareto_values: 411684,
             },
             step_lb_stats: StepLbSolverStats {
@@ -282,7 +286,8 @@ fn backload_progress_single_delicate_synthesis() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 8087,
+                parallel_states: 7906,
+                sequential_states: 181,
                 pareto_values: 7205,
             },
             step_lb_stats: StepLbSolverStats {

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -92,7 +92,8 @@ fn rinascita_3700_3280() {
                 pareto_buckets_squared_size_sum: 967,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1997494,
+                parallel_states: 1899585,
+                sequential_states: 97909,
                 pareto_values: 32767785,
             },
             step_lb_stats: StepLbSolverStats {
@@ -142,7 +143,8 @@ fn pactmaker_3240_3130() {
                 pareto_buckets_squared_size_sum: 125899,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1720207,
+                parallel_states: 1619985,
+                sequential_states: 100222,
                 pareto_values: 25164851,
             },
             step_lb_stats: StepLbSolverStats {
@@ -191,7 +193,8 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 1101,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 3522424,
+                parallel_states: 3267540,
+                sequential_states: 254884,
                 pareto_values: 52901313,
             },
             step_lb_stats: StepLbSolverStats {
@@ -241,7 +244,8 @@ fn diadochos_4021_3660() {
                 pareto_buckets_squared_size_sum: 7951,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1857804,
+                parallel_states: 1759785,
+                sequential_states: 98019,
                 pareto_values: 33337539,
             },
             step_lb_stats: StepLbSolverStats {
@@ -291,7 +295,8 @@ fn indagator_3858_4057() {
                 pareto_buckets_squared_size_sum: 46094,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 2022395,
+                parallel_states: 1924050,
+                sequential_states: 98345,
                 pareto_values: 33757173,
             },
             step_lb_stats: StepLbSolverStats {
@@ -341,7 +346,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_buckets_squared_size_sum: 4300260,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1891566,
+                parallel_states: 1793778,
+                sequential_states: 97788,
                 pareto_values: 36452805,
             },
             step_lb_stats: StepLbSolverStats {
@@ -393,7 +399,8 @@ fn stuffed_peppers_2() {
                 pareto_buckets_squared_size_sum: 851424,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1887532,
+                parallel_states: 1793778,
+                sequential_states: 93754,
                 pareto_values: 36307624,
             },
             step_lb_stats: StepLbSolverStats {
@@ -444,7 +451,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 318868,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 3861239,
+                parallel_states: 3574930,
+                sequential_states: 286309,
                 pareto_values: 76805356,
             },
             step_lb_stats: StepLbSolverStats {
@@ -495,7 +503,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_buckets_squared_size_sum: 1668192,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 3906985,
+                parallel_states: 3713303,
+                sequential_states: 193682,
                 pareto_values: 75578405,
             },
             step_lb_stats: StepLbSolverStats {
@@ -545,7 +554,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_buckets_squared_size_sum: 688,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1530982,
+                parallel_states: 1524663,
+                sequential_states: 6319,
                 pareto_values: 22678028,
             },
             step_lb_stats: StepLbSolverStats {
@@ -595,7 +605,8 @@ fn black_star_4048_3997() {
                 pareto_buckets_squared_size_sum: 390274,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1364169,
+                parallel_states: 1354365,
+                sequential_states: 9804,
                 pareto_values: 7047900,
             },
             step_lb_stats: StepLbSolverStats {
@@ -645,7 +656,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_buckets_squared_size_sum: 2257854,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1567808,
+                parallel_states: 1527705,
+                sequential_states: 40103,
                 pareto_values: 10548959,
             },
             step_lb_stats: StepLbSolverStats {
@@ -695,7 +707,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_buckets_squared_size_sum: 824,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1704132,
+                parallel_states: 1702908,
+                sequential_states: 1224,
                 pareto_values: 17986508,
             },
             step_lb_stats: StepLbSolverStats {
@@ -745,7 +758,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_buckets_squared_size_sum: 5056,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1725882,
+                parallel_states: 1723878,
+                sequential_states: 2004,
                 pareto_values: 15649784,
             },
             step_lb_stats: StepLbSolverStats {
@@ -795,7 +809,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_buckets_squared_size_sum: 515951,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 2133674,
+                parallel_states: 2115694,
+                sequential_states: 17980,
                 pareto_values: 31413523,
             },
             step_lb_stats: StepLbSolverStats {
@@ -845,7 +860,8 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_buckets_squared_size_sum: 39842952,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 2281658,
+                parallel_states: 2025537,
+                sequential_states: 256121,
                 pareto_values: 23980771,
             },
             step_lb_stats: StepLbSolverStats {

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -853,16 +853,16 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 594271,
+            finish_states: 564208,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 166658,
-                dropped_nodes: 421345,
-                pareto_buckets_squared_size_sum: 39842952,
+                processed_nodes: 147786,
+                dropped_nodes: 365831,
+                pareto_buckets_squared_size_sum: 34054442,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 2025537,
-                sequential_states: 256121,
-                pareto_values: 23980771,
+                parallel_states: 1824780,
+                sequential_states: 196403,
+                pareto_values: 24755170,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 361555,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -92,7 +92,8 @@ fn rinascita_3700_3280() {
                 pareto_buckets_squared_size_sum: 8399,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1992645,
+                parallel_states: 1876488,
+                sequential_states: 116157,
                 pareto_values: 45877967,
             },
             step_lb_stats: StepLbSolverStats {
@@ -142,7 +143,8 @@ fn pactmaker_3240_3130() {
                 pareto_buckets_squared_size_sum: 31706,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1717054,
+                parallel_states: 1600168,
+                sequential_states: 116886,
                 pareto_values: 35029305,
             },
             step_lb_stats: StepLbSolverStats {
@@ -191,7 +193,8 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 1101,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 3512259,
+                parallel_states: 3225234,
+                sequential_states: 287025,
                 pareto_values: 73817062,
             },
             step_lb_stats: StepLbSolverStats {
@@ -241,7 +244,8 @@ fn diadochos_4021_3660() {
                 pareto_buckets_squared_size_sum: 13256,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1856817,
+                parallel_states: 1738328,
+                sequential_states: 118489,
                 pareto_values: 46578947,
             },
             step_lb_stats: StepLbSolverStats {
@@ -291,7 +295,8 @@ fn indagator_3858_4057() {
                 pareto_buckets_squared_size_sum: 382,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 2018574,
+                parallel_states: 1900666,
+                sequential_states: 117908,
                 pareto_values: 46676861,
             },
             step_lb_stats: StepLbSolverStats {
@@ -341,7 +346,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_buckets_squared_size_sum: 70342159,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1902738,
+                parallel_states: 1780340,
+                sequential_states: 122398,
                 pareto_values: 48797927,
             },
             step_lb_stats: StepLbSolverStats {
@@ -393,7 +399,8 @@ fn stuffed_peppers_2() {
                 pareto_buckets_squared_size_sum: 9996352,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1903042,
+                parallel_states: 1780340,
+                sequential_states: 122702,
                 pareto_values: 48602222,
             },
             step_lb_stats: StepLbSolverStats {
@@ -444,7 +451,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 961604,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 3891589,
+                parallel_states: 3541414,
+                sequential_states: 350175,
                 pareto_values: 101975636,
             },
             step_lb_stats: StepLbSolverStats {
@@ -495,7 +503,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_buckets_squared_size_sum: 18751495,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 3972942,
+                parallel_states: 3713640,
+                sequential_states: 259302,
                 pareto_values: 100957172,
             },
             step_lb_stats: StepLbSolverStats {
@@ -545,7 +554,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_buckets_squared_size_sum: 209669,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1531018,
+                parallel_states: 1514382,
+                sequential_states: 16636,
                 pareto_values: 27021469,
             },
             step_lb_stats: StepLbSolverStats {
@@ -595,7 +605,8 @@ fn black_star_4048_3997() {
                 pareto_buckets_squared_size_sum: 15150,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1346442,
+                parallel_states: 1337664,
+                sequential_states: 8778,
                 pareto_values: 7817546,
             },
             step_lb_stats: StepLbSolverStats {
@@ -645,7 +656,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_buckets_squared_size_sum: 77195,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1524205,
+                parallel_states: 1510763,
+                sequential_states: 13442,
                 pareto_values: 12436758,
             },
             step_lb_stats: StepLbSolverStats {
@@ -695,7 +707,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_buckets_squared_size_sum: 100,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1700326,
+                parallel_states: 1690536,
+                sequential_states: 9790,
                 pareto_values: 20254488,
             },
             step_lb_stats: StepLbSolverStats {
@@ -745,7 +758,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_buckets_squared_size_sum: 29510,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 1716689,
+                parallel_states: 1711260,
+                sequential_states: 5429,
                 pareto_values: 17523599,
             },
             step_lb_stats: StepLbSolverStats {
@@ -795,7 +809,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_buckets_squared_size_sum: 41020,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 2112472,
+                parallel_states: 2096892,
+                sequential_states: 15580,
                 pareto_values: 37998717,
             },
             step_lb_stats: StepLbSolverStats {
@@ -845,7 +860,8 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_buckets_squared_size_sum: 186147222,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 2042647,
+                parallel_states: 1775123,
+                sequential_states: 267524,
                 pareto_values: 34781645,
             },
             step_lb_stats: StepLbSolverStats {
@@ -892,7 +908,8 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
                 pareto_buckets_squared_size_sum: 221587,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 5205402,
+                parallel_states: 3790384,
+                sequential_states: 1415018,
                 pareto_values: 73874945,
             },
             step_lb_stats: StepLbSolverStats {
@@ -942,7 +959,8 @@ fn ceviche_4900_4800_no_quality() {
                 pareto_buckets_squared_size_sum: 37,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 25637,
+                parallel_states: 25637,
+                sequential_states: 0,
                 pareto_values: 25597,
             },
             step_lb_stats: StepLbSolverStats {

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -853,21 +853,21 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 867728,
+            finish_states: 850066,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1887006,
-                dropped_nodes: 12371425,
-                pareto_buckets_squared_size_sum: 186147222,
+                processed_nodes: 1758190,
+                dropped_nodes: 11419861,
+                pareto_buckets_squared_size_sum: 173684277,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1775123,
-                sequential_states: 267524,
-                pareto_values: 34781645,
+                parallel_states: 1804353,
+                sequential_states: 204768,
+                pareto_values: 35422963,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 386882,
-                sequential_states: 24974,
-                pareto_values: 6100754,
+                sequential_states: 24985,
+                pareto_values: 6100839,
             },
         }
     "#]];
@@ -901,16 +901,16 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 278336,
+            finish_states: 251474,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 20519,
-                dropped_nodes: 35735,
-                pareto_buckets_squared_size_sum: 221587,
+                processed_nodes: 17166,
+                dropped_nodes: 35034,
+                pareto_buckets_squared_size_sum: 182325,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3790384,
-                sequential_states: 1415018,
-                pareto_values: 73874945,
+                parallel_states: 3887914,
+                sequential_states: 1122842,
+                pareto_values: 73566066,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -104,7 +104,8 @@ fn stuffed_peppers() {
                 pareto_buckets_squared_size_sum: 1172823,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 4722074,
+                parallel_states: 4687721,
+                sequential_states: 34353,
                 pareto_values: 77746538,
             },
             step_lb_stats: StepLbSolverStats {
@@ -156,7 +157,8 @@ fn test_rare_tacos_2() {
                 pareto_buckets_squared_size_sum: 143370684,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 5030738,
+                parallel_states: 4687721,
+                sequential_states: 343017,
                 pareto_values: 135274246,
             },
             step_lb_stats: StepLbSolverStats {
@@ -209,7 +211,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
                 pareto_buckets_squared_size_sum: 463009,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 3772842,
+                parallel_states: 3634469,
+                sequential_states: 138373,
                 pareto_values: 33011766,
             },
             step_lb_stats: StepLbSolverStats {
@@ -259,7 +262,8 @@ fn test_indagator_3858_4057() {
                 pareto_buckets_squared_size_sum: 99526,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 5310554,
+                parallel_states: 4975741,
+                sequential_states: 334813,
                 pareto_values: 125659412,
             },
             step_lb_stats: StepLbSolverStats {
@@ -310,13 +314,120 @@ fn test_rare_tacos_4628_4410() {
                 pareto_buckets_squared_size_sum: 23891886,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states: 5298836,
+                parallel_states: 4962902,
+                sequential_states: 335934,
                 pareto_values: 151000601,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 420784,
                 sequential_states: 31396,
                 pareto_values: 8949978,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
+}
+
+#[test]
+fn issue_113() {
+    // https://github.com/KonaeAkira/raphael-rs/issues/113
+    // Ceremonial Gunblade
+    // 5428/5236/645 + HQ Ceviche + HQ Cunning Tisane
+    let simulator_settings = Settings {
+        max_cp: 768,
+        max_durability: 70,
+        max_progress: 9000,
+        max_quality: 18700,
+        base_progress: 297,
+        base_quality: 288,
+        job_level: 100,
+        allowed_actions: ActionMask::all()
+            .remove(Action::TrainedEye)
+            .remove(Action::HeartAndSoul)
+            .remove(Action::QuickInnovation),
+        adversarial: true,
+        backload_progress: false,
+    };
+    let solver_settings = SolverSettings { simulator_settings };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 14070,
+                steps: 33,
+                duration: 93,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 1802668,
+            search_queue_stats: SearchQueueStats {
+                processed_nodes: 689654,
+                dropped_nodes: 2387671,
+                pareto_buckets_squared_size_sum: 23983773,
+            },
+            quality_ub_stats: QualityUbSolverStats {
+                parallel_states: 5766907,
+                sequential_states: 477022,
+                pareto_values: 240066959,
+            },
+            step_lb_stats: StepLbSolverStats {
+                parallel_states: 0,
+                sequential_states: 0,
+                pareto_values: 0,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
+}
+
+#[test]
+fn issue_118() {
+    // https://github.com/KonaeAkira/raphael-rs/issues/118
+    let simulator_settings = Settings {
+        max_cp: 614,
+        max_durability: 20,
+        max_progress: 2310,
+        max_quality: 8400,
+        base_progress: 205,
+        base_quality: 240,
+        job_level: 100,
+        allowed_actions: ActionMask::all()
+            .remove(Action::TrainedEye)
+            .remove(Action::HeartAndSoul)
+            .remove(Action::QuickInnovation),
+        adversarial: true,
+        backload_progress: false,
+    };
+    let solver_settings = SolverSettings { simulator_settings };
+    let expected_score = expect![[r#"
+        Some(
+            SolutionScore {
+                capped_quality: 8400,
+                steps: 19,
+                duration: 52,
+                overflow_quality: 84,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            finish_states: 642232,
+            search_queue_stats: SearchQueueStats {
+                processed_nodes: 1865005,
+                dropped_nodes: 2864681,
+                pareto_buckets_squared_size_sum: 450180034,
+            },
+            quality_ub_stats: QualityUbSolverStats {
+                parallel_states: 3375064,
+                sequential_states: 759737,
+                pareto_values: 48206571,
+            },
+            step_lb_stats: StepLbSolverStats {
+                parallel_states: 258314,
+                sequential_states: 17995,
+                pareto_values: 2876218,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -413,21 +413,21 @@ fn issue_118() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 642232,
+            finish_states: 551297,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1865005,
-                dropped_nodes: 2864681,
-                pareto_buckets_squared_size_sum: 450180034,
+                processed_nodes: 1078966,
+                dropped_nodes: 1735775,
+                pareto_buckets_squared_size_sum: 205942420,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3375064,
-                sequential_states: 759737,
-                pareto_values: 48206571,
+                parallel_states: 3389575,
+                sequential_states: 610465,
+                pareto_values: 49377405,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 258314,
-                sequential_states: 17995,
-                pareto_values: 2876218,
+                sequential_states: 17811,
+                pareto_values: 2875147,
             },
         }
     "#]];


### PR DESCRIPTION
The search space compression of the `QualityUbSolver` works by removing the durability attribute from states, and instead allows for "magicaly" restoring durability on-demand via CP.

The bug is that the original `max_durability` value is used when converting from `ReducedState` to `SimulationState`, causing some action combos to result in invalid states, even though there is enough CP to "magically" restore durability to make the actions succeed.

Also added more consistency fuzz checks for `QualityUbSolver` and track parallel/sequential states separately.