### PR TITLE
Reduce redundant `QualityUbSolver` states & Avoid `MuscleMemory` effect in inner solvers

### DIFF
--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -1,6 +1,6 @@
 use crate::{
     SolverException, SolverSettings,
-    actions::{ActionCombo, FULL_SEARCH_ACTIONS, PROGRESS_ONLY_SEARCH_ACTIONS, use_action_combo},
+    actions::{ActionCombo, FULL_SEARCH_ACTIONS, PROGRESS_ONLY_SEARCH_ACTIONS},
     utils,
 };
 use raphael_sim::*;
@@ -49,7 +49,7 @@ impl QualityUbSolver {
                 settings.max_quality(),
             ),
             durability_cost,
-            largest_progress_increase: find_largest_single_action_progress_increase(&settings),
+            largest_progress_increase: utils::largest_single_action_progress_increase(&settings),
             precomputed_states: 0,
         }
     }
@@ -375,20 +375,6 @@ fn durability_cost(settings: &Settings) -> u16 {
         cost = std::cmp::min(cost, cost_per_five);
     }
     cost
-}
-
-fn find_largest_single_action_progress_increase(settings: &SolverSettings) -> u32 {
-    let state = SimulationState::new(&settings.simulator_settings);
-    assert_eq!(state.progress, 0);
-    PROGRESS_ONLY_SEARCH_ACTIONS
-        .iter()
-        .filter_map(|&action| {
-            use_action_combo(settings, state, action)
-                .ok()
-                .map(|state| state.progress)
-        })
-        .max()
-        .unwrap()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Hash)]

--- a/raphael-solver/src/step_lower_bound_solver/state.rs
+++ b/raphael-solver/src/step_lower_bound_solver/state.rs
@@ -59,7 +59,7 @@ impl ReducedState {
             // this gives a looser bound but decreases the number of states
             effects.set_great_strides(3);
         }
-        effects.set_adversarial_guard(true);
+        effects.set_adversarial_guard(false);
         // Optimize durability
         let durability = {
             let mut usable_durability = u16::from(step_budget.get()) * 20;

--- a/raphael-solver/src/test_utils.rs
+++ b/raphael-solver/src/test_utils.rs
@@ -13,6 +13,7 @@ pub const WITH_SPECIALIST_ACTIONS: ActionMask = REGULAR_ACTIONS
 
 fn random_effects(settings: &Settings, rng: &mut impl rand::Rng) -> Effects {
     let mut effects = Effects::new()
+        .with_muscle_memory(rng.random_range(0..=5))
         .with_inner_quiet(rng.random_range(0..=10))
         .with_great_strides(rng.random_range(0..=3))
         .with_innovation(rng.random_range(0..=4))

--- a/raphael-solver/src/utils/mod.rs
+++ b/raphael-solver/src/utils/mod.rs
@@ -3,6 +3,12 @@ mod pareto_front_builder;
 
 pub use atomic_flag::AtomicFlag;
 pub use pareto_front_builder::{ParetoFrontBuilder, ParetoValue};
+use raphael_sim::*;
+
+use crate::{
+    SolverSettings,
+    actions::{FULL_SEARCH_ACTIONS, use_action_combo},
+};
 
 pub struct ScopedTimer {
     name: &'static str,
@@ -75,4 +81,42 @@ impl<T: Copy> Drop for Backtracking<T> {
     fn drop(&mut self) {
         log::debug!("Backtracking - nodes: {}", self.entries.len());
     }
+}
+
+/// The only way to increase the InnerQuiet effect is to use Quality-increasing actions,
+/// which means that all states with InnerQuiet must have some amount of Quality.
+/// This function finds a lower-bound on the minimum amount of Quality a state with `n` InnerQuiet can have.
+pub fn compute_iq_quality_lut(settings: &SolverSettings) -> [u32; 11] {
+    if settings.simulator_settings.adversarial {
+        // TODO: implement this for adversarial mode
+        return [0; 11];
+    }
+    let mut result = [u32::MAX; 11];
+    result[0] = 0;
+    for iq in 0..10 {
+        let state = SimulationState {
+            cp: 500,
+            durability: 100,
+            progress: 0,
+            quality: 0,
+            unreliable_quality: 0,
+            effects: Effects::new()
+                .with_allow_quality_actions(true)
+                .with_adversarial_guard(true)
+                .with_inner_quiet(iq),
+        };
+        for &action in FULL_SEARCH_ACTIONS {
+            if let Ok(new_state) = use_action_combo(settings, state, action) {
+                let new_iq = new_state.effects.inner_quiet();
+                if new_iq > iq {
+                    let action_quality = new_state.quality;
+                    result[usize::from(new_iq)] = std::cmp::min(
+                        result[usize::from(new_iq)],
+                        result[usize::from(iq)] + action_quality,
+                    );
+                }
+            }
+        }
+    }
+    result
 }

--- a/raphael-solver/src/utils/mod.rs
+++ b/raphael-solver/src/utils/mod.rs
@@ -91,6 +91,13 @@ pub fn compute_iq_quality_lut(settings: &SolverSettings) -> [u32; 11] {
         // TODO: implement this for adversarial mode
         return [0; 11];
     }
+    if settings
+        .simulator_settings
+        .is_action_allowed::<HeartAndSoul>()
+    {
+        // TODO: implement this for heart and soul
+        return [0; 11];
+    }
     let mut result = [u32::MAX; 11];
     result[0] = 0;
     for iq in 0..10 {

--- a/raphael-solver/src/utils/mod.rs
+++ b/raphael-solver/src/utils/mod.rs
@@ -127,3 +127,17 @@ pub fn compute_iq_quality_lut(settings: &SolverSettings) -> [u32; 11] {
     }
     result
 }
+
+pub fn largest_single_action_progress_increase(settings: &SolverSettings) -> u32 {
+    let state = SimulationState::new(&settings.simulator_settings);
+    assert_eq!(state.progress, 0);
+    FULL_SEARCH_ACTIONS
+        .iter()
+        .filter_map(|&action| {
+            use_action_combo(settings, state, action)
+                .ok()
+                .map(|state| state.progress)
+        })
+        .max()
+        .unwrap()
+}

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -187,9 +187,9 @@ fn max_quality() {
                 pareto_buckets_squared_size_sum: 31041,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 423600,
-                sequential_states: 21629,
-                pareto_values: 3172560,
+                parallel_states: 410619,
+                sequential_states: 18234,
+                pareto_values: 3147357,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 244815,
@@ -235,9 +235,9 @@ fn large_progress_quality_increase() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 259207,
+                parallel_states: 33095,
                 sequential_states: 0,
-                pareto_values: 259207,
+                pareto_values: 33095,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 120,
@@ -286,9 +286,9 @@ fn backload_progress_single_delicate_synthesis() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 13083,
+                parallel_states: 9307,
                 sequential_states: 0,
-                pareto_values: 13083,
+                pareto_values: 9307,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 116,

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -187,9 +187,9 @@ fn max_quality() {
                 pareto_buckets_squared_size_sum: 31041,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 410619,
-                sequential_states: 18234,
-                pareto_values: 3147357,
+                parallel_states: 392060,
+                sequential_states: 7255,
+                pareto_values: 3020564,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 244815,
@@ -286,9 +286,9 @@ fn backload_progress_single_delicate_synthesis() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 9307,
+                parallel_states: 7773,
                 sequential_states: 0,
-                pareto_values: 9307,
+                pareto_values: 7773,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 116,

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -137,8 +137,8 @@ fn zero_quality() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 31147,
-                sequential_states: 3000,
-                pareto_values: 117954,
+                sequential_states: 0,
+                pareto_values: 109398,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -183,18 +183,18 @@ fn max_quality() {
             finish_states: 228053,
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 4411,
-                dropped_nodes: 51315,
+                dropped_nodes: 51368,
                 pareto_buckets_squared_size_sum: 31041,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 392060,
-                sequential_states: 7105,
-                pareto_values: 3019766,
+                sequential_states: 2551,
+                pareto_values: 2990347,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 244815,
-                sequential_states: 11953,
-                pareto_values: 1767265,
+                sequential_states: 11956,
+                pareto_values: 1767278,
             },
         }
     "#]];

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -188,8 +188,8 @@ fn max_quality() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 392060,
-                sequential_states: 7255,
-                pareto_values: 3020564,
+                sequential_states: 7105,
+                pareto_values: 3019766,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 244815,

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -180,11 +180,11 @@ fn max_quality() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 228053,
+            finish_states: 233841,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 4411,
-                dropped_nodes: 51368,
-                pareto_buckets_squared_size_sum: 31041,
+                processed_nodes: 4917,
+                dropped_nodes: 59115,
+                pareto_buckets_squared_size_sum: 39418,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 392060,
@@ -193,8 +193,8 @@ fn max_quality() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 244815,
-                sequential_states: 11956,
-                pareto_values: 1767278,
+                sequential_states: 0,
+                pareto_values: 1641682,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -346,9 +346,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_buckets_squared_size_sum: 7194095,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 949885,
-                sequential_states: 19864,
-                pareto_values: 18219274,
+                parallel_states: 948868,
+                sequential_states: 19672,
+                pareto_values: 18218050,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2318275,
@@ -554,9 +554,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_buckets_squared_size_sum: 755,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 813580,
-                sequential_states: 333,
-                pareto_values: 11470549,
+                parallel_states: 787615,
+                sequential_states: 163,
+                pareto_values: 11444414,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1579065,
@@ -605,9 +605,9 @@ fn black_star_4048_3997() {
                 pareto_buckets_squared_size_sum: 424279,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 685320,
-                sequential_states: 4988,
-                pareto_values: 3525620,
+                parallel_states: 541319,
+                sequential_states: 451,
+                pareto_values: 3376940,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 168003,
@@ -656,9 +656,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_buckets_squared_size_sum: 2485986,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 850769,
-                sequential_states: 4861,
-                pareto_values: 5359342,
+                parallel_states: 709329,
+                sequential_states: 174,
+                pareto_values: 5213214,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 461630,
@@ -707,9 +707,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_buckets_squared_size_sum: 958,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 904450,
-                sequential_states: 275,
-                pareto_values: 8902777,
+                parallel_states: 722074,
+                sequential_states: 95,
+                pareto_values: 8720221,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1336246,
@@ -758,9 +758,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_buckets_squared_size_sum: 5651,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 914935,
-                sequential_states: 456,
-                pareto_values: 7850894,
+                parallel_states: 686300,
+                sequential_states: 95,
+                pareto_values: 7621898,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1118641,
@@ -809,9 +809,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_buckets_squared_size_sum: 593237,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1118578,
-                sequential_states: 3172,
-                pareto_values: 15062019,
+                parallel_states: 941154,
+                sequential_states: 103,
+                pareto_values: 14881526,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1556489,
@@ -860,9 +860,9 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_buckets_squared_size_sum: 35944616,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1001054,
-                sequential_states: 17331,
-                pareto_values: 12556168,
+                parallel_states: 999498,
+                sequential_states: 16979,
+                pareto_values: 12554249,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 361555,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -347,8 +347,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,
-                sequential_states: 14887,
-                pareto_values: 18146338,
+                sequential_states: 10797,
+                pareto_values: 18106424,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2318275,
@@ -555,8 +555,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 750109,
-                sequential_states: 96,
-                pareto_values: 11255594,
+                sequential_states: 95,
+                pareto_values: 11255593,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1579065,
@@ -861,8 +861,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 994029,
-                sequential_states: 12310,
-                pareto_values: 12491162,
+                sequential_states: 5188,
+                pareto_values: 12428283,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 361555,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -93,8 +93,8 @@ fn rinascita_3700_3280() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 957930,
-                sequential_states: 42908,
-                pareto_values: 17006564,
+                sequential_states: 42813,
+                pareto_values: 17006469,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -144,8 +144,8 @@ fn pactmaker_3240_3130() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 818130,
-                sequential_states: 45022,
-                pareto_values: 13132190,
+                sequential_states: 44927,
+                pareto_values: 13132095,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -194,8 +194,8 @@ fn pactmaker_3240_3130_heart_and_soul() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1690660,
-                sequential_states: 84803,
-                pareto_values: 27638037,
+                sequential_states: 84617,
+                pareto_values: 27637851,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -245,8 +245,8 @@ fn diadochos_4021_3660() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 888030,
-                sequential_states: 44492,
-                pareto_values: 17385111,
+                sequential_states: 44397,
+                pareto_values: 17385016,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -296,8 +296,8 @@ fn indagator_3858_4057() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 971910,
-                sequential_states: 46067,
-                pareto_values: 17456902,
+                sequential_states: 45972,
+                pareto_values: 17456807,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -347,8 +347,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,
-                sequential_states: 10797,
-                pareto_values: 18106424,
+                sequential_states: 10702,
+                pareto_values: 18106329,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2318275,
@@ -400,8 +400,8 @@ fn stuffed_peppers_2() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 949885,
-                sequential_states: 19258,
-                pareto_values: 18691111,
+                sequential_states: 19163,
+                pareto_values: 18691016,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -452,8 +452,8 @@ fn stuffed_peppers_2_heart_and_soul() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1946676,
-                sequential_states: 37542,
-                pareto_values: 40513452,
+                sequential_states: 37356,
+                pareto_values: 40513266,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -504,8 +504,8 @@ fn stuffed_peppers_2_quick_innovation() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1965991,
-                sequential_states: 39940,
-                pareto_values: 39084375,
+                sequential_states: 39845,
+                pareto_values: 39084280,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -555,8 +555,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 750109,
-                sequential_states: 95,
-                pareto_values: 11255593,
+                sequential_states: 0,
+                pareto_values: 11255498,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1579065,
@@ -606,8 +606,8 @@ fn black_star_4048_3997() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 448545,
-                sequential_states: 115,
-                pareto_values: 3013772,
+                sequential_states: 20,
+                pareto_values: 3013677,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 168003,
@@ -657,8 +657,8 @@ fn claro_walnut_lumber_4900_4800() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 632525,
-                sequential_states: 134,
-                pareto_values: 4877173,
+                sequential_states: 39,
+                pareto_values: 4877078,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 461630,
@@ -708,8 +708,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 654113,
-                sequential_states: 95,
-                pareto_values: 8411367,
+                sequential_states: 0,
+                pareto_values: 8411272,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1336246,
@@ -759,8 +759,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 620174,
-                sequential_states: 95,
-                pareto_values: 7335092,
+                sequential_states: 0,
+                pareto_values: 7334997,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1118641,
@@ -810,8 +810,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 871349,
-                sequential_states: 95,
-                pareto_values: 14549668,
+                sequential_states: 0,
+                pareto_values: 14549573,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1556489,
@@ -861,8 +861,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 994029,
-                sequential_states: 5188,
-                pareto_values: 12428283,
+                sequential_states: 5093,
+                pareto_values: 12428188,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 361555,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -346,9 +346,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_buckets_squared_size_sum: 7194095,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 948868,
-                sequential_states: 19672,
-                pareto_values: 18218050,
+                parallel_states: 945752,
+                sequential_states: 14887,
+                pareto_values: 18146338,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2318275,
@@ -554,9 +554,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_buckets_squared_size_sum: 755,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 787615,
-                sequential_states: 163,
-                pareto_values: 11444414,
+                parallel_states: 750109,
+                sequential_states: 96,
+                pareto_values: 11255594,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1579065,
@@ -605,9 +605,9 @@ fn black_star_4048_3997() {
                 pareto_buckets_squared_size_sum: 424279,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 541319,
-                sequential_states: 451,
-                pareto_values: 3376940,
+                parallel_states: 448545,
+                sequential_states: 115,
+                pareto_values: 3013772,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 168003,
@@ -656,9 +656,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_buckets_squared_size_sum: 2485986,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 709329,
-                sequential_states: 174,
-                pareto_values: 5213214,
+                parallel_states: 632525,
+                sequential_states: 134,
+                pareto_values: 4877173,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 461630,
@@ -707,9 +707,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_buckets_squared_size_sum: 958,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 722074,
+                parallel_states: 654113,
                 sequential_states: 95,
-                pareto_values: 8720221,
+                pareto_values: 8411367,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1336246,
@@ -758,9 +758,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_buckets_squared_size_sum: 5651,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 686300,
+                parallel_states: 620174,
                 sequential_states: 95,
-                pareto_values: 7621898,
+                pareto_values: 7335092,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1118641,
@@ -809,9 +809,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_buckets_squared_size_sum: 593237,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 941154,
-                sequential_states: 103,
-                pareto_values: 14881526,
+                parallel_states: 871349,
+                sequential_states: 95,
+                pareto_values: 14549668,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1556489,
@@ -860,9 +860,9 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_buckets_squared_size_sum: 35944616,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 999498,
-                sequential_states: 16979,
-                pareto_values: 12554249,
+                parallel_states: 994029,
+                sequential_states: 12310,
+                pareto_values: 12491162,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 361555,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -85,16 +85,16 @@ fn rinascita_3700_3280() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 320753,
+            finish_states: 321264,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3590,
-                dropped_nodes: 45482,
-                pareto_buckets_squared_size_sum: 31086,
+                processed_nodes: 3677,
+                dropped_nodes: 46631,
+                pareto_buckets_squared_size_sum: 31595,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 946344,
-                sequential_states: 53553,
-                pareto_values: 23383443,
+                sequential_states: 45503,
+                pareto_values: 23103012,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -136,16 +136,16 @@ fn pactmaker_3240_3130() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 298376,
+            finish_states: 298444,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 5033,
-                dropped_nodes: 62257,
-                pareto_buckets_squared_size_sum: 79895,
+                processed_nodes: 5040,
+                dropped_nodes: 62372,
+                pareto_buckets_squared_size_sum: 79906,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 808184,
-                sequential_states: 54133,
-                pareto_values: 17994785,
+                sequential_states: 46095,
+                pareto_values: 17736548,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -186,16 +186,16 @@ fn pactmaker_3240_3130_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 273121,
+            finish_states: 273192,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1007,
-                dropped_nodes: 16118,
-                pareto_buckets_squared_size_sum: 7341,
+                processed_nodes: 1014,
+                dropped_nodes: 16268,
+                pareto_buckets_squared_size_sum: 7368,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1668344,
-                sequential_states: 99725,
-                pareto_values: 38050304,
+                sequential_states: 87012,
+                pareto_values: 37644777,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -237,16 +237,16 @@ fn diadochos_4021_3660() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 521559,
+            finish_states: 522769,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 5790,
-                dropped_nodes: 35051,
-                pareto_buckets_squared_size_sum: 56514,
+                processed_nodes: 5960,
+                dropped_nodes: 35578,
+                pareto_buckets_squared_size_sum: 58238,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 877264,
-                sequential_states: 55373,
-                pareto_values: 23915977,
+                sequential_states: 46835,
+                pareto_values: 23560094,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -288,16 +288,16 @@ fn indagator_3858_4057() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 244830,
+            finish_states: 244964,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 332,
-                dropped_nodes: 4854,
-                pareto_buckets_squared_size_sum: 666,
+                processed_nodes: 341,
+                dropped_nodes: 5021,
+                pareto_buckets_squared_size_sum: 705,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 960160,
-                sequential_states: 54543,
-                pareto_values: 23560985,
+                sequential_states: 45425,
+                pareto_values: 23318404,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -339,21 +339,21 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 2399138,
+            finish_states: 2399269,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1521634,
-                dropped_nodes: 10326810,
-                pareto_buckets_squared_size_sum: 95832129,
+                processed_nodes: 1522184,
+                dropped_nodes: 10330474,
+                pareto_buckets_squared_size_sum: 95852804,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
-                sequential_states: 14501,
-                pareto_values: 24536298,
+                sequential_states: 3374,
+                pareto_values: 24352482,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
-                sequential_states: 52107,
-                pareto_values: 43627531,
+                sequential_states: 52233,
+                pareto_values: 43628459,
             },
         }
     "#]];
@@ -392,16 +392,16 @@ fn stuffed_peppers_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 905658,
+            finish_states: 905935,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 624151,
-                dropped_nodes: 5458512,
-                pareto_buckets_squared_size_sum: 33720201,
+                processed_nodes: 624421,
+                dropped_nodes: 5460978,
+                pareto_buckets_squared_size_sum: 33727927,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 943006,
-                sequential_states: 34735,
-                pareto_values: 25911852,
+                sequential_states: 25383,
+                pareto_values: 25572638,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -444,16 +444,16 @@ fn stuffed_peppers_2_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 880186,
+            finish_states: 880717,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 136445,
-                dropped_nodes: 2259226,
-                pareto_buckets_squared_size_sum: 3366258,
+                processed_nodes: 136776,
+                dropped_nodes: 2265702,
+                pareto_buckets_squared_size_sum: 3372283,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1927690,
-                sequential_states: 61019,
-                pareto_values: 53894771,
+                sequential_states: 47209,
+                pareto_values: 53396652,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -496,16 +496,16 @@ fn stuffed_peppers_2_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 918522,
+            finish_states: 918966,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1064441,
-                dropped_nodes: 11400599,
-                pareto_buckets_squared_size_sum: 56957167,
+                processed_nodes: 1064957,
+                dropped_nodes: 11405000,
+                pareto_buckets_squared_size_sum: 56970375,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1966489,
-                sequential_states: 74342,
-                pareto_values: 54252964,
+                sequential_states: 50389,
+                pareto_values: 53389943,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -550,18 +550,18 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             finish_states: 1209189,
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 20647,
-                dropped_nodes: 325237,
+                dropped_nodes: 325236,
                 pareto_buckets_squared_size_sum: 224253,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 709548,
-                sequential_states: 7454,
-                pareto_values: 13436168,
+                sequential_states: 0,
+                pareto_values: 13383321,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1514037,
-                sequential_states: 36975,
-                pareto_values: 22609802,
+                sequential_states: 36978,
+                pareto_values: 22609817,
             },
         }
     "#]];
@@ -606,8 +606,8 @@ fn black_star_4048_3997() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 414395,
-                sequential_states: 18717,
-                pareto_values: 3416804,
+                sequential_states: 0,
+                pareto_values: 3311964,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 161900,
@@ -657,8 +657,8 @@ fn claro_walnut_lumber_4900_4800() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 588992,
-                sequential_states: 13149,
-                pareto_values: 5750328,
+                sequential_states: 0,
+                pareto_values: 5653305,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 456982,
@@ -708,8 +708,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 615546,
-                sequential_states: 7731,
-                pareto_values: 9692019,
+                sequential_states: 0,
+                pareto_values: 9634708,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1229899,
@@ -759,8 +759,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 579131,
-                sequential_states: 11233,
-                pareto_values: 8340143,
+                sequential_states: 0,
+                pareto_values: 8283565,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1108877,
@@ -810,8 +810,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 812878,
-                sequential_states: 18681,
-                pareto_values: 18279919,
+                sequential_states: 0,
+                pareto_values: 18128867,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1517488,
@@ -853,21 +853,21 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 860537,
+            finish_states: 860593,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1814200,
-                dropped_nodes: 13096936,
-                pareto_buckets_squared_size_sum: 184022542,
+                processed_nodes: 1814335,
+                dropped_nodes: 13097441,
+                pareto_buckets_squared_size_sum: 184024915,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,
-                sequential_states: 8518,
-                pareto_values: 17519683,
+                sequential_states: 1226,
+                pareto_values: 17428578,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 386882,
-                sequential_states: 25042,
-                pareto_values: 6101199,
+                sequential_states: 25133,
+                pareto_values: 6101721,
             },
         }
     "#]];
@@ -901,16 +901,16 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 264341,
+            finish_states: 268611,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 25325,
-                dropped_nodes: 282720,
-                pareto_buckets_squared_size_sum: 403523,
+                processed_nodes: 26258,
+                dropped_nodes: 291149,
+                pareto_buckets_squared_size_sum: 411956,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2397570,
-                sequential_states: 146482,
-                pareto_values: 39652640,
+                sequential_states: 106038,
+                pareto_values: 38830081,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -339,11 +339,11 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 2399269,
+            finish_states: 2399401,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1522184,
-                dropped_nodes: 10330474,
-                pareto_buckets_squared_size_sum: 95852804,
+                processed_nodes: 1522851,
+                dropped_nodes: 10342895,
+                pareto_buckets_squared_size_sum: 95896352,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
@@ -352,8 +352,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
-                sequential_states: 52233,
-                pareto_values: 43628459,
+                sequential_states: 1715,
+                pareto_values: 42543452,
             },
         }
     "#]];
@@ -547,11 +547,11 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1209189,
+            finish_states: 1222842,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 20647,
-                dropped_nodes: 325236,
-                pareto_buckets_squared_size_sum: 224253,
+                processed_nodes: 22002,
+                dropped_nodes: 353025,
+                pareto_buckets_squared_size_sum: 254713,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 709548,
@@ -560,8 +560,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1514037,
-                sequential_states: 36978,
-                pareto_values: 22609817,
+                sequential_states: 3286,
+                pareto_values: 21951389,
             },
         }
     "#]];
@@ -598,11 +598,11 @@ fn black_star_4048_3997() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 44692,
+            finish_states: 49178,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1464,
-                dropped_nodes: 21835,
-                pareto_buckets_squared_size_sum: 17948,
+                processed_nodes: 1720,
+                dropped_nodes: 25962,
+                pareto_buckets_squared_size_sum: 20044,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 414395,
@@ -611,8 +611,8 @@ fn black_star_4048_3997() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 161900,
-                sequential_states: 11244,
-                pareto_values: 1437955,
+                sequential_states: 277,
+                pareto_values: 1332734,
             },
         }
     "#]];
@@ -649,11 +649,11 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 100548,
+            finish_states: 126482,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 6387,
-                dropped_nodes: 124640,
-                pareto_buckets_squared_size_sum: 78147,
+                processed_nodes: 8107,
+                dropped_nodes: 157103,
+                pareto_buckets_squared_size_sum: 105912,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 588992,
@@ -662,8 +662,8 @@ fn claro_walnut_lumber_4900_4800() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 456982,
-                sequential_states: 22699,
-                pareto_values: 4195379,
+                sequential_states: 225,
+                pareto_values: 4024767,
             },
         }
     "#]];
@@ -700,11 +700,11 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 281494,
+            finish_states: 281648,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 71,
-                dropped_nodes: 1434,
-                pareto_buckets_squared_size_sum: 99,
+                processed_nodes: 73,
+                dropped_nodes: 1479,
+                pareto_buckets_squared_size_sum: 101,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 615546,
@@ -713,8 +713,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1229899,
-                sequential_states: 26205,
-                pareto_values: 16044627,
+                sequential_states: 25,
+                pareto_values: 15572449,
             },
         }
     "#]];
@@ -751,11 +751,11 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 675620,
+            finish_states: 680751,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 6508,
-                dropped_nodes: 123957,
-                pareto_buckets_squared_size_sum: 31712,
+                processed_nodes: 6927,
+                dropped_nodes: 132614,
+                pareto_buckets_squared_size_sum: 36655,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 579131,
@@ -764,8 +764,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1108877,
-                sequential_states: 29991,
-                pareto_values: 13457566,
+                sequential_states: 3253,
+                pareto_values: 13021714,
             },
         }
     "#]];
@@ -802,11 +802,11 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 863223,
+            finish_states: 869011,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 7252,
-                dropped_nodes: 143849,
-                pareto_buckets_squared_size_sum: 42058,
+                processed_nodes: 7708,
+                dropped_nodes: 153251,
+                pareto_buckets_squared_size_sum: 53382,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 812878,
@@ -815,8 +815,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1517488,
-                sequential_states: 41627,
-                pareto_values: 25547385,
+                sequential_states: 2208,
+                pareto_values: 24733620,
             },
         }
     "#]];
@@ -853,11 +853,11 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 860593,
+            finish_states: 861042,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1814335,
-                dropped_nodes: 13097441,
-                pareto_buckets_squared_size_sum: 184024915,
+                processed_nodes: 1815163,
+                dropped_nodes: 13104013,
+                pareto_buckets_squared_size_sum: 184051501,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,
@@ -866,8 +866,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 386882,
-                sequential_states: 25133,
-                pareto_values: 6101721,
+                sequential_states: 429,
+                pareto_values: 5750522,
             },
         }
     "#]];
@@ -965,8 +965,8 @@ fn ceviche_4900_4800_no_quality() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 7478,
-                sequential_states: 382,
-                pareto_values: 7860,
+                sequential_states: 0,
+                pareto_values: 7478,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -347,8 +347,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
-                sequential_states: 20831,
-                pareto_values: 24626265,
+                sequential_states: 14501,
+                pareto_values: 24536298,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
@@ -861,8 +861,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,
-                sequential_states: 11927,
-                pareto_values: 17567623,
+                sequential_states: 8518,
+                pareto_values: 17519683,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 386882,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -346,9 +346,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_buckets_squared_size_sum: 95832129,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 943006,
-                sequential_states: 31047,
-                pareto_values: 24801604,
+                parallel_states: 939990,
+                sequential_states: 30237,
+                pareto_values: 24797278,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
@@ -554,9 +554,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_buckets_squared_size_sum: 224253,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 808300,
-                sequential_states: 3752,
-                pareto_values: 13757803,
+                parallel_states: 758914,
+                sequential_states: 3450,
+                pareto_values: 13708115,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1514037,
@@ -605,9 +605,9 @@ fn black_star_4048_3997() {
                 pareto_buckets_squared_size_sum: 17948,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 676932,
-                sequential_states: 1725,
-                pareto_values: 3877903,
+                parallel_states: 501788,
+                sequential_states: 1775,
+                pareto_values: 3702808,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 161900,
@@ -656,9 +656,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_buckets_squared_size_sum: 78147,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 841227,
-                sequential_states: 2597,
-                pareto_values: 6275475,
+                parallel_states: 668435,
+                sequential_states: 1908,
+                pareto_values: 6101994,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 456982,
@@ -707,9 +707,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_buckets_squared_size_sum: 99,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 898104,
-                sequential_states: 205,
-                pareto_values: 10169847,
+                parallel_states: 679406,
+                sequential_states: 446,
+                pareto_values: 9951390,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1229899,
@@ -758,9 +758,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_buckets_squared_size_sum: 31712,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 908466,
-                sequential_states: 2827,
-                pareto_values: 8849637,
+                parallel_states: 640073,
+                sequential_states: 3560,
+                pareto_values: 8581977,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1108877,
@@ -809,9 +809,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_buckets_squared_size_sum: 42058,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1108202,
-                sequential_states: 3573,
-                pareto_values: 18798132,
+                parallel_states: 881496,
+                sequential_states: 3783,
+                pareto_values: 18571636,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1517488,
@@ -860,9 +860,9 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_buckets_squared_size_sum: 184022542,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 989749,
-                sequential_states: 23667,
-                pareto_values: 17791032,
+                parallel_states: 983899,
+                sequential_states: 22293,
+                pareto_values: 17783652,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 386882,
@@ -959,9 +959,9 @@ fn ceviche_4900_4800_no_quality() {
                 pareto_buckets_squared_size_sum: 35,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 13866,
+                parallel_states: 5168,
                 sequential_states: 0,
-                pareto_values: 13866,
+                pareto_values: 5168,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 7478,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -346,9 +346,9 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_buckets_squared_size_sum: 95832129,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 939990,
-                sequential_states: 30237,
-                pareto_values: 24797278,
+                parallel_states: 932788,
+                sequential_states: 20831,
+                pareto_values: 24626265,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
@@ -554,9 +554,9 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_buckets_squared_size_sum: 224253,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 758914,
-                sequential_states: 3450,
-                pareto_values: 13708115,
+                parallel_states: 709548,
+                sequential_states: 7454,
+                pareto_values: 13436168,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1514037,
@@ -605,9 +605,9 @@ fn black_star_4048_3997() {
                 pareto_buckets_squared_size_sum: 17948,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 501788,
-                sequential_states: 1775,
-                pareto_values: 3702808,
+                parallel_states: 414395,
+                sequential_states: 18717,
+                pareto_values: 3416804,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 161900,
@@ -656,9 +656,9 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_buckets_squared_size_sum: 78147,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 668435,
-                sequential_states: 1908,
-                pareto_values: 6101994,
+                parallel_states: 588992,
+                sequential_states: 13149,
+                pareto_values: 5750328,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 456982,
@@ -707,9 +707,9 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_buckets_squared_size_sum: 99,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 679406,
-                sequential_states: 446,
-                pareto_values: 9951390,
+                parallel_states: 615546,
+                sequential_states: 7731,
+                pareto_values: 9692019,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1229899,
@@ -758,9 +758,9 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_buckets_squared_size_sum: 31712,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 640073,
-                sequential_states: 3560,
-                pareto_values: 8581977,
+                parallel_states: 579131,
+                sequential_states: 11233,
+                pareto_values: 8340143,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1108877,
@@ -809,9 +809,9 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_buckets_squared_size_sum: 42058,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 881496,
-                sequential_states: 3783,
-                pareto_values: 18571636,
+                parallel_states: 812878,
+                sequential_states: 18681,
+                pareto_values: 18279919,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1517488,
@@ -860,9 +860,9 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_buckets_squared_size_sum: 184022542,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 983899,
-                sequential_states: 22293,
-                pareto_values: 17783652,
+                parallel_states: 969126,
+                sequential_states: 11927,
+                pareto_values: 17567623,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 386882,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -104,9 +104,9 @@ fn stuffed_peppers() {
                 pareto_buckets_squared_size_sum: 1190791,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 2490788,
-                sequential_states: 9439,
-                pareto_values: 39433453,
+                parallel_states: 2271577,
+                sequential_states: 6898,
+                pareto_values: 39211692,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1414006,
@@ -157,9 +157,9 @@ fn test_rare_tacos_2() {
                 pareto_buckets_squared_size_sum: 298697843,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 2490788,
+                parallel_states: 2490785,
                 sequential_states: 90229,
-                pareto_values: 70483459,
+                pareto_values: 70483456,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
@@ -211,9 +211,9 @@ fn test_mountain_chromite_ingot_no_manipulation() {
                 pareto_buckets_squared_size_sum: 456620,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1839894,
-                sequential_states: 50645,
-                pareto_values: 16816502,
+                parallel_states: 1800446,
+                sequential_states: 43703,
+                pareto_values: 16748522,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 52408,
@@ -420,9 +420,9 @@ fn issue_118() {
                 pareto_buckets_squared_size_sum: 216063563,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 1931356,
-                sequential_states: 70702,
-                pareto_values: 25707810,
+                parallel_states: 1931154,
+                sequential_states: 70683,
+                pareto_values: 25707447,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 258314,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -105,8 +105,8 @@ fn stuffed_peppers() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2271577,
-                sequential_states: 6893,
-                pareto_values: 39211597,
+                sequential_states: 11,
+                pareto_values: 39199991,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1414006,
@@ -150,21 +150,21 @@ fn test_rare_tacos_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1465125,
+            finish_states: 1465416,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3385746,
-                dropped_nodes: 28572558,
-                pareto_buckets_squared_size_sum: 298697843,
+                processed_nodes: 3386238,
+                dropped_nodes: 28581578,
+                pareto_buckets_squared_size_sum: 298723145,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490785,
-                sequential_states: 89951,
-                pareto_values: 70479369,
+                sequential_states: 77289,
+                pareto_values: 70117907,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
-                sequential_states: 47014,
-                pareto_values: 43597095,
+                sequential_states: 47286,
+                pareto_values: 43598798,
             },
         }
     "#]];
@@ -204,21 +204,21 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 76205,
+            finish_states: 76250,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 26562,
-                dropped_nodes: 348147,
-                pareto_buckets_squared_size_sum: 456620,
+                processed_nodes: 26576,
+                dropped_nodes: 348359,
+                pareto_buckets_squared_size_sum: 456647,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1800446,
-                sequential_states: 5317,
-                pareto_values: 16383032,
+                sequential_states: 545,
+                pareto_values: 16363329,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 52408,
-                sequential_states: 11357,
-                pareto_values: 542930,
+                sequential_states: 11363,
+                pareto_values: 542970,
             },
         }
     "#]];
@@ -255,16 +255,16 @@ fn test_indagator_3858_4057() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 512190,
+            finish_states: 512563,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 20339,
-                dropped_nodes: 197983,
-                pareto_buckets_squared_size_sum: 312904,
+                processed_nodes: 20479,
+                dropped_nodes: 199583,
+                pareto_buckets_squared_size_sum: 314742,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2515306,
-                sequential_states: 151863,
-                pareto_values: 65076119,
+                sequential_states: 140937,
+                pareto_values: 64650413,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -307,21 +307,21 @@ fn test_rare_tacos_4628_4410() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 553896,
+            finish_states: 554262,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 947084,
-                dropped_nodes: 2311281,
-                pareto_buckets_squared_size_sum: 65503086,
+                processed_nodes: 947509,
+                dropped_nodes: 2316455,
+                pareto_buckets_squared_size_sum: 65519330,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2623634,
-                sequential_states: 79247,
-                pareto_values: 78388861,
+                sequential_states: 69176,
+                pareto_values: 78047665,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 420784,
-                sequential_states: 31429,
-                pareto_values: 8950199,
+                sequential_states: 32014,
+                pareto_values: 8954890,
             },
         }
     "#]];
@@ -361,16 +361,16 @@ fn issue_113() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1959668,
+            finish_states: 1960833,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1267875,
-                dropped_nodes: 17909160,
-                pareto_buckets_squared_size_sum: 78126500,
+                processed_nodes: 1268483,
+                dropped_nodes: 17918421,
+                pareto_buckets_squared_size_sum: 78163755,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 3043554,
-                sequential_states: 94212,
-                pareto_values: 121470665,
+                sequential_states: 80265,
+                pareto_values: 120616636,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -413,21 +413,21 @@ fn issue_118() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 571064,
+            finish_states: 571635,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1214933,
-                dropped_nodes: 14402683,
-                pareto_buckets_squared_size_sum: 216063563,
+                processed_nodes: 1215503,
+                dropped_nodes: 14407205,
+                pareto_buckets_squared_size_sum: 216088258,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1931154,
-                sequential_states: 59856,
-                pareto_values: 25546575,
+                sequential_states: 50515,
+                pareto_values: 25428797,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 258314,
-                sequential_states: 17917,
-                pareto_values: 2875845,
+                sequential_states: 18262,
+                pareto_values: 2877979,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -97,11 +97,11 @@ fn stuffed_peppers() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 882590,
+            finish_states: 887756,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 79649,
-                dropped_nodes: 1553519,
-                pareto_buckets_squared_size_sum: 1190791,
+                processed_nodes: 81291,
+                dropped_nodes: 1587531,
+                pareto_buckets_squared_size_sum: 1244052,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2271577,
@@ -110,8 +110,8 @@ fn stuffed_peppers() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1414006,
-                sequential_states: 35537,
-                pareto_values: 21195116,
+                sequential_states: 1355,
+                pareto_values: 20623813,
             },
         }
     "#]];
@@ -152,19 +152,19 @@ fn test_rare_tacos_2() {
         MacroSolverStats {
             finish_states: 1465416,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3386238,
-                dropped_nodes: 28581578,
-                pareto_buckets_squared_size_sum: 298723145,
+                processed_nodes: 3386237,
+                dropped_nodes: 28582063,
+                pareto_buckets_squared_size_sum: 298723983,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490785,
-                sequential_states: 77289,
-                pareto_values: 70117907,
+                sequential_states: 77299,
+                pareto_values: 70118044,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
-                sequential_states: 47286,
-                pareto_values: 43598798,
+                sequential_states: 2,
+                pareto_values: 42541739,
             },
         }
     "#]];
@@ -204,11 +204,11 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 76250,
+            finish_states: 77649,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 26576,
-                dropped_nodes: 348359,
-                pareto_buckets_squared_size_sum: 456647,
+                processed_nodes: 28453,
+                dropped_nodes: 373944,
+                pareto_buckets_squared_size_sum: 600321,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1800446,
@@ -217,8 +217,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 52408,
-                sequential_states: 11363,
-                pareto_values: 542970,
+                sequential_states: 314,
+                pareto_values: 449928,
             },
         }
     "#]];
@@ -309,8 +309,8 @@ fn test_rare_tacos_4628_4410() {
         MacroSolverStats {
             finish_states: 554262,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 947509,
-                dropped_nodes: 2316455,
+                processed_nodes: 947506,
+                dropped_nodes: 2316515,
                 pareto_buckets_squared_size_sum: 65519330,
             },
             quality_ub_stats: QualityUbSolverStats {
@@ -320,8 +320,8 @@ fn test_rare_tacos_4628_4410() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 420784,
-                sequential_states: 32014,
-                pareto_values: 8954890,
+                sequential_states: 0,
+                pareto_values: 8205611,
             },
         }
     "#]];
@@ -413,11 +413,11 @@ fn issue_118() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 571635,
+            finish_states: 571642,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1215503,
-                dropped_nodes: 14407205,
-                pareto_buckets_squared_size_sum: 216088258,
+                processed_nodes: 1215569,
+                dropped_nodes: 14411862,
+                pareto_buckets_squared_size_sum: 216085380,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1931154,
@@ -426,8 +426,8 @@ fn issue_118() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 258314,
-                sequential_states: 18262,
-                pareto_values: 2877979,
+                sequential_states: 36,
+                pareto_values: 2699561,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -105,8 +105,8 @@ fn stuffed_peppers() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2271577,
-                sequential_states: 6898,
-                pareto_values: 39211692,
+                sequential_states: 6893,
+                pareto_values: 39211597,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1414006,
@@ -158,8 +158,8 @@ fn test_rare_tacos_2() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490785,
-                sequential_states: 90229,
-                pareto_values: 70483456,
+                sequential_states: 89951,
+                pareto_values: 70479369,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
@@ -212,8 +212,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1800446,
-                sequential_states: 43703,
-                pareto_values: 16748522,
+                sequential_states: 5317,
+                pareto_values: 16383032,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 52408,
@@ -421,8 +421,8 @@ fn issue_118() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1931154,
-                sequential_states: 70683,
-                pareto_values: 25707447,
+                sequential_states: 59856,
+                pareto_values: 25546575,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 258314,


### PR DESCRIPTION
If a `QualityUbSolver` state can reach max progress and quality with some amount of CP, it is unnecessary to compute that state again with more CP.

- Precompute templates are removed as soon as their instantiated state can reach max progress and quality to make sure that template isn't instantiated again with higher CP.
- Querying the Quality upper-bound first checks if there exists an identical state (but with less-or-equal CP) that can reach max progress and quality. If so, return max quality instead of solving the state.

Also remove the `MuscleMemory` effect from both `QualityUbSolver` states and `StepLbSolver` states, by just assuming that it can be used to its full potential.