### PR TITLE
Add options to load rotation when initiating solve and load recipe & consumables from saved rotations

### DIFF
--- a/raphael-data/src/lib.rs
+++ b/raphael-data/src/lib.rs
@@ -41,7 +41,7 @@ pub struct RecipeLevel {
     pub quality_mod: u32,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CustomRecipeOverrides {
     pub max_progress_override: u16,

--- a/src/app.rs
+++ b/src/app.rs
@@ -440,6 +440,11 @@ impl eframe::App for MacroSolverApp {
                 self.locale,
                 &mut self.saved_rotations_data,
                 &mut self.actions,
+                &mut self.crafter_config,
+                &mut self.recipe_config,
+                &mut self.custom_recipe_overrides_config,
+                &mut self.selected_food,
+                &mut self.selected_potion,
             ));
         });
     }
@@ -513,6 +518,7 @@ impl MacroSolverApp {
                             .unwrap_or("Unknown item".to_owned()),
                             self.actions.clone(),
                             &self.recipe_config.recipe,
+                            &self.custom_recipe_overrides_config,
                             game_settings,
                             initial_quality,
                             self.solver_config
@@ -521,6 +527,7 @@ impl MacroSolverApp {
                             self.selected_food,
                             self.selected_potion,
                             &self.crafter_config,
+                            &self.solver_config,
                         ));
                     } else {
                         self.solver_error = exception;

--- a/src/app.rs
+++ b/src/app.rs
@@ -511,16 +511,6 @@ impl MacroSolverApp {
                         );
                         game_settings.adversarial = self.solver_config.adversarial;
                         game_settings.backload_progress = self.solver_config.backload_progress;
-                        let initial_quality = match self.recipe_config.quality_source {
-                            QualitySource::HqMaterialList(hq_materials) => {
-                                raphael_data::get_initial_quality(
-                                    *self.crafter_config.active_stats(),
-                                    self.recipe_config.recipe,
-                                    hq_materials,
-                                )
-                            }
-                            QualitySource::Value(quality) => quality,
-                        };
                         self.saved_rotations_data.add_solved_rotation(Rotation::new(
                             raphael_data::get_item_name(
                                 self.recipe_config.recipe.item_id,
@@ -529,17 +519,13 @@ impl MacroSolverApp {
                             )
                             .unwrap_or("Unknown item".to_owned()),
                             self.actions.clone(),
-                            &self.recipe_config.recipe,
+                            &self.recipe_config,
                             &self.custom_recipe_overrides_config,
-                            game_settings,
-                            initial_quality,
-                            self.solver_config
-                                .quality_target
-                                .get_target(game_settings.max_quality),
+                            &game_settings,
+                            &self.solver_config,
                             self.selected_food,
                             self.selected_potion,
                             &self.crafter_config,
-                            &self.solver_config,
                         ));
                     } else {
                         self.solver_error = exception;
@@ -1104,7 +1090,7 @@ impl MacroSolverApp {
             && let Some(actions) = self.saved_rotations_data.find_solved_rotation(
                 &game_settings,
                 initial_quality,
-                target_quality,
+                &self.solver_config,
             )
         {
             let mut solver_events = self.solver_events.lock().unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ impl Default for AppConfig {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct CustomRecipeOverridesConfiguration {
     pub use_custom_recipe: bool,
     pub custom_recipe_overrides: CustomRecipeOverrides,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub use app::MacroSolverApp;
 
 mod config;
 mod thread_pool;
+mod util;
 mod widgets;
 
 #[cfg(target_arch = "wasm32")]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,46 @@
+use raphael_data::Consumable;
+
+use crate::{
+    app::SolverConfig,
+    config::{
+        CrafterConfig, CustomRecipeOverridesConfiguration, QualitySource, RecipeConfiguration,
+    },
+};
+
+pub fn get_initial_quality(
+    recipe_config: &RecipeConfiguration,
+    crafter_config: &CrafterConfig,
+) -> u16 {
+    match recipe_config.quality_source {
+        QualitySource::HqMaterialList(hq_materials) => raphael_data::get_initial_quality(
+            *crafter_config.active_stats(),
+            recipe_config.recipe,
+            hq_materials,
+        ),
+        QualitySource::Value(quality) => quality,
+    }
+}
+
+pub fn get_game_settings(
+    recipe_config: &RecipeConfiguration,
+    custom_recipe_overrides_config: &CustomRecipeOverridesConfiguration,
+    solver_config: &SolverConfig,
+    crafter_config: &CrafterConfig,
+    selected_food: Option<Consumable>,
+    selected_potion: Option<Consumable>,
+) -> raphael_sim::Settings {
+    let mut game_settings = raphael_data::get_game_settings(
+        recipe_config.recipe,
+        match custom_recipe_overrides_config.use_custom_recipe {
+            true => Some(custom_recipe_overrides_config.custom_recipe_overrides),
+            false => None,
+        },
+        *crafter_config.active_stats(),
+        selected_food,
+        selected_potion,
+    );
+
+    game_settings.adversarial = solver_config.adversarial;
+    game_settings.backload_progress = solver_config.backload_progress;
+    game_settings
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -23,6 +23,8 @@ mod item_name_label;
 pub use item_name_label::ItemNameLabel;
 
 mod saved_rotations;
-pub use saved_rotations::{Rotation, SavedRotationsData, SavedRotationsWidget};
+pub use saved_rotations::{
+    Rotation, SavedRotationsConfig, SavedRotationsData, SavedRotationsWidget,
+};
 
 mod util;

--- a/src/widgets/saved_rotations.rs
+++ b/src/widgets/saved_rotations.rs
@@ -184,7 +184,7 @@ impl std::fmt::Display for SavedRotationLoadOperation {
             SavedRotationLoadOperation::LoadRotation => "Load rotation",
             SavedRotationLoadOperation::LoadRotationRecipe => "Load rotation & recipe",
             SavedRotationLoadOperation::LoadRotationRecipeConsumables => {
-                "Load rotation, recipe, & consumables"
+                "Load rotation, recipe & consumables"
             }
         };
         write!(f, "{}", output_str)
@@ -589,7 +589,7 @@ impl egui::Widget for SavedRotationsWidget<'_> {
                     ui.add(
                         egui::Label::new(
                             egui::RichText::new(
-                                "⚠ Rotations saved before v0.20.3 do not contain the necessary information to uniquely identify the recipe data.",
+                                "⚠ Rotations saved before v0.20.3 do not contain the necessary information to uniquely identify the recipe.",
                             )
                             .small()
                             .color(ui.visuals().warn_fg_color),
@@ -640,12 +640,18 @@ impl egui::Widget for SavedRotationsWidget<'_> {
                 ui.group(|ui| {
                     ui.horizontal(|ui| {
                         ui.label(egui::RichText::new("Solve history").strong());
-                        ui.label(format!("({}/", self.rotations.solve_history.len(),));
-                        ui.add(
-                            egui::DragValue::new(&mut self.rotations.max_history_size)
-                                .range(DEFAULT_MAX_HISTORY_SIZE..=200),
-                        );
-                        ui.label(")");
+                        ui.horizontal(|ui| {
+                            ui.style_mut().spacing.item_spacing.x = 3.0;
+                            ui.label("(");
+                            ui.add_enabled(false, egui::DragValue::new(&mut self.rotations.solve_history.len()));
+                            ui.label("/");
+                            ui.add(
+                                egui::DragValue::new(&mut self.rotations.max_history_size)
+                                    .range(DEFAULT_MAX_HISTORY_SIZE..=200),
+                            );
+                            ui.label(")");
+                        });
+
 
                         if self.rotations.solve_history.len() > self.rotations.max_history_size {
                             ui.add(

--- a/src/widgets/saved_rotations.rs
+++ b/src/widgets/saved_rotations.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     app::SolverConfig,
-    config::{CrafterConfig, CustomRecipeOverridesConfiguration, RecipeConfiguration},
+    config::{
+        CrafterConfig, CustomRecipeOverridesConfiguration, QualitySource, RecipeConfiguration,
+    },
 };
 
 use super::util;
@@ -393,7 +395,10 @@ impl<'a> RotationWidget<'a> {
             match recipe_configuration {
                 RecipeInputConfiguration::NormalRecipe(recipe_id) => {
                     if let Some(recipe) = raphael_data::RECIPES.get(recipe_id) {
-                        self.recipe_config.recipe = *recipe;
+                        *self.recipe_config = RecipeConfiguration {
+                            recipe: *recipe,
+                            quality_source: QualitySource::HqMaterialList([0; 6]),
+                        };
                         self.crafter_config.selected_job = self.rotation.job_id;
                         self.custom_recipe_overrides_config.use_custom_recipe = false;
                     } else {
@@ -401,7 +406,10 @@ impl<'a> RotationWidget<'a> {
                     }
                 }
                 RecipeInputConfiguration::CustomRecipe(recipe, custom_recipe_overrides_config) => {
-                    self.recipe_config.recipe = *recipe;
+                    *self.recipe_config = RecipeConfiguration {
+                        recipe: *recipe,
+                        quality_source: QualitySource::Value(0),
+                    };
                     *self.custom_recipe_overrides_config = *custom_recipe_overrides_config;
                     self.crafter_config.selected_job = self.rotation.job_id;
                 }
@@ -410,7 +418,10 @@ impl<'a> RotationWidget<'a> {
             if let Some(recipe) = raphael_data::RECIPES.values().find(|recipe| {
                 recipe.item_id == self.rotation.item && recipe.job_id == self.rotation.job_id
             }) {
-                self.recipe_config.recipe = *recipe;
+                *self.recipe_config = RecipeConfiguration {
+                    recipe: *recipe,
+                    quality_source: QualitySource::HqMaterialList([0; 6]),
+                };
                 self.crafter_config.selected_job = self.rotation.job_id;
                 self.custom_recipe_overrides_config.use_custom_recipe = false;
             } else {

--- a/src/widgets/saved_rotations.rs
+++ b/src/widgets/saved_rotations.rs
@@ -60,7 +60,11 @@ pub struct SolverInputConfiguration {
 }
 
 impl SolverInputConfiguration {
-    pub fn new(game_settings: &Settings, initial_quality: u16, solver_config: &SolverConfig) -> Self {
+    pub fn new(
+        game_settings: &Settings,
+        initial_quality: u16,
+        solver_config: &SolverConfig,
+    ) -> Self {
         Self {
             game_settings: *game_settings,
             initial_quality,
@@ -108,16 +112,7 @@ impl Rotation {
                 false => "",
             },
         );
-        let initial_quality = match recipe_config.quality_source {
-            QualitySource::HqMaterialList(hq_materials) => {
-                raphael_data::get_initial_quality(
-                    *crafter_config.active_stats(),
-                    recipe_config.recipe,
-                    hq_materials,
-                )
-            }
-            QualitySource::Value(quality) => quality,
-        };
+        let initial_quality = crate::util::get_initial_quality(&recipe_config, &crafter_config);
         Self {
             unique_id: generate_unique_rotation_id(),
             name: name.into(),

--- a/src/widgets/saved_rotations.rs
+++ b/src/widgets/saved_rotations.rs
@@ -218,20 +218,18 @@ fn default_max_history_size() -> usize {
 
 impl SavedRotationsData {
     pub fn add_solved_rotation(&mut self, rotation: Rotation) {
-        let rotation_to_push_front = if let Some(index) = self
+        if let Some(index) = self
             .solve_history
             .iter()
             .position(|saved_rotation| *saved_rotation == rotation)
         {
-            self.solve_history.remove(index).unwrap()
-        } else {
-            rotation
-        };
+            self.solve_history.remove(index);
+        }
 
         while self.solve_history.len() >= self.max_history_size {
             self.solve_history.pop_back();
         }
-        self.solve_history.push_front(rotation_to_push_front);
+        self.solve_history.push_front(rotation);
     }
 
     pub fn find_solved_rotation(


### PR DESCRIPTION
Adds a few new options for ways in which the saved rotations, i.e. the saved macros and solve history, can be used.

**Added functionality:**
* Loading saved rotations when a matching one is already part of the saved rotations. By default, this is turned off and rotations are only loaded if they were generated from the current solver version
* Loading recipe and consumables (food/potions) when loading a saved rotation is loaded. This can be done by either right-clicking the "Load"-Button or by selecting one of the operations in the (newly added) settings
* Changing the number of rotations in the history
* Solving the same configuration multiple times no longer adds duplicate rotations to the history

To be able to load custom recipes the relevant data is saved in the `Rotation` struct, which sort of addresses #121, although the UI is not really suited for that use case.

**Caveats:**
* The existing `Rotation` struct is extended to avoid having the saved rotations reset. This comes with some downsides:
  1. The struct's size is quite large, 264 bytes, and some information is redundant/unnecessary if the added members are non-none
  2. Loading the recipe for old saved rotations is done via a search using the `item_id` which, as of 7.21, no longer uniquely identifies a recipe. I chose to still implement this since only a small portion of recipes are affected and added a warning to the settings and context menu
* The saved rotations can theoretically take up a not insignificant portion of the web version's 4GB memory (especially combined with the first previous point). I chose to limit the maximum history size that can be selected to 200 so that it should hopefully not make a real difference (although a user with a bunch of saved macros would see a greater effect and those have always been unlimited)
* The way I extended the UI widget structs is not ideal. I just added a bunch of mutable references. These could probably be consolidated in a single struct (something like a `solver_ui_context`) but I couldn't figure out a way to get it to work

**Preview of the UI additions:**
![image](https://github.com/user-attachments/assets/36a85f02-93fb-450c-86ad-41800ed2119f)
Context menu for an old saved rotation:
![image](https://github.com/user-attachments/assets/0810fbac-b7d5-4b81-ad25-841ad358f5e7)
