### PR TITLE
Fix UI freeze after solve if saved rotations widget has never been openend

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -516,7 +516,7 @@ impl MacroSolverApp {
                         );
                         game_settings.adversarial = self.solver_config.adversarial;
                         game_settings.backload_progress = self.solver_config.backload_progress;
-                        self.saved_rotations_data.add_solved_rotation(Rotation::new(
+                        let new_rotation = Rotation::new(
                             raphael_data::get_item_name(
                                 self.recipe_config.recipe.item_id,
                                 false,
@@ -531,7 +531,9 @@ impl MacroSolverApp {
                             self.selected_food,
                             self.selected_potion,
                             &self.crafter_config,
-                        ));
+                        );
+                        self.saved_rotations_data
+                            .add_solved_rotation(new_rotation, &self.saved_rotations_config);
                     } else {
                         self.solver_error = exception;
                     }


### PR DESCRIPTION
Fixes #185 

The problem was caused by `max_history_size` being set to `0` by default. This caused the rotation insertion logic to loop indefinitely:
```rust
while self.solve_history.len() >= self.max_history_size {
    self.solve_history.pop_back();
}
self.solve_history.push_front(rotation);
```

The problem has been fixed by correctly setting the default value of `max_history_size` to `50`, and changing the rotation insertion logic to be able zero `max_history_size`:
```rust
self.solve_history.push_front(rotation);
while self.solve_history.len() > config.max_history_size {
    self.solve_history.pop_back();
}
```

Also, the `max_history_size` is now part of `SavedRotationsConfig` instead of `SavedRotationsData`.