### PR TITLE
Reduce number of sequential states for `QualityUbSolver`

### DIFF
--- a/raphael-sim/src/effects.rs
+++ b/raphael-sim/src/effects.rs
@@ -1,7 +1,7 @@
 use crate::{Combo, Settings};
 
 #[bitfield_struct::bitfield(u32, default = false)]
-#[derive(PartialEq, Eq, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Effects {
     #[bits(4)]
     pub inner_quiet: u8,

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -210,8 +210,7 @@ impl QualityUbSolver {
             )));
         }
 
-        let reduced_state =
-            ReducedState::from_simulation_state(state, &self.settings, self.durability_cost);
+        let reduced_state = ReducedState::from_state(state, &self.settings, self.durability_cost);
         let required_progress = self.settings.max_progress() - state.progress;
 
         if let Some(pareto_front) = self.solved_states.get(&reduced_state) {

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -129,7 +129,9 @@ impl QualityUbSolver {
                         && template.effects.quick_innovation_available() == quick_innovation
                 })
                 .collect();
-            for cp in self.durability_cost..=self.settings.max_cp() {
+            // 2 * durability_cost is the minimum CP a state must have to not be considered "final".
+            // See `ReducedState::is_final` for details.
+            for cp in 2 * self.durability_cost..=self.settings.max_cp() {
                 if self.interrupt_signal.is_set() {
                     return;
                 }

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -31,7 +31,10 @@ pub struct QualityUbSolver {
 impl QualityUbSolver {
     pub fn new(mut settings: SolverSettings, interrupt_signal: utils::AtomicFlag) -> Self {
         let durability_cost = durability_cost(&settings.simulator_settings);
-        settings.simulator_settings.max_cp += durability_cost * (settings.max_durability() / 5);
+        settings.simulator_settings.max_cp = {
+            let initial_state = SimulationState::new(&settings.simulator_settings);
+            ReducedState::from_state(initial_state, &settings, durability_cost).cp
+        };
         Self {
             settings,
             interrupt_signal,
@@ -100,6 +103,7 @@ impl QualityUbSolver {
     pub fn precompute(&mut self) {
         assert!(self.solved_states.is_empty());
         let all_templates = self.generate_precompute_templates();
+        dbg!(self.settings.max_cp());
         for (heart_and_soul, quick_innovation) in
             [(false, false), (false, true), (true, false), (true, true)]
         {

--- a/raphael-solver/src/quality_upper_bound_solver/state.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/state.rs
@@ -83,6 +83,11 @@ impl ReducedState {
     }
 
     pub fn is_final(&self, durability_cost: u16) -> bool {
+        // CP = 0 means this state has at most -5 durability.
+        // CP = durability_cost means this state has at most 0 durability.
+        // CP = 2 * durability_cost means this state has at most 5 durability.
+        // Because the smallest unit of durability is 5 (when excluding expert conditions),
+        // we consider a state as "final" if its CP is less than that required for 5 durability.
         self.cp < 2 * durability_cost
     }
 

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -136,9 +136,9 @@ fn zero_quality() {
                 pareto_buckets_squared_size_sum: 141,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 60311,
+                parallel_states: 73282,
                 sequential_states: 3077,
-                pareto_values: 172523,
+                pareto_values: 230745,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -187,9 +187,9 @@ fn max_quality() {
                 pareto_buckets_squared_size_sum: 32640,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 830760,
-                sequential_states: 67926,
-                pareto_values: 6304450,
+                parallel_states: 872628,
+                sequential_states: 44273,
+                pareto_values: 6361343,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 244815,
@@ -235,9 +235,9 @@ fn large_progress_quality_increase() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 412085,
-                sequential_states: 1339,
-                pareto_values: 411684,
+                parallel_states: 515045,
+                sequential_states: 145,
+                pareto_values: 513450,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 120,
@@ -286,9 +286,9 @@ fn backload_progress_single_delicate_synthesis() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 7906,
-                sequential_states: 181,
-                pareto_values: 7205,
+                parallel_states: 31837,
+                sequential_states: 0,
+                pareto_values: 30829,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 116,

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -136,9 +136,9 @@ fn zero_quality() {
                 pareto_buckets_squared_size_sum: 141,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 73282,
+                parallel_states: 60311,
                 sequential_states: 3077,
-                pareto_values: 230745,
+                pareto_values: 220425,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -187,9 +187,9 @@ fn max_quality() {
                 pareto_buckets_squared_size_sum: 32640,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 872628,
+                parallel_states: 830760,
                 sequential_states: 44273,
-                pareto_values: 6361343,
+                pareto_values: 6325079,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 244815,
@@ -235,9 +235,9 @@ fn large_progress_quality_increase() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 537203,
+                parallel_states: 516611,
                 sequential_states: 35,
-                pareto_values: 535498,
+                pareto_values: 516646,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 120,
@@ -286,9 +286,9 @@ fn backload_progress_single_delicate_synthesis() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 31837,
+                parallel_states: 25645,
                 sequential_states: 0,
-                pareto_values: 30829,
+                pareto_values: 25645,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 116,

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -235,9 +235,9 @@ fn large_progress_quality_increase() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 515045,
-                sequential_states: 145,
-                pareto_values: 513450,
+                parallel_states: 537203,
+                sequential_states: 35,
+                pareto_values: 535498,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 120,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -92,9 +92,9 @@ fn rinascita_3700_3280() {
                 pareto_buckets_squared_size_sum: 967,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1941525,
+                parallel_states: 1899585,
                 sequential_states: 68220,
-                pareto_values: 33069324,
+                pareto_values: 33032988,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -143,9 +143,9 @@ fn pactmaker_3240_3130() {
                 pareto_buckets_squared_size_sum: 125899,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1661925,
+                parallel_states: 1619985,
                 sequential_states: 70379,
-                pareto_values: 25454153,
+                pareto_values: 25417817,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -193,9 +193,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 1101,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3435632,
+                parallel_states: 3351752,
                 sequential_states: 133009,
-                pareto_values: 54007777,
+                pareto_values: 53929501,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -244,9 +244,9 @@ fn diadochos_4021_3660() {
                 pareto_buckets_squared_size_sum: 7951,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1801725,
+                parallel_states: 1759785,
                 sequential_states: 68329,
-                pareto_values: 33733632,
+                pareto_values: 33697296,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -295,9 +295,9 @@ fn indagator_3858_4057() {
                 pareto_buckets_squared_size_sum: 46094,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1965990,
+                parallel_states: 1924050,
                 sequential_states: 68577,
-                pareto_values: 33965651,
+                pareto_values: 33929315,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -346,9 +346,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_buckets_squared_size_sum: 4300260,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1916103,
+                parallel_states: 1891638,
                 sequential_states: 19923,
-                pareto_values: 36969606,
+                pareto_values: 36948410,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2318275,
@@ -399,9 +399,9 @@ fn stuffed_peppers_2() {
                 pareto_buckets_squared_size_sum: 851424,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1916103,
+                parallel_states: 1891638,
                 sequential_states: 18196,
-                pareto_values: 37668672,
+                pareto_values: 37647476,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -451,9 +451,9 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 318868,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3926084,
+                parallel_states: 3877154,
                 sequential_states: 34925,
-                pareto_values: 79725423,
+                pareto_values: 79679762,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -503,9 +503,9 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_buckets_squared_size_sum: 1668192,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3965758,
+                parallel_states: 3915267,
                 sequential_states: 37644,
-                pareto_values: 78348312,
+                pareto_values: 78304478,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -554,9 +554,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_buckets_squared_size_sum: 688,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1646988,
+                parallel_states: 1622523,
                 sequential_states: 337,
-                pareto_values: 23270328,
+                pareto_values: 23249132,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1579065,
@@ -605,9 +605,9 @@ fn black_star_4048_3997() {
                 pareto_buckets_squared_size_sum: 390274,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1396305,
+                parallel_states: 1354365,
                 sequential_states: 6155,
-                pareto_values: 7098336,
+                pareto_values: 7062000,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 168003,
@@ -656,9 +656,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_buckets_squared_size_sum: 2257854,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1737405,
+                parallel_states: 1695465,
                 sequential_states: 5317,
-                pareto_values: 10812841,
+                pareto_values: 10776505,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 461630,
@@ -707,9 +707,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_buckets_squared_size_sum: 824,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1825233,
+                parallel_states: 1800768,
                 sequential_states: 281,
-                pareto_values: 18116667,
+                pareto_values: 18095471,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1336246,
@@ -758,9 +758,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_buckets_squared_size_sum: 5056,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1846203,
+                parallel_states: 1821738,
                 sequential_states: 470,
-                pareto_values: 15771206,
+                pareto_values: 15750010,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1118641,
@@ -809,9 +809,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_buckets_squared_size_sum: 515951,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 2255494,
+                parallel_states: 2227534,
                 sequential_states: 4177,
-                pareto_values: 31558424,
+                pareto_values: 31534200,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1556489,
@@ -860,9 +860,9 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_buckets_squared_size_sum: 34054442,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 2034480,
+                parallel_states: 1992540,
                 sequential_states: 22052,
-                pareto_values: 24998237,
+                pareto_values: 24961901,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 361555,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -193,9 +193,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 1101,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3351420,
-                sequential_states: 187207,
-                pareto_values: 53295614,
+                parallel_states: 3435632,
+                sequential_states: 133009,
+                pareto_values: 54007777,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -451,9 +451,9 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 318868,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3819580,
-                sequential_states: 87785,
-                pareto_values: 78195182,
+                parallel_states: 3926084,
+                sequential_states: 34925,
+                pareto_values: 79725423,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -92,9 +92,9 @@ fn rinascita_3700_3280() {
                 pareto_buckets_squared_size_sum: 967,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1899585,
-                sequential_states: 97909,
-                pareto_values: 32767785,
+                parallel_states: 1941525,
+                sequential_states: 68220,
+                pareto_values: 33069324,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -143,9 +143,9 @@ fn pactmaker_3240_3130() {
                 pareto_buckets_squared_size_sum: 125899,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1619985,
-                sequential_states: 100222,
-                pareto_values: 25164851,
+                parallel_states: 1661925,
+                sequential_states: 70379,
+                pareto_values: 25454153,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -193,9 +193,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 1101,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3267540,
-                sequential_states: 254884,
-                pareto_values: 52901313,
+                parallel_states: 3351420,
+                sequential_states: 187207,
+                pareto_values: 53295614,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -244,9 +244,9 @@ fn diadochos_4021_3660() {
                 pareto_buckets_squared_size_sum: 7951,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1759785,
-                sequential_states: 98019,
-                pareto_values: 33337539,
+                parallel_states: 1801725,
+                sequential_states: 68329,
+                pareto_values: 33733632,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -295,9 +295,9 @@ fn indagator_3858_4057() {
                 pareto_buckets_squared_size_sum: 46094,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1924050,
-                sequential_states: 98345,
-                pareto_values: 33757173,
+                parallel_states: 1965990,
+                sequential_states: 68577,
+                pareto_values: 33965651,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -346,9 +346,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_buckets_squared_size_sum: 4300260,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1793778,
-                sequential_states: 97788,
-                pareto_values: 36452805,
+                parallel_states: 1916103,
+                sequential_states: 19923,
+                pareto_values: 36969606,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2318275,
@@ -399,9 +399,9 @@ fn stuffed_peppers_2() {
                 pareto_buckets_squared_size_sum: 851424,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1793778,
-                sequential_states: 93754,
-                pareto_values: 36307624,
+                parallel_states: 1916103,
+                sequential_states: 18196,
+                pareto_values: 37668672,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -451,9 +451,9 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 318868,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3574930,
-                sequential_states: 286309,
-                pareto_values: 76805356,
+                parallel_states: 3819580,
+                sequential_states: 87785,
+                pareto_values: 78195182,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -503,9 +503,9 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_buckets_squared_size_sum: 1668192,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3713303,
-                sequential_states: 193682,
-                pareto_values: 75578405,
+                parallel_states: 3965758,
+                sequential_states: 37644,
+                pareto_values: 78348312,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -554,9 +554,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_buckets_squared_size_sum: 688,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1524663,
-                sequential_states: 6319,
-                pareto_values: 22678028,
+                parallel_states: 1646988,
+                sequential_states: 337,
+                pareto_values: 23270328,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1579065,
@@ -605,9 +605,9 @@ fn black_star_4048_3997() {
                 pareto_buckets_squared_size_sum: 390274,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1354365,
-                sequential_states: 9804,
-                pareto_values: 7047900,
+                parallel_states: 1396305,
+                sequential_states: 6155,
+                pareto_values: 7098336,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 168003,
@@ -656,9 +656,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_buckets_squared_size_sum: 2257854,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1527705,
-                sequential_states: 40103,
-                pareto_values: 10548959,
+                parallel_states: 1737405,
+                sequential_states: 5317,
+                pareto_values: 10812841,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 461630,
@@ -707,9 +707,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_buckets_squared_size_sum: 824,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1702908,
-                sequential_states: 1224,
-                pareto_values: 17986508,
+                parallel_states: 1825233,
+                sequential_states: 281,
+                pareto_values: 18116667,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1336246,
@@ -758,9 +758,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_buckets_squared_size_sum: 5056,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1723878,
-                sequential_states: 2004,
-                pareto_values: 15649784,
+                parallel_states: 1846203,
+                sequential_states: 470,
+                pareto_values: 15771206,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1118641,
@@ -809,9 +809,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_buckets_squared_size_sum: 515951,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 2115694,
-                sequential_states: 17980,
-                pareto_values: 31413523,
+                parallel_states: 2255494,
+                sequential_states: 4177,
+                pareto_values: 31558424,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1556489,
@@ -860,9 +860,9 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_buckets_squared_size_sum: 34054442,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1824780,
-                sequential_states: 196403,
-                pareto_values: 24755170,
+                parallel_states: 2034480,
+                sequential_states: 22052,
+                pareto_values: 24998237,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 361555,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -92,9 +92,9 @@ fn rinascita_3700_3280() {
                 pareto_buckets_squared_size_sum: 8399,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1917936,
+                parallel_states: 1876488,
                 sequential_states: 83356,
-                pareto_values: 46209270,
+                pareto_values: 46173366,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -143,9 +143,9 @@ fn pactmaker_3240_3130() {
                 pareto_buckets_squared_size_sum: 31706,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1641616,
+                parallel_states: 1600168,
                 sequential_states: 84343,
-                pareto_values: 35376875,
+                pareto_values: 35340971,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -193,9 +193,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 1101,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3390156,
+                parallel_states: 3307260,
                 sequential_states: 151491,
-                pareto_values: 74964736,
+                pareto_values: 74887384,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -244,9 +244,9 @@ fn diadochos_4021_3660() {
                 pareto_buckets_squared_size_sum: 13256,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1779776,
+                parallel_states: 1738328,
                 sequential_states: 85663,
-                pareto_values: 47013241,
+                pareto_values: 46977337,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -295,9 +295,9 @@ fn indagator_3858_4057() {
                 pareto_buckets_squared_size_sum: 382,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1942114,
+                parallel_states: 1900666,
                 sequential_states: 85124,
-                pareto_values: 46873194,
+                pareto_values: 46837290,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -346,9 +346,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_buckets_squared_size_sum: 70342159,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1901230,
+                parallel_states: 1877052,
                 sequential_states: 32860,
-                pareto_values: 49153126,
+                pareto_values: 49132182,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
@@ -399,9 +399,9 @@ fn stuffed_peppers_2() {
                 pareto_buckets_squared_size_sum: 9996352,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1901230,
+                parallel_states: 1877052,
                 sequential_states: 31638,
-                pareto_values: 49837324,
+                pareto_values: 49816380,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -451,9 +451,9 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 961604,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3886344,
+                parallel_states: 3837988,
                 sequential_states: 57998,
-                pareto_values: 104208424,
+                pareto_values: 104163302,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -503,9 +503,9 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_buckets_squared_size_sum: 18751495,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3964660,
+                parallel_states: 3914456,
                 sequential_states: 70615,
-                pareto_values: 103469934,
+                pareto_values: 103426352,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -554,9 +554,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_buckets_squared_size_sum: 209669,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1635272,
+                parallel_states: 1611094,
                 sequential_states: 9370,
-                pareto_values: 27445887,
+                pareto_values: 27424943,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1514037,
@@ -605,9 +605,9 @@ fn black_star_4048_3997() {
                 pareto_buckets_squared_size_sum: 15150,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1379112,
+                parallel_states: 1337664,
                 sequential_states: 8531,
-                pareto_values: 7868538,
+                pareto_values: 7832634,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 161900,
@@ -656,9 +656,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_buckets_squared_size_sum: 77195,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1718003,
+                parallel_states: 1676555,
                 sequential_states: 2693,
-                pareto_values: 12704811,
+                pareto_values: 12668907,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 456982,
@@ -707,9 +707,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_buckets_squared_size_sum: 100,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1811426,
+                parallel_states: 1787248,
                 sequential_states: 9710,
-                pareto_values: 20375897,
+                pareto_values: 20354953,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1229899,
@@ -758,9 +758,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_buckets_squared_size_sum: 29510,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1832150,
+                parallel_states: 1807972,
                 sequential_states: 2870,
-                pareto_values: 17641943,
+                pareto_values: 17620999,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1108877,
@@ -809,9 +809,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_buckets_squared_size_sum: 41020,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 2235052,
+                parallel_states: 2207420,
                 sequential_states: 11923,
-                pareto_values: 38135376,
+                pareto_values: 38111440,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1517488,
@@ -860,9 +860,9 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_buckets_squared_size_sum: 173684277,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 2011593,
+                parallel_states: 1970145,
                 sequential_states: 29325,
-                pareto_values: 35654654,
+                pareto_values: 35618750,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 386882,
@@ -908,9 +908,9 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
                 pareto_buckets_squared_size_sum: 182325,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 4945388,
+                parallel_states: 4773260,
                 sequential_states: 183740,
-                pareto_values: 77162082,
+                pareto_values: 77001306,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -959,9 +959,9 @@ fn ceviche_4900_4800_no_quality() {
                 pareto_buckets_squared_size_sum: 37,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 28026,
+                parallel_states: 27690,
                 sequential_states: 0,
-                pareto_values: 27978,
+                pareto_values: 27690,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 7478,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -92,9 +92,9 @@ fn rinascita_3700_3280() {
                 pareto_buckets_squared_size_sum: 8399,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1876488,
-                sequential_states: 116157,
-                pareto_values: 45877967,
+                parallel_states: 1917936,
+                sequential_states: 83356,
+                pareto_values: 46209270,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -143,9 +143,9 @@ fn pactmaker_3240_3130() {
                 pareto_buckets_squared_size_sum: 31706,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1600168,
-                sequential_states: 116886,
-                pareto_values: 35029305,
+                parallel_states: 1641616,
+                sequential_states: 84343,
+                pareto_values: 35376875,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -193,9 +193,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 1101,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3225234,
-                sequential_states: 287025,
-                pareto_values: 73817062,
+                parallel_states: 3308130,
+                sequential_states: 211097,
+                pareto_values: 74100222,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -244,9 +244,9 @@ fn diadochos_4021_3660() {
                 pareto_buckets_squared_size_sum: 13256,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1738328,
-                sequential_states: 118489,
-                pareto_values: 46578947,
+                parallel_states: 1779776,
+                sequential_states: 85663,
+                pareto_values: 47013241,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -295,9 +295,9 @@ fn indagator_3858_4057() {
                 pareto_buckets_squared_size_sum: 382,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1900666,
-                sequential_states: 117908,
-                pareto_values: 46676861,
+                parallel_states: 1942114,
+                sequential_states: 85124,
+                pareto_values: 46873194,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -346,9 +346,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_buckets_squared_size_sum: 70342159,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1780340,
-                sequential_states: 122398,
-                pareto_values: 48797927,
+                parallel_states: 1901230,
+                sequential_states: 32860,
+                pareto_values: 49153126,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
@@ -399,9 +399,9 @@ fn stuffed_peppers_2() {
                 pareto_buckets_squared_size_sum: 9996352,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1780340,
-                sequential_states: 122702,
-                pareto_values: 48602222,
+                parallel_states: 1901230,
+                sequential_states: 31638,
+                pareto_values: 49837324,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -451,9 +451,9 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 961604,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3541414,
-                sequential_states: 350175,
-                pareto_values: 101975636,
+                parallel_states: 3783194,
+                sequential_states: 120228,
+                pareto_values: 102545381,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -503,9 +503,9 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_buckets_squared_size_sum: 18751495,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3713640,
-                sequential_states: 259302,
-                pareto_values: 100957172,
+                parallel_states: 3964660,
+                sequential_states: 70615,
+                pareto_values: 103469934,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -554,9 +554,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_buckets_squared_size_sum: 209669,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1514382,
-                sequential_states: 16636,
-                pareto_values: 27021469,
+                parallel_states: 1635272,
+                sequential_states: 9370,
+                pareto_values: 27445887,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1514037,
@@ -605,9 +605,9 @@ fn black_star_4048_3997() {
                 pareto_buckets_squared_size_sum: 15150,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1337664,
-                sequential_states: 8778,
-                pareto_values: 7817546,
+                parallel_states: 1379112,
+                sequential_states: 8531,
+                pareto_values: 7868538,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 161900,
@@ -656,9 +656,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_buckets_squared_size_sum: 77195,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1510763,
-                sequential_states: 13442,
-                pareto_values: 12436758,
+                parallel_states: 1718003,
+                sequential_states: 2693,
+                pareto_values: 12704811,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 456982,
@@ -707,9 +707,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_buckets_squared_size_sum: 100,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1690536,
-                sequential_states: 9790,
-                pareto_values: 20254488,
+                parallel_states: 1811426,
+                sequential_states: 9710,
+                pareto_values: 20375897,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1229899,
@@ -758,9 +758,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_buckets_squared_size_sum: 29510,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1711260,
-                sequential_states: 5429,
-                pareto_values: 17523599,
+                parallel_states: 1832150,
+                sequential_states: 2870,
+                pareto_values: 17641943,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1108877,
@@ -809,9 +809,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_buckets_squared_size_sum: 41020,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 2096892,
-                sequential_states: 15580,
-                pareto_values: 37998717,
+                parallel_states: 2235052,
+                sequential_states: 11923,
+                pareto_values: 38135376,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1517488,
@@ -860,9 +860,9 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_buckets_squared_size_sum: 173684277,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1804353,
-                sequential_states: 204768,
-                pareto_values: 35422963,
+                parallel_states: 2011593,
+                sequential_states: 29325,
+                pareto_values: 35654654,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 386882,
@@ -908,9 +908,9 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
                 pareto_buckets_squared_size_sum: 182325,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3887914,
-                sequential_states: 1122842,
-                pareto_values: 73566066,
+                parallel_states: 4748554,
+                sequential_states: 324400,
+                pareto_values: 75502097,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -959,9 +959,9 @@ fn ceviche_4900_4800_no_quality() {
                 pareto_buckets_squared_size_sum: 37,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 25637,
+                parallel_states: 27277,
                 sequential_states: 0,
-                pareto_values: 25597,
+                pareto_values: 27237,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 7478,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -193,9 +193,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 1101,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3308130,
-                sequential_states: 211097,
-                pareto_values: 74100222,
+                parallel_states: 3390156,
+                sequential_states: 151491,
+                pareto_values: 74964736,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -451,9 +451,9 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_buckets_squared_size_sum: 961604,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3783194,
-                sequential_states: 120228,
-                pareto_values: 102545381,
+                parallel_states: 3886344,
+                sequential_states: 57998,
+                pareto_values: 104208424,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -908,9 +908,9 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
                 pareto_buckets_squared_size_sum: 182325,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 4748554,
-                sequential_states: 324400,
-                pareto_values: 75502097,
+                parallel_states: 4945388,
+                sequential_states: 183740,
+                pareto_values: 77162082,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -959,9 +959,9 @@ fn ceviche_4900_4800_no_quality() {
                 pareto_buckets_squared_size_sum: 37,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 27277,
+                parallel_states: 28026,
                 sequential_states: 0,
-                pareto_values: 27237,
+                pareto_values: 27978,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 7478,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -104,9 +104,9 @@ fn stuffed_peppers() {
                 pareto_buckets_squared_size_sum: 1172823,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 4687721,
-                sequential_states: 34353,
-                pareto_values: 77746538,
+                parallel_states: 5019836,
+                sequential_states: 13813,
+                pareto_values: 79198339,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1414006,
@@ -157,9 +157,9 @@ fn test_rare_tacos_2() {
                 pareto_buckets_squared_size_sum: 143370684,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 4687721,
-                sequential_states: 343017,
-                pareto_values: 135274246,
+                parallel_states: 5019836,
+                sequential_states: 84338,
+                pareto_values: 137779123,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2225633,
@@ -211,9 +211,9 @@ fn test_mountain_chromite_ingot_no_manipulation() {
                 pareto_buckets_squared_size_sum: 463009,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3634469,
-                sequential_states: 138373,
-                pareto_values: 33011766,
+                parallel_states: 3767315,
+                sequential_states: 79907,
+                pareto_values: 33483499,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 52311,
@@ -262,9 +262,9 @@ fn test_indagator_3858_4057() {
                 pareto_buckets_squared_size_sum: 99526,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 4975741,
-                sequential_states: 334813,
-                pareto_values: 125659412,
+                parallel_states: 5089609,
+                sequential_states: 242241,
+                pareto_values: 126572372,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -314,9 +314,9 @@ fn test_rare_tacos_4628_4410() {
                 pareto_buckets_squared_size_sum: 23891886,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 4962902,
-                sequential_states: 335934,
-                pareto_values: 151000601,
+                parallel_states: 5295017,
+                sequential_states: 81046,
+                pareto_values: 154020473,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 420784,
@@ -368,9 +368,9 @@ fn issue_113() {
                 pareto_buckets_squared_size_sum: 23983773,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 5766907,
-                sequential_states: 477022,
-                pareto_values: 240066959,
+                parallel_states: 6146467,
+                sequential_states: 131800,
+                pareto_values: 242744004,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -420,9 +420,9 @@ fn issue_118() {
                 pareto_buckets_squared_size_sum: 205942420,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3389575,
-                sequential_states: 610465,
-                pareto_values: 49377405,
+                parallel_states: 3958915,
+                sequential_states: 98658,
+                pareto_values: 50363752,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 258314,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -104,9 +104,9 @@ fn stuffed_peppers() {
                 pareto_buckets_squared_size_sum: 1172823,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 5019836,
+                parallel_states: 4953413,
                 sequential_states: 13813,
-                pareto_values: 79198339,
+                pareto_values: 79141772,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1414006,
@@ -157,9 +157,9 @@ fn test_rare_tacos_2() {
                 pareto_buckets_squared_size_sum: 143370684,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 5019836,
+                parallel_states: 4953413,
                 sequential_states: 84338,
-                pareto_values: 137779123,
+                pareto_values: 137722556,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2225633,
@@ -211,9 +211,9 @@ fn test_mountain_chromite_ingot_no_manipulation() {
                 pareto_buckets_squared_size_sum: 463009,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3767315,
+                parallel_states: 3634469,
                 sequential_states: 79907,
-                pareto_values: 33483499,
+                pareto_values: 33370365,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 52311,
@@ -262,9 +262,9 @@ fn test_indagator_3858_4057() {
                 pareto_buckets_squared_size_sum: 99526,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 5089609,
+                parallel_states: 4975741,
                 sequential_states: 242241,
-                pareto_values: 126572372,
+                pareto_values: 126475400,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -314,9 +314,9 @@ fn test_rare_tacos_4628_4410() {
                 pareto_buckets_squared_size_sum: 23891886,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 5295017,
+                parallel_states: 5228594,
                 sequential_states: 81046,
-                pareto_values: 154020473,
+                pareto_values: 153963906,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 420784,
@@ -368,9 +368,9 @@ fn issue_113() {
                 pareto_buckets_squared_size_sum: 23983773,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 6146467,
+                parallel_states: 6070555,
                 sequential_states: 131800,
-                pareto_values: 242744004,
+                pareto_values: 242679356,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -420,9 +420,9 @@ fn issue_118() {
                 pareto_buckets_squared_size_sum: 205942420,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 3958915,
+                parallel_states: 3845047,
                 sequential_states: 98658,
-                pareto_values: 50363752,
+                pareto_values: 50266780,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 258314,


### PR DESCRIPTION
This PR aims to reduce the number of `QualityUbSolver` states that are computed sequentially by computing more states in parallel.

Configurations with `HeartAndSoul` enabled see the most benefit from this PR.