### PR TITLE
Add dev panel with UI profiling and debugging options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,6 @@ overflow-checks = true
 [patch.crates-io]
 # unsafe(no_mangle) fix for csbindgen in raphael-bindings
 csbindgen = { git = "https://github.com/Cysharp/csbindgen.git", rev = "refs/pull/103/head" }
+
+[features]
+dev-panel = []

--- a/src/app.rs
+++ b/src/app.rs
@@ -360,6 +360,8 @@ impl eframe::App for MacroSolverApp {
                             )
                             .open_in_new_tab(true),
                         );
+                        #[cfg(debug_assertions)]
+                        ui.allocate_space(egui::vec2(125.0, 0.0));
                         ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                             #[cfg(debug_assertions)]
                             if ui

--- a/src/app.rs
+++ b/src/app.rs
@@ -39,8 +39,8 @@ pub struct SolverConfig {
 
 #[cfg(debug_assertions)]
 #[derive(Debug, Default)]
-struct DevInfoState {
-    show_dev_info_panel: bool,
+struct DevPanelState {
+    show_dev_panel: bool,
     render_info_state: RenderInfoState,
 }
 
@@ -58,7 +58,7 @@ pub struct MacroSolverApp {
     saved_rotations_data: SavedRotationsData,
 
     #[cfg(debug_assertions)]
-    dev_info_state: DevInfoState,
+    dev_panel_state: DevPanelState,
 
     latest_version: Arc<Mutex<semver::Version>>,
     current_version: semver::Version,
@@ -120,7 +120,7 @@ impl MacroSolverApp {
             saved_rotations_data: load(cc, "SAVED_ROTATIONS", SavedRotationsData::default()),
 
             #[cfg(debug_assertions)]
-            dev_info_state: DevInfoState::default(),
+            dev_panel_state: DevPanelState::default(),
 
             latest_version: latest_version.clone(),
             current_version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
@@ -361,33 +361,30 @@ impl eframe::App for MacroSolverApp {
                             .open_in_new_tab(true),
                         );
                         #[cfg(debug_assertions)]
-                        ui.allocate_space(egui::vec2(125.0, 0.0));
+                        ui.allocate_space(egui::vec2(145.0, 0.0));
                         ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                             #[cfg(debug_assertions)]
                             if ui
-                                .selectable_label(
-                                    self.dev_info_state.show_dev_info_panel,
-                                    "Dev Info",
-                                )
+                                .selectable_label(self.dev_panel_state.show_dev_panel, "Dev Panel")
                                 .clicked()
                             {
-                                self.dev_info_state.show_dev_info_panel =
-                                    !self.dev_info_state.show_dev_info_panel;
+                                self.dev_panel_state.show_dev_panel =
+                                    !self.dev_panel_state.show_dev_panel;
                             };
                             egui::warn_if_debug_build(ui);
+                            ui.separator();
                         });
                     });
                 });
         });
 
         #[cfg(debug_assertions)]
-        if self.dev_info_state.show_dev_info_panel {
-            egui::SidePanel::right("right_panel")
+        if self.dev_panel_state.show_dev_panel {
+            egui::SidePanel::right("dev_panel")
                 .resizable(true)
                 .show(ctx, |ui| {
                     ui.style_mut().spacing.item_spacing = egui::vec2(8.0, 3.0);
-                    ui.heading("Rendering");
-                    RenderInfo::new(&mut self.dev_info_state.render_info_state).ui(ui, _frame);
+                    RenderInfo::new(&mut self.dev_panel_state.render_info_state).ui(ui, _frame);
                 });
         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -362,15 +362,15 @@ impl eframe::App for MacroSolverApp {
                         );
                         #[cfg(debug_assertions)]
                         ui.allocate_space(egui::vec2(145.0, 0.0));
+                        #[cfg(debug_assertions)]
                         ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                            #[cfg(debug_assertions)]
                             if ui
                                 .selectable_label(self.dev_panel_state.show_dev_panel, "Dev Panel")
                                 .clicked()
                             {
                                 self.dev_panel_state.show_dev_panel =
                                     !self.dev_panel_state.show_dev_panel;
-                            };
+                            }
                             egui::warn_if_debug_build(ui);
                             ui.separator();
                         });

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,7 +37,7 @@ pub struct SolverConfig {
     pub adversarial: bool,
 }
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "dev-panel"))]
 #[derive(Debug, Default)]
 struct DevPanelState {
     show_dev_panel: bool,
@@ -57,7 +57,7 @@ pub struct MacroSolverApp {
     saved_rotations_config: SavedRotationsConfig,
     saved_rotations_data: SavedRotationsData,
 
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, feature = "dev-panel"))]
     dev_panel_state: DevPanelState,
 
     latest_version: Arc<Mutex<semver::Version>>,
@@ -119,7 +119,7 @@ impl MacroSolverApp {
             ),
             saved_rotations_data: load(cc, "SAVED_ROTATIONS", SavedRotationsData::default()),
 
-            #[cfg(debug_assertions)]
+            #[cfg(any(debug_assertions, feature = "dev-panel"))]
             dev_panel_state: DevPanelState::default(),
 
             latest_version: latest_version.clone(),
@@ -362,7 +362,9 @@ impl eframe::App for MacroSolverApp {
                         );
                         #[cfg(debug_assertions)]
                         ui.allocate_space(egui::vec2(145.0, 0.0));
-                        #[cfg(debug_assertions)]
+                        #[cfg(all(not(debug_assertions), feature = "dev-panel"))]
+                        ui.allocate_space(egui::vec2(68.0, 0.0));
+                        #[cfg(any(debug_assertions, feature = "dev-panel"))]
                         ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                             if ui
                                 .selectable_label(self.dev_panel_state.show_dev_panel, "Dev Panel")
@@ -378,7 +380,7 @@ impl eframe::App for MacroSolverApp {
                 });
         });
 
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "dev-panel"))]
         if self.dev_panel_state.show_dev_panel {
             egui::SidePanel::right("dev_panel")
                 .resizable(true)

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -27,9 +27,9 @@ pub use saved_rotations::{
     Rotation, SavedRotationsConfig, SavedRotationsData, SavedRotationsWidget,
 };
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "dev-panel"))]
 mod render_info;
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "dev-panel"))]
 pub use render_info::{RenderInfo, RenderInfoState};
 
 mod util;

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -27,4 +27,9 @@ pub use saved_rotations::{
     Rotation, SavedRotationsConfig, SavedRotationsData, SavedRotationsWidget,
 };
 
+#[cfg(debug_assertions)]
+mod render_info;
+#[cfg(debug_assertions)]
+pub use render_info::{RenderInfo, RenderInfoState};
+
 mod util;

--- a/src/widgets/render_info.rs
+++ b/src/widgets/render_info.rs
@@ -1,0 +1,271 @@
+// code borrows heavily from the `egui_demo_app`, specifically `backend_panel.rs` & `frame_history.rs`
+
+use egui::util::History;
+
+#[derive(Debug, Clone, PartialEq)]
+enum RunMode {
+    Reactive,
+    Continuous,
+}
+
+#[derive(Debug, Clone)]
+pub struct RenderInfoState {
+    run_mode: RunMode,
+    cpu_usage_history: History<f32>,
+    last_frames_time: Option<f64>,
+}
+
+impl RenderInfoState {
+    pub fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
+        if let Some(cpu_usage) = frame.info().cpu_usage {
+            self.cpu_usage_history
+                .add(self.last_frames_time.unwrap_or_default(), cpu_usage);
+        }
+        self.last_frames_time = Some(ctx.input(|i| i.time));
+
+        match self.run_mode {
+            RunMode::Continuous => {
+                ctx.request_repaint();
+            }
+            RunMode::Reactive => {
+            }
+        }
+    }
+
+    pub fn mean_cpu_usage(&self) -> f32 {
+        self.cpu_usage_history.average().unwrap_or_default()
+    }
+
+    pub fn theoretical_fps(&self) -> f32 {
+        if let Some(average_frame_time) = self.cpu_usage_history.average() {
+            1.0 / average_frame_time
+        } else {
+            0.0
+        }
+    }
+
+    pub fn mean_frame_time(&self) -> f32 {
+        self.cpu_usage_history.mean_time_interval().unwrap_or_default()
+    }
+
+    pub fn average_fps(&self) -> f32 {
+        if let Some(mean_time_interval) = self.cpu_usage_history.mean_time_interval() {
+            1.0 / mean_time_interval
+        } else {
+            0.0
+        }
+    }
+
+    
+}
+
+impl Default for RenderInfoState {
+    fn default() -> Self {
+        Self {
+            run_mode: RunMode::Reactive,
+            cpu_usage_history: History::new(0..300, 1.0),
+            last_frames_time: None,
+        }
+    }
+}
+
+pub struct RenderInfo<'a> {
+    state: &'a mut RenderInfoState,
+}
+
+impl<'a> RenderInfo<'a> {
+    pub fn new(state: &'a mut RenderInfoState) -> Self {
+        Self { state }
+    }
+
+    pub fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
+        self.state.update(ui.ctx(), frame);
+
+        ui.horizontal(|ui| {
+            ui.label("Mode:");
+            ui.radio_value(&mut self.state.run_mode, RunMode::Reactive, "Reactive");
+            ui.radio_value(&mut self.state.run_mode, RunMode::Continuous, "Continuous");
+        });
+        ui.separator();
+
+        ui.label("Stats:");
+        egui::Grid::new("adapter_info").show(ui, |ui| {
+            ui.label("Mean CPU usage:");
+            ui.label(
+                egui::RichText::new(format!("{:5.2}", self.state.mean_cpu_usage() * 1000.0))
+                    .monospace(),
+            );
+            ui.label("ms");
+            ui.end_row();
+
+            ui.label("Mean frame time:");
+            ui.label(
+                egui::RichText::new(format!("{:5.2}", self.state.mean_frame_time() * 1000.0))
+                    .monospace(),
+            );
+            ui.label("ms");
+            ui.end_row();
+
+            match self.state.run_mode {
+                RunMode::Reactive => {
+                    ui.label("Theoretical FPS:");
+                    ui.label(
+                        egui::RichText::new(format!("{:6.1}", self.state.theoretical_fps()))
+                            .monospace(),
+                    );
+                }
+                RunMode::Continuous => {
+                    ui.label("FPS:");
+                    ui.label(
+                        egui::RichText::new(format!("{:6.1}", self.state.average_fps()))
+                            .monospace(),
+                    );
+                }
+            }
+
+            ui.end_row();
+        });
+        ui.collapsing("📊 CPU usage history", |ui| {
+            self.graph(ui);
+        });
+
+        ui.separator();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(wgpu_render_state) = frame.wgpu_render_state() {
+            let adapter = &wgpu_render_state.adapter;
+            let eframe::wgpu::AdapterInfo {
+                name,
+                vendor,
+                device,
+                device_type,
+                driver,
+                driver_info,
+                backend,
+            } = &adapter.get_info();
+
+            ui.horizontal(|ui| {
+                ui.label("Backend:");
+                ui.label(format!("{backend:?}")).on_hover_ui(|ui| {
+                    egui::Grid::new("adapter_info").show(ui, |ui| {
+                        ui.label("Device Type:");
+                        ui.label(format!("{device_type:?}"));
+                        ui.end_row();
+
+                        if !name.is_empty() {
+                            ui.label("Name:");
+                            ui.label(format!("{name:?}"));
+                            ui.end_row();
+                        }
+                        if !driver.is_empty() {
+                            ui.label("Driver:");
+                            ui.label(format!("{driver:?}"));
+                            ui.end_row();
+                        }
+                        if !driver_info.is_empty() {
+                            ui.label("Driver info:");
+                            ui.label(format!("{driver_info:?}"));
+                            ui.end_row();
+                        }
+                        if *vendor != 0 {
+                            ui.label("Vendor:");
+                            ui.label(format!("0x{vendor:04X}"));
+                            ui.end_row();
+                        }
+                        if *device != 0 {
+                            ui.label("Device:");
+                            ui.label(format!("0x{device:02X}"));
+                            ui.end_row();
+                        }
+                    });
+                });
+            });
+        }
+    }
+
+    fn graph(&self, ui: &mut egui::Ui) -> egui::Response {
+        use egui::{Pos2, Rect, Sense, Shape, Stroke, TextStyle, emath, epaint, pos2, vec2};
+
+        let history = &self.state.cpu_usage_history;
+
+        let size = vec2(ui.available_size_before_wrap().x, 100.0);
+        let (rect, response) = ui.allocate_at_least(size, Sense::hover());
+        let style = ui.style().noninteractive();
+
+        let graph_top_cpu_usage = 0.010; // 10.0 ms
+        let graph_rect = Rect::from_x_y_ranges(history.max_age()..=0.0, graph_top_cpu_usage..=0.0);
+        let to_screen = emath::RectTransform::from_to(graph_rect, rect);
+
+        let mut shapes = Vec::with_capacity(3 + history.len()); // Preallocates space for box + hover line & text + samples
+        shapes.push(Shape::Rect(epaint::RectShape::new(
+            rect,
+            style.corner_radius,
+            ui.visuals().extreme_bg_color,
+            ui.style().noninteractive().bg_stroke,
+            egui::StrokeKind::Inside,
+        )));
+
+        let rect = rect.shrink(4.0);
+        let color = ui.visuals().text_color();
+        let line_stroke = Stroke::new(1.0, color);
+
+        let right_side_time = self.state.last_frames_time.unwrap_or_default();
+
+        // Add samples
+        let mut history_peekable_iter = history.iter().peekable();
+        for _ in 0..history.len() {
+            if let Some((time, cpu_usage)) = history_peekable_iter.next() {
+                let age = (right_side_time - time) as f32;
+                let pos = to_screen.transform_pos_clamped(Pos2::new(age, cpu_usage));
+
+                let mut draw_disconnected = true;
+                if let Some((following_time, following_cpu_usage)) = history_peekable_iter.peek() {
+                    let time_distance = following_time - time;
+                    // connect samples with line if they are in a window of rougly one frame at 60 fps
+                    // rounded and with additional ~1ms, since normal debug builds can miss this window quite often
+                    if time_distance < 0.018 {
+                        let following_age = (right_side_time - following_time) as f32;
+                        let following_pos = to_screen
+                            .transform_pos_clamped(Pos2::new(following_age, *following_cpu_usage));
+
+                        shapes.push(Shape::line_segment([pos, following_pos], line_stroke));
+                        draw_disconnected = false;
+                    }
+                }
+
+                if draw_disconnected {
+                    shapes.push(Shape::circle_filled(pos, 1.0, color));
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Add hover line & text
+        let color = ui.visuals().strong_text_color();
+        let line_stroke = Stroke::new(1.0, color);
+        if let Some(pointer_pos) = response.hover_pos() {
+            let y = pointer_pos.y;
+            shapes.push(Shape::line_segment(
+                [pos2(rect.left(), y), pos2(rect.right(), y)],
+                line_stroke,
+            ));
+            let cpu_usage = to_screen.inverse().transform_pos(pointer_pos).y;
+            let text = format!("{:4.1} ms", 1000.0 * cpu_usage);
+            shapes.push(ui.fonts(|f| {
+                Shape::text(
+                    f,
+                    pos2(rect.left(), y),
+                    egui::Align2::LEFT_BOTTOM,
+                    text,
+                    TextStyle::Monospace.resolve(ui.style()),
+                    color,
+                )
+            }));
+        }
+
+        ui.painter().extend(shapes);
+
+        response
+    }
+}

--- a/src/widgets/render_info.rs
+++ b/src/widgets/render_info.rs
@@ -8,6 +8,44 @@ enum RunMode {
     Continuous,
 }
 
+#[derive(Debug, Clone, Default)]
+struct EguiWindows {
+    settings: bool,
+    inspection: bool,
+    memory: bool,
+    // `output_events` is skipped
+}
+
+impl EguiWindows {
+    fn ui(&mut self, ui: &mut egui::Ui) {
+        ui.checkbox(&mut self.settings, "🔧 Settings");
+        ui.checkbox(&mut self.inspection, "🔍 Inspection");
+        ui.checkbox(&mut self.memory, "📝 Memory");
+
+        let ctx = ui.ctx();
+        egui::Window::new("🔧 Settings")
+            .open(&mut self.settings)
+            .vscroll(true)
+            .show(ctx, |ui| {
+                ctx.settings_ui(ui);
+            });
+
+        egui::Window::new("🔍 Inspection")
+            .open(&mut self.inspection)
+            .vscroll(true)
+            .show(ctx, |ui| {
+                ctx.inspection_ui(ui);
+            });
+
+        egui::Window::new("📝 Memory")
+            .open(&mut self.memory)
+            .resizable(false)
+            .show(ctx, |ui| {
+                ctx.memory_ui(ui);
+            });
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RenderInfoState {
     run_mode: RunMode,
@@ -18,6 +56,8 @@ pub struct RenderInfoState {
     y_lim: f32,
     plot_cpu_usage: bool,
     plot_frame_time: bool,
+
+    egui_windows: EguiWindows,
 }
 
 impl RenderInfoState {
@@ -77,6 +117,8 @@ impl Default for RenderInfoState {
             y_lim: 0.010,
             plot_cpu_usage: true,
             plot_frame_time: false,
+
+            egui_windows: EguiWindows::default(),
         }
     }
 }
@@ -92,6 +134,12 @@ impl<'a> RenderInfo<'a> {
 
     pub fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
         self.state.update(ui.ctx(), frame);
+
+        ui.vertical_centered(|ui| {
+            ui.heading("Rendering / UI");
+        });
+
+        ui.separator();
 
         ui.horizontal(|ui| {
             ui.label("Mode:");
@@ -208,6 +256,11 @@ impl<'a> RenderInfo<'a> {
                 });
             });
         }
+        ui.separator();
+
+        ui.label("egui windows:");
+        ui.add(egui::Label::new(egui::RichText::new("⚠ Changing settings in these windows may not allow for them to be reset unless the entire stored state is deleted").color(ui.visuals().warn_fg_color).small()).wrap());
+        self.state.egui_windows.ui(ui);
     }
 
     fn graph(&self, ui: &mut egui::Ui) -> egui::Response {

--- a/src/widgets/render_info.rs
+++ b/src/widgets/render_info.rs
@@ -84,11 +84,9 @@ impl RenderInfoState {
     }
 
     pub fn theoretical_fps(&self) -> f32 {
-        if let Some(average_frame_time) = self.cpu_usage_history.average() {
-            1.0 / average_frame_time
-        } else {
-            0.0
-        }
+        self.cpu_usage_history
+            .average()
+            .map_or(0.0, |average_frame_time| 1.0 / average_frame_time)
     }
 
     pub fn mean_frame_time(&self) -> f32 {
@@ -98,11 +96,9 @@ impl RenderInfoState {
     }
 
     pub fn average_fps(&self) -> f32 {
-        if let Some(mean_time_interval) = self.cpu_usage_history.mean_time_interval() {
-            1.0 / mean_time_interval
-        } else {
-            0.0
-        }
+        self.cpu_usage_history
+            .mean_time_interval()
+            .map_or(0.0, |mean_time_interval| 1.0 / mean_time_interval)
     }
 }
 
@@ -138,7 +134,6 @@ impl<'a> RenderInfo<'a> {
         ui.vertical_centered(|ui| {
             ui.heading("Rendering / UI");
         });
-
         ui.separator();
 
         ui.horizontal(|ui| {
@@ -203,7 +198,6 @@ impl<'a> RenderInfo<'a> {
 
             self.graph(ui);
         });
-
         ui.separator();
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/src/widgets/render_info.rs
+++ b/src/widgets/render_info.rs
@@ -12,23 +12,30 @@ enum RunMode {
 pub struct RenderInfoState {
     run_mode: RunMode,
     cpu_usage_history: History<f32>,
+    frame_time_history: History<f32>,
     last_frames_time: Option<f64>,
+
+    y_lim: f32,
+    plot_cpu_usage: bool,
+    plot_frame_time: bool,
 }
 
 impl RenderInfoState {
     pub fn update(&mut self, ctx: &egui::Context, frame: &eframe::Frame) {
+        let now = ctx.input(|i| i.time);
         if let Some(cpu_usage) = frame.info().cpu_usage {
-            self.cpu_usage_history
-                .add(self.last_frames_time.unwrap_or_default(), cpu_usage);
+            let last_frames_time = self.last_frames_time.unwrap_or_default();
+            self.cpu_usage_history.add(last_frames_time, cpu_usage);
+            self.frame_time_history
+                .add(last_frames_time, (now - last_frames_time) as f32);
         }
-        self.last_frames_time = Some(ctx.input(|i| i.time));
+        self.last_frames_time = Some(now);
 
         match self.run_mode {
             RunMode::Continuous => {
                 ctx.request_repaint();
             }
-            RunMode::Reactive => {
-            }
+            RunMode::Reactive => {}
         }
     }
 
@@ -45,7 +52,9 @@ impl RenderInfoState {
     }
 
     pub fn mean_frame_time(&self) -> f32 {
-        self.cpu_usage_history.mean_time_interval().unwrap_or_default()
+        self.cpu_usage_history
+            .mean_time_interval()
+            .unwrap_or_default()
     }
 
     pub fn average_fps(&self) -> f32 {
@@ -55,8 +64,6 @@ impl RenderInfoState {
             0.0
         }
     }
-
-    
 }
 
 impl Default for RenderInfoState {
@@ -64,7 +71,12 @@ impl Default for RenderInfoState {
         Self {
             run_mode: RunMode::Reactive,
             cpu_usage_history: History::new(0..300, 1.0),
+            frame_time_history: History::new(0..300, 1.0),
             last_frames_time: None,
+
+            y_lim: 0.010,
+            plot_cpu_usage: true,
+            plot_frame_time: false,
         }
     }
 }
@@ -125,7 +137,22 @@ impl<'a> RenderInfo<'a> {
 
             ui.end_row();
         });
-        ui.collapsing("📊 CPU usage history", |ui| {
+        ui.collapsing("📊 History", |ui| {
+            ui.horizontal(|ui| {
+                ui.checkbox(&mut self.state.plot_cpu_usage, "CPU usage");
+                ui.checkbox(&mut self.state.plot_frame_time, "Frame time");
+            });
+            ui.horizontal(|ui| {
+                ui.label("Y axis limit:");
+                let mut y_lim = self.state.y_lim * 1000.0;
+                ui.add(
+                    egui::DragValue::new(&mut y_lim)
+                        .range(1.0..=30.0)
+                        .suffix(" ms"),
+                );
+                self.state.y_lim = y_lim * 0.001;
+            });
+
             self.graph(ui);
         });
 
@@ -184,64 +211,55 @@ impl<'a> RenderInfo<'a> {
     }
 
     fn graph(&self, ui: &mut egui::Ui) -> egui::Response {
-        use egui::{Pos2, Rect, Sense, Shape, Stroke, TextStyle, emath, epaint, pos2, vec2};
+        use egui::{Rect, Sense, Shape, Stroke, TextStyle, emath, epaint, pos2, vec2};
 
-        let history = &self.state.cpu_usage_history;
+        let cpu_usage_history = &self.state.cpu_usage_history;
 
         let size = vec2(ui.available_size_before_wrap().x, 100.0);
         let (rect, response) = ui.allocate_at_least(size, Sense::hover());
         let style = ui.style().noninteractive();
 
-        let graph_top_cpu_usage = 0.010; // 10.0 ms
-        let graph_rect = Rect::from_x_y_ranges(history.max_age()..=0.0, graph_top_cpu_usage..=0.0);
+        let graph_top_cpu_usage = self.state.y_lim; // 10.0 ms
+        let graph_rect =
+            Rect::from_x_y_ranges(cpu_usage_history.max_age()..=0.0, graph_top_cpu_usage..=0.0);
         let to_screen = emath::RectTransform::from_to(graph_rect, rect);
 
-        let mut shapes = Vec::with_capacity(3 + history.len()); // Preallocates space for box + hover line & text + samples
+        // Preallocates space for box + hover line & text + samples
+        let number_of_shapes = 3 + 2 * cpu_usage_history.len();
+        let mut shapes = Vec::with_capacity(number_of_shapes);
         shapes.push(Shape::Rect(epaint::RectShape::new(
             rect,
             style.corner_radius,
             ui.visuals().extreme_bg_color,
             ui.style().noninteractive().bg_stroke,
-            egui::StrokeKind::Inside,
+            egui::StrokeKind::Middle,
         )));
 
-        let rect = rect.shrink(4.0);
-        let color = ui.visuals().text_color();
-        let line_stroke = Stroke::new(1.0, color);
-
-        let right_side_time = self.state.last_frames_time.unwrap_or_default();
-
-        // Add samples
-        let mut history_peekable_iter = history.iter().peekable();
-        for _ in 0..history.len() {
-            if let Some((time, cpu_usage)) = history_peekable_iter.next() {
-                let age = (right_side_time - time) as f32;
-                let pos = to_screen.transform_pos_clamped(Pos2::new(age, cpu_usage));
-
-                let mut draw_disconnected = true;
-                if let Some((following_time, following_cpu_usage)) = history_peekable_iter.peek() {
-                    let time_distance = following_time - time;
-                    // connect samples with line if they are in a window of rougly one frame at 60 fps
-                    // rounded and with additional ~1ms, since normal debug builds can miss this window quite often
-                    if time_distance < 0.018 {
-                        let following_age = (right_side_time - following_time) as f32;
-                        let following_pos = to_screen
-                            .transform_pos_clamped(Pos2::new(following_age, *following_cpu_usage));
-
-                        shapes.push(Shape::line_segment([pos, following_pos], line_stroke));
-                        draw_disconnected = false;
-                    }
-                }
-
-                if draw_disconnected {
-                    shapes.push(Shape::circle_filled(pos, 1.0, color));
-                }
-            } else {
-                break;
-            }
+        if self.state.plot_cpu_usage {
+            let color = ui.visuals().text_color();
+            let line_stroke = Stroke::new(1.0, color);
+            self.add_samples(
+                &mut shapes,
+                cpu_usage_history,
+                &to_screen,
+                line_stroke,
+                true,
+            );
+        }
+        if self.state.plot_frame_time {
+            let color = ui.visuals().weak_text_color();
+            let line_stroke = Stroke::new(1.0, color);
+            self.add_samples(
+                &mut shapes,
+                &self.state.frame_time_history,
+                &to_screen,
+                line_stroke,
+                false,
+            );
         }
 
         // Add hover line & text
+        let rect = rect.shrink(4.0);
         let color = ui.visuals().strong_text_color();
         let line_stroke = Stroke::new(1.0, color);
         if let Some(pointer_pos) = response.hover_pos() {
@@ -267,5 +285,49 @@ impl<'a> RenderInfo<'a> {
         ui.painter().extend(shapes);
 
         response
+    }
+
+    fn add_samples(
+        &self,
+        shapes: &mut Vec<egui::Shape>,
+        history: &History<f32>,
+        to_screen: &egui::emath::RectTransform,
+        line_stroke: egui::Stroke,
+        assume_value_continuity: bool,
+    ) {
+        let right_side_time = self.state.last_frames_time.unwrap_or_default();
+        let mut history_peekable_iter = history.iter().peekable();
+        for _ in 0..history.len() {
+            if let Some((time, value)) = history_peekable_iter.next() {
+                let age = (right_side_time - time) as f32;
+                let pos = to_screen.transform_pos_clamped(egui::Pos2::new(age, value));
+
+                let mut draw_disconnected = true;
+                if let Some((following_time, following_value)) = history_peekable_iter.peek() {
+                    let time_distance = following_time - time;
+                    let value_difference = following_value - value;
+                    // connect samples with line if they are in a window of rougly one frame at 60 fps
+                    // rounded and with additional ~1ms, since normal debug builds can miss this window quite often
+                    if time_distance < 0.018
+                        && (assume_value_continuity || value_difference.abs() < 0.020)
+                    {
+                        let following_age = (right_side_time - following_time) as f32;
+                        let following_pos = to_screen.transform_pos_clamped(egui::Pos2::new(
+                            following_age,
+                            *following_value,
+                        ));
+
+                        shapes.push(egui::Shape::line_segment([pos, following_pos], line_stroke));
+                        draw_disconnected = false;
+                    }
+                }
+
+                if draw_disconnected {
+                    shapes.push(egui::Shape::circle_filled(pos, 1.0, line_stroke.color));
+                }
+            } else {
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds a new dev side panel to debug builds (i.e. builds compiled with debug assertions) or when enabling the new `dev-panel` feature. For now, it contains information about the frame times and toggles to show some `egui` windows that can be useful for debugging the layout and GUI memory usage.
This allows it to be used for #183, note that `trunk` uses the `--cargo-profile` argument for specifying the profile (although I saw a quite significant performance hit with the `release-with-debug` profile compared to `release` on one setup, so using the feature may be preferable for the web version).

The implementation is based on the "Backend" panel in the `egui_demo_app` (specifically `backend_panel.rs` and `frame_history.rs`) that is used for https://www.egui.rs/#demo

**Preview of the UI:**
Screenshots of the native app running on my laptop with the `release-with-debug` profile and the default `wgpu` options:
![image](https://github.com/user-attachments/assets/a73bcbce-de30-43ad-8d24-50c75fd9c498)&nbsp;&nbsp;&nbsp;&nbsp;![image](https://github.com/user-attachments/assets/d69ad4af-11e7-4de9-91d1-ebd9969ee343)

Some things to note:
* For my setup, enabling vsync came with an increase in frame times of ~1ms but disabling vsync caused frame times to be erratic with two displays active
* There seems to be a frame pacing issue that can occur when interacting with the app. 60fps is usually held for longer periods but certain interactions can cause the frame pacing to become inconsistent. In my testing, opening a complex window (e.g. the stats edit window) consistently caused it and the issues sometimes persist even after closing the window again. This could be related to the renderer, as the web version doesn't exhibit this issue and still uses `glow`. The functionality from #187 could be used for testing different `wgpu` options (it could also be set-up dependent, but this behavior would fit with the VRR flicker issue I experienced on my desktop PC)
