### PR TITLE
Various small optimizations and refactorings

### DIFF
--- a/raphael-sim/src/actions.rs
+++ b/raphael-sim/src/actions.rs
@@ -221,6 +221,16 @@ impl GreatStrides {
 impl ActionImpl for GreatStrides {
     const LEVEL_REQUIREMENT: u8 = 21;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::GreatStrides);
+    fn precondition(
+        state: &SimulationState,
+        _settings: &Settings,
+        _condition: Condition,
+    ) -> Result<(), &'static str> {
+        match state.effects.allow_quality_actions() {
+            false => Err("Forbidden by backload_progress setting"),
+            true => Ok(()),
+        }
+    }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
         Self::CP_COST
     }
@@ -236,6 +246,16 @@ impl Innovation {
 impl ActionImpl for Innovation {
     const LEVEL_REQUIREMENT: u8 = 26;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::Innovation);
+    fn precondition(
+        state: &SimulationState,
+        _settings: &Settings,
+        _condition: Condition,
+    ) -> Result<(), &'static str> {
+        match state.effects.allow_quality_actions() {
+            false => Err("Forbidden by backload_progress setting"),
+            true => Ok(()),
+        }
+    }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
         Self::CP_COST
     }

--- a/raphael-sim/src/actions.rs
+++ b/raphael-sim/src/actions.rs
@@ -15,44 +15,24 @@ pub trait ActionImpl {
         Ok(())
     }
 
-    fn progress_increase(
-        state: &SimulationState,
-        settings: &Settings,
-        _condition: Condition,
-    ) -> u32 {
-        let efficiency_mod = Self::base_progress_increase(state, settings) as u64;
-        let mut effect_mod = 100;
-        if state.effects.muscle_memory() != 0 {
-            effect_mod += 100;
-        }
-        if state.effects.veneration() != 0 {
-            effect_mod += 50;
-        }
-        (settings.base_progress as u64 * efficiency_mod * effect_mod / 10000) as u32
+    #[inline]
+    fn progress_increase(state: &SimulationState, settings: &Settings) -> u32 {
+        let action_mod = u32::from(Self::progress_modifier(state, settings));
+        let effect_mod = u32::from(state.effects.progress_modifier());
+        u32::from(settings.base_progress) * action_mod * effect_mod / 10000
     }
 
+    #[inline]
     fn quality_increase(state: &SimulationState, settings: &Settings, condition: Condition) -> u32 {
-        let efficieny_mod = Self::base_quality_increase(state, settings) as u64;
+        let action_mod = u32::from(Self::quality_modifier(state, settings));
+        let effect_mod = u32::from(state.effects.quality_modifier());
         let condition_mod = match condition {
-            Condition::Good => 150,
-            Condition::Excellent => 400,
-            Condition::Poor => 50,
-            _ => 100,
+            Condition::Normal => 2,
+            Condition::Good => 3,
+            Condition::Excellent => 8,
+            Condition::Poor => 1,
         };
-        let mut effect_mod = 100;
-        if state.effects.innovation() != 0 {
-            effect_mod += 50;
-        }
-        if state.effects.great_strides() != 0 {
-            effect_mod += 100;
-        }
-        let inner_quiet_mod = 100 + 10 * state.effects.inner_quiet() as u64;
-        (settings.base_quality as u64
-            * efficieny_mod
-            * condition_mod
-            * effect_mod
-            * inner_quiet_mod
-            / 100_000_000) as u32
+        u32::from(settings.base_quality) * action_mod * effect_mod * condition_mod / 20000
     }
 
     fn durability_cost(state: &SimulationState, settings: &Settings, _condition: Condition) -> u16 {
@@ -69,10 +49,10 @@ pub trait ActionImpl {
         Self::base_cp_cost(state, settings)
     }
 
-    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn progress_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         0
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         0
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -94,7 +74,7 @@ pub struct BasicSynthesis {}
 impl ActionImpl for BasicSynthesis {
     const LEVEL_REQUIREMENT: u8 = 1;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::BasicSynthesis);
-    fn base_progress_increase(_state: &SimulationState, settings: &Settings) -> u32 {
+    fn progress_modifier(_state: &SimulationState, settings: &Settings) -> u32 {
         if settings.job_level < 31 { 100 } else { 120 }
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -109,7 +89,7 @@ impl BasicTouch {
 impl ActionImpl for BasicTouch {
     const LEVEL_REQUIREMENT: u8 = 5;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::BasicTouch);
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         100
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -214,7 +194,7 @@ pub struct StandardTouch {}
 impl ActionImpl for StandardTouch {
     const LEVEL_REQUIREMENT: u8 = 18;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::StandardTouch);
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         125
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -293,7 +273,7 @@ impl ActionImpl for ByregotsBlessing {
             _ => Ok(()),
         }
     }
-    fn base_quality_increase(state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(state: &SimulationState, _settings: &Settings) -> u32 {
         100 + 20 * state.effects.inner_quiet() as u32
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -324,7 +304,7 @@ impl ActionImpl for PreciseTouch {
         }
         Ok(())
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         150
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -356,7 +336,7 @@ impl ActionImpl for MuscleMemory {
         }
         Ok(())
     }
-    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn progress_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         300
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -374,7 +354,7 @@ pub struct CarefulSynthesis {}
 impl ActionImpl for CarefulSynthesis {
     const LEVEL_REQUIREMENT: u8 = 62;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::CarefulSynthesis);
-    fn base_progress_increase(_state: &SimulationState, settings: &Settings) -> u32 {
+    fn progress_modifier(_state: &SimulationState, settings: &Settings) -> u32 {
         match settings.job_level {
             0..82 => 150,
             82.. => 180,
@@ -420,7 +400,7 @@ impl ActionImpl for PrudentTouch {
         }
         Ok(())
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         100
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -435,7 +415,7 @@ pub struct AdvancedTouch {}
 impl ActionImpl for AdvancedTouch {
     const LEVEL_REQUIREMENT: u8 = 68;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::AdvancedTouch);
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         150
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -463,7 +443,7 @@ impl ActionImpl for Reflect {
         }
         Ok(())
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         300
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -485,7 +465,7 @@ impl PreparatoryTouch {
 impl ActionImpl for PreparatoryTouch {
     const LEVEL_REQUIREMENT: u8 = 71;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::PreparatoryTouch);
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         200
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -504,7 +484,7 @@ pub struct Groundwork {}
 impl ActionImpl for Groundwork {
     const LEVEL_REQUIREMENT: u8 = 72;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::Groundwork);
-    fn base_progress_increase(state: &SimulationState, settings: &Settings) -> u32 {
+    fn progress_modifier(state: &SimulationState, settings: &Settings) -> u32 {
         let base = match settings.job_level {
             0..86 => 300,
             86.. => 360,
@@ -526,13 +506,13 @@ pub struct DelicateSynthesis {}
 impl ActionImpl for DelicateSynthesis {
     const LEVEL_REQUIREMENT: u8 = 76;
     const ACTION_MASK: ActionMask = ActionMask::none().add(Action::DelicateSynthesis);
-    fn base_progress_increase(_state: &SimulationState, settings: &Settings) -> u32 {
+    fn progress_modifier(_state: &SimulationState, settings: &Settings) -> u32 {
         match settings.job_level {
             0..94 => 100,
             94.. => 150,
         }
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         100
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -562,7 +542,7 @@ impl ActionImpl for IntensiveSynthesis {
         }
         Ok(())
     }
-    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn progress_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         400
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -599,7 +579,7 @@ impl ActionImpl for TrainedEye {
     ) -> u32 {
         u32::from(settings.max_quality)
     }
-    fn base_quality_increase(_state: &SimulationState, settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, settings: &Settings) -> u32 {
         u32::from(settings.max_quality)
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -645,7 +625,7 @@ impl ActionImpl for PrudentSynthesis {
         }
         Ok(())
     }
-    fn base_progress_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn progress_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         180
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -670,7 +650,7 @@ impl ActionImpl for TrainedFinesse {
         }
         Ok(())
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         100
     }
     fn base_cp_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
@@ -695,7 +675,7 @@ impl ActionImpl for RefinedTouch {
         }
         Ok(())
     }
-    fn base_quality_increase(_state: &SimulationState, _settings: &Settings) -> u32 {
+    fn quality_modifier(_state: &SimulationState, _settings: &Settings) -> u32 {
         100
     }
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {

--- a/raphael-sim/src/effects.rs
+++ b/raphael-sim/src/effects.rs
@@ -49,6 +49,21 @@ impl Effects {
             .with_combo(Combo::SynthesisBegin)
     }
 
+    #[inline]
+    pub const fn progress_modifier(self) -> u32 {
+        let mm_mod = 2 * (self.muscle_memory() != 0) as u32;
+        let vene_mod = (self.veneration() != 0) as u32;
+        50 * (2 + mm_mod + vene_mod)
+    }
+
+    #[inline]
+    pub const fn quality_modifier(self) -> u32 {
+        let gs_mod = 2 * (self.great_strides() != 0) as u32;
+        let inno_mod = (self.innovation() != 0) as u32;
+        5 * (self.inner_quiet() as u32 + 10) * (2 + gs_mod + inno_mod)
+    }
+
+    #[inline]
     pub const fn tick_down(self) -> Self {
         const {
             assert!(Combo::SynthesisBegin.into_bits() == 0b11);
@@ -76,6 +91,7 @@ impl Effects {
     }
 
     /// Removes all effects that are only relevant for Quality.
+    #[inline]
     pub const fn strip_quality_effects(self) -> Self {
         self.with_allow_quality_actions(false)
             .with_inner_quiet(0)

--- a/raphael-sim/src/state.rs
+++ b/raphael-sim/src/state.rs
@@ -127,7 +127,7 @@ impl SimulationState {
                 .set_inner_quiet(std::cmp::min(10, state.effects.inner_quiet() + 1));
         }
 
-        let progress_increase = A::progress_increase(self, settings, condition);
+        let progress_increase = A::progress_increase(self, settings);
         state.progress += progress_increase;
         if progress_increase != 0 && state.effects.muscle_memory() != 0 {
             state.effects.set_muscle_memory(0);

--- a/raphael-sim/tests/backload_progress_tests.rs
+++ b/raphael-sim/tests/backload_progress_tests.rs
@@ -45,10 +45,19 @@ fn test_quality_actions_forbidden() {
         &[Action::Reflect, Action::BasicSynthesis, Action::Observe],
     )
     .unwrap();
+
     let result = state.use_action(Action::BasicTouch, Condition::Normal, &SETTINGS);
     assert_eq!(result, Err("Forbidden by backload_progress setting"));
+
     let result = state.use_action(Action::PreciseTouch, Condition::Good, &SETTINGS);
     assert_eq!(result, Err("Forbidden by backload_progress setting"));
+
+    let result = state.use_action(Action::Innovation, Condition::Normal, &SETTINGS);
+    assert_eq!(result, Err("Forbidden by backload_progress setting"));
+
+    let result = state.use_action(Action::GreatStrides, Condition::Normal, &SETTINGS);
+    assert_eq!(result, Err("Forbidden by backload_progress setting"));
+
     // Using a Progress-action resets Inner Quiet.
     let result = state.use_action(Action::ByregotsBlessing, Condition::Normal, &SETTINGS);
     assert_eq!(

--- a/raphael-solver/src/actions.rs
+++ b/raphael-solver/src/actions.rs
@@ -73,7 +73,7 @@ impl ActionCombo {
     }
 }
 
-pub const FULL_SEARCH_ACTIONS: &[ActionCombo] = &[
+pub const FULL_SEARCH_ACTIONS: [ActionCombo; 32] = [
     ActionCombo::AdvancedTouch,
     ActionCombo::TricksOfTheTrade,
     ActionCombo::IntensiveSynthesis,
@@ -112,7 +112,7 @@ pub const FULL_SEARCH_ACTIONS: &[ActionCombo] = &[
     ActionCombo::Single(Action::DelicateSynthesis),
 ];
 
-pub const PROGRESS_ONLY_SEARCH_ACTIONS: &[ActionCombo] = &[
+pub const PROGRESS_ONLY_SEARCH_ACTIONS: [ActionCombo; 14] = [
     ActionCombo::IntensiveSynthesis,
     ActionCombo::TricksOfTheTrade,
     // progress

--- a/raphael-solver/src/finish_solver.rs
+++ b/raphael-solver/src/finish_solver.rs
@@ -61,7 +61,7 @@ impl FinishSolver {
                 let mut max_progress = 0;
                 for action in PROGRESS_ONLY_SEARCH_ACTIONS {
                     if let Ok(new_state) =
-                        use_action_combo(&self.settings, state.to_state(), *action)
+                        use_action_combo(&self.settings, state.to_state(), action)
                     {
                         if new_state.is_final(&self.settings.simulator_settings) {
                             max_progress = std::cmp::max(max_progress, new_state.progress);

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -1,9 +1,7 @@
 use raphael_sim::*;
 
 use super::search_queue::{SearchQueueStats, SearchScore};
-use crate::actions::{
-    ActionCombo, FULL_SEARCH_ACTIONS, PROGRESS_ONLY_SEARCH_ACTIONS, use_action_combo,
-};
+use crate::actions::{ActionCombo, FULL_SEARCH_ACTIONS, use_action_combo};
 use crate::macro_solver::search_queue::SearchQueue;
 use crate::quality_upper_bound_solver::QualityUbSolverStats;
 use crate::step_lower_bound_solver::StepLbSolverStats;
@@ -109,13 +107,8 @@ impl<'a> MacroSolver<'a> {
                 (self.progress_callback)(popped);
             }
 
-            let search_actions = match state.effects.allow_quality_actions() {
-                false => PROGRESS_ONLY_SEARCH_ACTIONS,
-                true => FULL_SEARCH_ACTIONS,
-            };
-
-            for action in search_actions {
-                if let Ok(state) = use_action_combo(&self.settings, state, *action) {
+            for action in FULL_SEARCH_ACTIONS {
+                if let Ok(state) = use_action_combo(&self.settings, state, action) {
                     if !state.is_final(&self.settings.simulator_settings) {
                         if !self.finish_solver.can_finish(&state) {
                             // skip this state if it is impossible to max out Progress
@@ -162,7 +155,7 @@ impl<'a> MacroSolver<'a> {
                                 current_steps: score.current_steps + action.steps(),
                                 current_duration: score.current_duration + action.duration(),
                             },
-                            *action,
+                            action,
                             backtrack_id,
                         );
                     } else if state.progress >= self.settings.max_progress() {
@@ -184,7 +177,7 @@ impl<'a> MacroSolver<'a> {
                                 score: (solution_score, state.quality),
                                 solver_actions: search_queue
                                     .backtrack(backtrack_id)
-                                    .chain(std::iter::once(*action))
+                                    .chain(std::iter::once(action))
                                     .collect(),
                             });
                             (self.solution_callback)(&solution.as_ref().unwrap().actions());

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -1,6 +1,6 @@
 use crate::{
     SolverException, SolverSettings,
-    actions::{ActionCombo, FULL_SEARCH_ACTIONS, PROGRESS_ONLY_SEARCH_ACTIONS},
+    actions::{ActionCombo, FULL_SEARCH_ACTIONS},
     utils,
 };
 use raphael_sim::*;
@@ -71,7 +71,7 @@ impl QualityUbSolver {
             if template.max_cp > *entry {
                 *entry = template.max_cp;
                 let state = template.instantiate(template.max_cp).unwrap();
-                for &action in FULL_SEARCH_ACTIONS {
+                for action in FULL_SEARCH_ACTIONS {
                     if let Some((new_state, _, _)) =
                         state.use_action(action, &self.settings, self.durability_cost)
                     {
@@ -185,7 +185,7 @@ impl QualityUbSolver {
     ) -> Box<[ParetoValue]> {
         pareto_front_builder.clear();
         pareto_front_builder.push_empty();
-        for &action in FULL_SEARCH_ACTIONS {
+        for action in FULL_SEARCH_ACTIONS {
             if let Some((new_state, progress, quality)) =
                 state.use_action(action, &self.settings, self.durability_cost)
             {
@@ -286,11 +286,7 @@ impl QualityUbSolver {
             return Err(SolverException::Interrupted);
         }
         self.pareto_front_builder.push_empty();
-        let search_actions = match state.effects.allow_quality_actions() {
-            false => PROGRESS_ONLY_SEARCH_ACTIONS,
-            true => FULL_SEARCH_ACTIONS,
-        };
-        for &action in search_actions {
+        for action in FULL_SEARCH_ACTIONS {
             self.build_child_front(state, action)?;
             if self.pareto_front_builder.is_max() {
                 // stop early if both Progress and Quality are maxed out

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -46,7 +46,7 @@ fn check_consistency(solver_settings: SolverSettings) {
         let state = random_state(&solver_settings, &mut rng);
         let state_upper_bound = solver.quality_upper_bound(state).unwrap();
         for action in FULL_SEARCH_ACTIONS {
-            let child_upper_bound = match use_action_combo(&solver_settings, state, *action) {
+            let child_upper_bound = match use_action_combo(&solver_settings, state, action) {
                 Ok(child) => match child.is_final(&solver_settings.simulator_settings) {
                     false => solver.quality_upper_bound(child).unwrap(),
                     true if child.progress >= u32::from(solver_settings.max_progress()) => {

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU8;
 
 use crate::{
     SolverException, SolverSettings,
-    actions::{ActionCombo, FULL_SEARCH_ACTIONS, PROGRESS_ONLY_SEARCH_ACTIONS, use_action_combo},
+    actions::{ActionCombo, FULL_SEARCH_ACTIONS, use_action_combo},
     utils::{self, largest_single_action_progress_increase},
 };
 use raphael_sim::*;
@@ -71,11 +71,7 @@ impl StepLbSolver {
 
         while let Some(template) = queue.pop_front() {
             let state = template.instantiate(NonZeroU8::MAX);
-            let search_actions = match state.effects.allow_quality_actions() {
-                false => PROGRESS_ONLY_SEARCH_ACTIONS,
-                true => FULL_SEARCH_ACTIONS,
-            };
-            for &action in search_actions {
+            for action in FULL_SEARCH_ACTIONS {
                 if let Ok(new_state) = use_action_combo(settings, state.to_state(), action) {
                     let new_state = ReducedState::from_state(new_state, NonZeroU8::MAX);
                     if new_state.durability > 0 {
@@ -152,11 +148,7 @@ impl StepLbSolver {
     ) -> Box<[ParetoValue]> {
         pareto_front_builder.clear();
         pareto_front_builder.push_empty();
-        let search_actions = match state.effects.allow_quality_actions() {
-            false => PROGRESS_ONLY_SEARCH_ACTIONS,
-            true => FULL_SEARCH_ACTIONS,
-        };
-        for &action in search_actions {
+        for action in FULL_SEARCH_ACTIONS {
             if state.steps_budget.get() < action.steps() {
                 continue;
             }
@@ -260,11 +252,7 @@ impl StepLbSolver {
             return Err(SolverException::Interrupted);
         }
         self.pareto_front_builder.push_empty();
-        let search_actions = match reduced_state.effects.allow_quality_actions() {
-            false => PROGRESS_ONLY_SEARCH_ACTIONS,
-            true => FULL_SEARCH_ACTIONS,
-        };
-        for &action in search_actions {
+        for action in FULL_SEARCH_ACTIONS {
             if action.steps() <= reduced_state.steps_budget.get() {
                 self.build_child_front(reduced_state, action)?;
                 if self.pareto_front_builder.is_max() {

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -18,7 +18,7 @@ fn check_consistency(solver_settings: SolverSettings) {
         let state = random_state(&solver_settings, &mut rng);
         let state_step_lb = solver.step_lower_bound(state, 0).unwrap();
         for action in FULL_SEARCH_ACTIONS {
-            if let Ok(child_state) = use_action_combo(&solver_settings, state, *action) {
+            if let Ok(child_state) = use_action_combo(&solver_settings, state, action) {
                 let child_step_lb = if child_state.is_final(&solver_settings.simulator_settings) {
                     let progress_maxed = child_state.progress >= solver_settings.max_progress();
                     let quality_maxed = child_state.quality >= solver_settings.max_quality();

--- a/raphael-solver/src/utils/mod.rs
+++ b/raphael-solver/src/utils/mod.rs
@@ -112,7 +112,7 @@ pub fn compute_iq_quality_lut(settings: &SolverSettings) -> [u32; 11] {
                 .with_adversarial_guard(true)
                 .with_inner_quiet(iq),
         };
-        for &action in FULL_SEARCH_ACTIONS {
+        for action in FULL_SEARCH_ACTIONS {
             if let Ok(new_state) = use_action_combo(settings, state, action) {
                 let new_iq = new_state.effects.inner_quiet();
                 if new_iq > iq {

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -125,9 +125,9 @@ fn zero_quality() {
         MacroSolverStats {
             finish_states: 1660,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 40,
-                dropped_nodes: 10,
-                pareto_buckets_squared_size_sum: 110,
+                processed_nodes: 41,
+                dropped_nodes: 12,
+                pareto_buckets_squared_size_sum: 73,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 31147,
@@ -171,11 +171,11 @@ fn max_quality() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 244100,
+            finish_states: 245618,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 5592,
-                dropped_nodes: 65882,
-                pareto_buckets_squared_size_sum: 46660,
+                processed_nodes: 5843,
+                dropped_nodes: 68720,
+                pareto_buckets_squared_size_sum: 36691,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 389796,
@@ -199,8 +199,8 @@ fn large_progress_quality_increase() {
         max_durability: 40,
         max_progress: 100,
         max_quality: 100,
-        base_progress: u16::MAX,
-        base_quality: u16::MAX,
+        base_progress: 5000,
+        base_quality: 5000,
         job_level: 100,
         allowed_actions: ActionMask::all(),
         adversarial: false,
@@ -213,7 +213,7 @@ fn large_progress_quality_increase() {
                 capped_quality: 100,
                 steps: 1,
                 duration: 3,
-                overflow_quality: 65435,
+                overflow_quality: 4900,
             },
         )
     "#]];

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -274,9 +274,9 @@ fn backload_progress_single_delicate_synthesis() {
                 pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
-                parallel_states: 9346,
+                parallel_states: 8965,
                 sequential_states: 0,
-                pareto_values: 9346,
+                pareto_values: 8965,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1596,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -429,7 +429,7 @@ fn stuffed_peppers_2_heart_and_soul() {
             finish_states: 479880,
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 3679,
-                dropped_nodes: 63488,
+                dropped_nodes: 63489,
                 pareto_buckets_squared_size_sum: 36165,
             },
             quality_ub_stats: QualityUbSolverStats {

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -84,9 +84,9 @@ fn rinascita_3700_3280() {
         MacroSolverStats {
             finish_states: 212417,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 456,
-                dropped_nodes: 4506,
-                pareto_buckets_squared_size_sum: 2538,
+                processed_nodes: 459,
+                dropped_nodes: 4545,
+                pareto_buckets_squared_size_sum: 1781,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 957930,
@@ -130,16 +130,16 @@ fn pactmaker_3240_3130() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 267200,
+            finish_states: 267636,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 4454,
-                dropped_nodes: 32686,
-                pareto_buckets_squared_size_sum: 241837,
+                processed_nodes: 4623,
+                dropped_nodes: 34199,
+                pareto_buckets_squared_size_sum: 171614,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 818130,
-                sequential_states: 44927,
-                pareto_values: 13132095,
+                sequential_states: 44933,
+                pareto_values: 13132245,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -182,9 +182,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
         MacroSolverStats {
             finish_states: 248396,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 571,
-                dropped_nodes: 6571,
-                pareto_buckets_squared_size_sum: 5691,
+                processed_nodes: 577,
+                dropped_nodes: 6649,
+                pareto_buckets_squared_size_sum: 3863,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1690660,
@@ -230,9 +230,9 @@ fn diadochos_4021_3660() {
         MacroSolverStats {
             finish_states: 426813,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1578,
-                dropped_nodes: 4978,
-                pareto_buckets_squared_size_sum: 37264,
+                processed_nodes: 1630,
+                dropped_nodes: 5157,
+                pareto_buckets_squared_size_sum: 24480,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 888030,
@@ -276,11 +276,11 @@ fn indagator_3858_4057() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 345769,
+            finish_states: 346009,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3222,
-                dropped_nodes: 18224,
-                pareto_buckets_squared_size_sum: 96982,
+                processed_nodes: 3359,
+                dropped_nodes: 19188,
+                pareto_buckets_squared_size_sum: 65123,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 971910,
@@ -324,16 +324,16 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1190393,
+            finish_states: 1197808,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 61930,
-                dropped_nodes: 250888,
-                pareto_buckets_squared_size_sum: 7195828,
+                processed_nodes: 65094,
+                dropped_nodes: 265540,
+                pareto_buckets_squared_size_sum: 4726300,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,
-                sequential_states: 10702,
-                pareto_values: 18106329,
+                sequential_states: 10989,
+                pareto_values: 18108944,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2318275,
@@ -374,11 +374,11 @@ fn stuffed_peppers_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 353410,
+            finish_states: 354023,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3115,
-                dropped_nodes: 47363,
-                pareto_buckets_squared_size_sum: 42015,
+                processed_nodes: 3145,
+                dropped_nodes: 47888,
+                pareto_buckets_squared_size_sum: 31195,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 727703,
@@ -426,11 +426,11 @@ fn stuffed_peppers_2_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 478840,
+            finish_states: 479880,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3643,
-                dropped_nodes: 62771,
-                pareto_buckets_squared_size_sum: 48356,
+                processed_nodes: 3679,
+                dropped_nodes: 63488,
+                pareto_buckets_squared_size_sum: 36165,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1547790,
@@ -478,11 +478,11 @@ fn stuffed_peppers_2_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 353411,
+            finish_states: 354024,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3115,
-                dropped_nodes: 48533,
-                pareto_buckets_squared_size_sum: 42015,
+                processed_nodes: 3145,
+                dropped_nodes: 49074,
+                pareto_buckets_squared_size_sum: 31195,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1477069,
@@ -530,7 +530,7 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 292,
                 dropped_nodes: 3564,
-                pareto_buckets_squared_size_sum: 783,
+                pareto_buckets_squared_size_sum: 644,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 750109,
@@ -574,11 +574,11 @@ fn black_star_4048_3997() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 131819,
+            finish_states: 136859,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 8093,
-                dropped_nodes: 97927,
-                pareto_buckets_squared_size_sum: 458666,
+                processed_nodes: 9079,
+                dropped_nodes: 111869,
+                pareto_buckets_squared_size_sum: 356414,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 448545,
@@ -622,11 +622,11 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 308214,
+            finish_states: 315154,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 26389,
-                dropped_nodes: 407583,
-                pareto_buckets_squared_size_sum: 2536899,
+                processed_nodes: 27817,
+                dropped_nodes: 430405,
+                pareto_buckets_squared_size_sum: 1595686,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 632525,
@@ -670,11 +670,11 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 395101,
+            finish_states: 395204,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 349,
-                dropped_nodes: 4773,
-                pareto_buckets_squared_size_sum: 889,
+                processed_nodes: 357,
+                dropped_nodes: 4875,
+                pareto_buckets_squared_size_sum: 679,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 654113,
@@ -718,11 +718,11 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 457339,
+            finish_states: 457491,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1194,
-                dropped_nodes: 17919,
-                pareto_buckets_squared_size_sum: 5727,
+                processed_nodes: 1202,
+                dropped_nodes: 18056,
+                pareto_buckets_squared_size_sum: 4650,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 620174,
@@ -766,11 +766,11 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1169189,
+            finish_states: 1171247,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 16259,
-                dropped_nodes: 246089,
-                pareto_buckets_squared_size_sum: 610705,
+                processed_nodes: 16606,
+                dropped_nodes: 251621,
+                pareto_buckets_squared_size_sum: 433633,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 871349,
@@ -814,16 +814,16 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 574570,
+            finish_states: 584023,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 151237,
-                dropped_nodes: 672402,
-                pareto_buckets_squared_size_sum: 35948055,
+                processed_nodes: 161594,
+                dropped_nodes: 720978,
+                pareto_buckets_squared_size_sum: 27623705,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 994029,
-                sequential_states: 5093,
-                pareto_values: 12428188,
+                sequential_states: 5457,
+                pareto_values: 12431117,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 361555,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -84,9 +84,9 @@ fn rinascita_3700_3280() {
         MacroSolverStats {
             finish_states: 321264,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3677,
-                dropped_nodes: 46631,
-                pareto_buckets_squared_size_sum: 31595,
+                processed_nodes: 3720,
+                dropped_nodes: 47101,
+                pareto_buckets_squared_size_sum: 20840,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 946344,
@@ -130,16 +130,16 @@ fn pactmaker_3240_3130() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 298444,
+            finish_states: 298565,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 5040,
-                dropped_nodes: 62372,
-                pareto_buckets_squared_size_sum: 79906,
+                processed_nodes: 5246,
+                dropped_nodes: 65584,
+                pareto_buckets_squared_size_sum: 54474,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 808184,
-                sequential_states: 46095,
-                pareto_values: 17736548,
+                sequential_states: 46099,
+                pareto_values: 17736698,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -182,9 +182,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
         MacroSolverStats {
             finish_states: 273192,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1014,
-                dropped_nodes: 16268,
-                pareto_buckets_squared_size_sum: 7368,
+                processed_nodes: 1020,
+                dropped_nodes: 16380,
+                pareto_buckets_squared_size_sum: 4700,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1668344,
@@ -228,16 +228,16 @@ fn diadochos_4021_3660() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 522769,
+            finish_states: 522802,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 5960,
-                dropped_nodes: 35578,
-                pareto_buckets_squared_size_sum: 58238,
+                processed_nodes: 6058,
+                dropped_nodes: 36110,
+                pareto_buckets_squared_size_sum: 36854,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 877264,
-                sequential_states: 46835,
-                pareto_values: 23560094,
+                sequential_states: 46836,
+                pareto_values: 23560138,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -280,7 +280,7 @@ fn indagator_3858_4057() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 341,
                 dropped_nodes: 5021,
-                pareto_buckets_squared_size_sum: 705,
+                pareto_buckets_squared_size_sum: 559,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 960160,
@@ -324,16 +324,16 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 2399401,
+            finish_states: 2411529,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1522890,
-                dropped_nodes: 10343173,
-                pareto_buckets_squared_size_sum: 95896549,
+                processed_nodes: 1591900,
+                dropped_nodes: 10803132,
+                pareto_buckets_squared_size_sum: 64404105,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
-                sequential_states: 3374,
-                pareto_values: 24352482,
+                sequential_states: 3433,
+                pareto_values: 24353529,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
@@ -378,7 +378,7 @@ fn stuffed_peppers_2() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 160,
                 dropped_nodes: 3297,
-                pareto_buckets_squared_size_sum: 296,
+                pareto_buckets_squared_size_sum: 256,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 685374,
@@ -426,11 +426,11 @@ fn stuffed_peppers_2_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 135606,
+            finish_states: 135817,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 165,
-                dropped_nodes: 3872,
-                pareto_buckets_squared_size_sum: 305,
+                processed_nodes: 170,
+                dropped_nodes: 4003,
+                pareto_buckets_squared_size_sum: 272,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1464188,
@@ -482,7 +482,7 @@ fn stuffed_peppers_2_quick_innovation() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 160,
                 dropped_nodes: 3422,
-                pareto_buckets_squared_size_sum: 296,
+                pareto_buckets_squared_size_sum: 256,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1405659,
@@ -526,11 +526,11 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1223013,
+            finish_states: 1224118,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 22094,
-                dropped_nodes: 354616,
-                pareto_buckets_squared_size_sum: 256311,
+                processed_nodes: 22404,
+                dropped_nodes: 359646,
+                pareto_buckets_squared_size_sum: 187676,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 709548,
@@ -576,9 +576,9 @@ fn black_star_4048_3997() {
         MacroSolverStats {
             finish_states: 49606,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1729,
-                dropped_nodes: 26277,
-                pareto_buckets_squared_size_sum: 20123,
+                processed_nodes: 1739,
+                dropped_nodes: 26431,
+                pareto_buckets_squared_size_sum: 15755,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 414395,
@@ -622,11 +622,11 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 126581,
+            finish_states: 127733,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 8117,
-                dropped_nodes: 157666,
-                pareto_buckets_squared_size_sum: 106096,
+                processed_nodes: 8296,
+                dropped_nodes: 161278,
+                pareto_buckets_squared_size_sum: 79064,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 588992,
@@ -674,7 +674,7 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 74,
                 dropped_nodes: 1486,
-                pareto_buckets_squared_size_sum: 104,
+                pareto_buckets_squared_size_sum: 90,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 615546,
@@ -718,11 +718,11 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 688802,
+            finish_states: 690212,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 7032,
-                dropped_nodes: 141830,
-                pareto_buckets_squared_size_sum: 37776,
+                processed_nodes: 7153,
+                dropped_nodes: 144383,
+                pareto_buckets_squared_size_sum: 27336,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 579131,
@@ -766,11 +766,11 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 870072,
+            finish_states: 870640,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 7714,
-                dropped_nodes: 153617,
-                pareto_buckets_squared_size_sum: 53454,
+                processed_nodes: 7820,
+                dropped_nodes: 155839,
+                pareto_buckets_squared_size_sum: 37628,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 812878,
@@ -814,16 +814,16 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 861043,
+            finish_states: 867357,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1815192,
-                dropped_nodes: 13104122,
-                pareto_buckets_squared_size_sum: 184052518,
+                processed_nodes: 1889237,
+                dropped_nodes: 13613015,
+                pareto_buckets_squared_size_sum: 142776403,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,
-                sequential_states: 1226,
-                pareto_values: 17428578,
+                sequential_states: 1305,
+                pareto_values: 17429437,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 386882,
@@ -862,16 +862,16 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 268611,
+            finish_states: 270612,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 26258,
-                dropped_nodes: 291149,
-                pareto_buckets_squared_size_sum: 411956,
+                processed_nodes: 28159,
+                dropped_nodes: 316039,
+                pareto_buckets_squared_size_sum: 310984,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2397570,
-                sequential_states: 106038,
-                pareto_values: 38830081,
+                sequential_states: 106175,
+                pareto_values: 38834009,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -915,7 +915,7 @@ fn ceviche_4900_4800_no_quality() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 29,
                 dropped_nodes: 552,
-                pareto_buckets_squared_size_sum: 35,
+                pareto_buckets_squared_size_sum: 31,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 428868,
@@ -963,9 +963,9 @@ fn ce_high_progress_zero_achieved_quality() {
         MacroSolverStats {
             finish_states: 1751541,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 390,
+                processed_nodes: 397,
                 dropped_nodes: 0,
-                pareto_buckets_squared_size_sum: 692,
+                pareto_buckets_squared_size_sum: 635,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 951755,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -97,11 +97,11 @@ fn stuffed_peppers() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 887952,
+            finish_states: 890816,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 81289,
-                dropped_nodes: 1587866,
-                pareto_buckets_squared_size_sum: 1244127,
+                processed_nodes: 91499,
+                dropped_nodes: 1784905,
+                pareto_buckets_squared_size_sum: 829308,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2271577,
@@ -147,16 +147,16 @@ fn test_rare_tacos_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1465416,
+            finish_states: 1474105,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3386237,
-                dropped_nodes: 28582063,
-                pareto_buckets_squared_size_sum: 298723983,
+                processed_nodes: 3940600,
+                dropped_nodes: 33281192,
+                pareto_buckets_squared_size_sum: 147481883,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490785,
-                sequential_states: 77299,
-                pareto_values: 70118044,
+                sequential_states: 77526,
+                pareto_values: 70121996,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
@@ -201,21 +201,21 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 77711,
+            finish_states: 78708,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 28455,
-                dropped_nodes: 374117,
-                pareto_buckets_squared_size_sum: 600321,
+                processed_nodes: 32081,
+                dropped_nodes: 420041,
+                pareto_buckets_squared_size_sum: 363187,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1800446,
-                sequential_states: 545,
-                pareto_values: 16363329,
+                sequential_states: 603,
+                pareto_values: 16364005,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 52408,
-                sequential_states: 240,
-                pareto_values: 449854,
+                sequential_states: 241,
+                pareto_values: 449860,
             },
         }
     "#]];
@@ -249,16 +249,16 @@ fn test_indagator_3858_4057() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 512563,
+            finish_states: 513344,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 20479,
-                dropped_nodes: 199583,
-                pareto_buckets_squared_size_sum: 314742,
+                processed_nodes: 20924,
+                dropped_nodes: 203700,
+                pareto_buckets_squared_size_sum: 155823,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2515306,
-                sequential_states: 140937,
-                pareto_values: 64650413,
+                sequential_states: 140940,
+                pareto_values: 64650515,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -301,16 +301,16 @@ fn test_rare_tacos_4628_4410() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 554262,
+            finish_states: 560313,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 947506,
-                dropped_nodes: 2316515,
-                pareto_buckets_squared_size_sum: 65519330,
+                processed_nodes: 1089875,
+                dropped_nodes: 2711119,
+                pareto_buckets_squared_size_sum: 31657262,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2623634,
-                sequential_states: 69176,
-                pareto_values: 78047665,
+                sequential_states: 69179,
+                pareto_values: 78047729,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 420784,
@@ -352,16 +352,16 @@ fn issue_113() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1960833,
+            finish_states: 1970350,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1268483,
-                dropped_nodes: 17918421,
-                pareto_buckets_squared_size_sum: 78163755,
+                processed_nodes: 1452200,
+                dropped_nodes: 20446753,
+                pareto_buckets_squared_size_sum: 36945689,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 3043554,
-                sequential_states: 80265,
-                pareto_values: 120616636,
+                sequential_states: 80275,
+                pareto_values: 120617206,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -401,16 +401,16 @@ fn issue_118() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 571642,
+            finish_states: 576460,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1215569,
-                dropped_nodes: 14411862,
-                pareto_buckets_squared_size_sum: 216085380,
+                processed_nodes: 1357305,
+                dropped_nodes: 16110898,
+                pareto_buckets_squared_size_sum: 127341497,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1931154,
-                sequential_states: 50515,
-                pareto_values: 25428797,
+                sequential_states: 50791,
+                pareto_values: 25432637,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 258314,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -97,11 +97,11 @@ fn stuffed_peppers() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 890816,
+            finish_states: 890638,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 91499,
-                dropped_nodes: 1784905,
-                pareto_buckets_squared_size_sum: 829308,
+                processed_nodes: 90783,
+                dropped_nodes: 1770876,
+                pareto_buckets_squared_size_sum: 805040,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2271577,
@@ -147,16 +147,16 @@ fn test_rare_tacos_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1474105,
+            finish_states: 1474064,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3940600,
-                dropped_nodes: 33281192,
-                pareto_buckets_squared_size_sum: 147481883,
+                processed_nodes: 3907014,
+                dropped_nodes: 33021901,
+                pareto_buckets_squared_size_sum: 140922931,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490785,
-                sequential_states: 77526,
-                pareto_values: 70121996,
+                sequential_states: 77523,
+                pareto_values: 70121907,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
@@ -201,11 +201,11 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 78708,
+            finish_states: 78637,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 32081,
-                dropped_nodes: 420041,
-                pareto_buckets_squared_size_sum: 363187,
+                processed_nodes: 31661,
+                dropped_nodes: 414254,
+                pareto_buckets_squared_size_sum: 348836,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1800446,
@@ -251,9 +251,9 @@ fn test_indagator_3858_4057() {
         MacroSolverStats {
             finish_states: 513344,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 20924,
-                dropped_nodes: 203700,
-                pareto_buckets_squared_size_sum: 155823,
+                processed_nodes: 20921,
+                dropped_nodes: 203673,
+                pareto_buckets_squared_size_sum: 155735,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2515306,
@@ -301,16 +301,16 @@ fn test_rare_tacos_4628_4410() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 560313,
+            finish_states: 560266,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1089875,
-                dropped_nodes: 2711119,
-                pareto_buckets_squared_size_sum: 31657262,
+                processed_nodes: 1083077,
+                dropped_nodes: 2702408,
+                pareto_buckets_squared_size_sum: 30741678,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2623634,
-                sequential_states: 69179,
-                pareto_values: 78047729,
+                sequential_states: 69174,
+                pareto_values: 78047587,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 420784,
@@ -352,16 +352,16 @@ fn issue_113() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1970350,
+            finish_states: 1969837,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1452200,
-                dropped_nodes: 20446753,
-                pareto_buckets_squared_size_sum: 36945689,
+                processed_nodes: 1443874,
+                dropped_nodes: 20339022,
+                pareto_buckets_squared_size_sum: 36070522,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 3043554,
-                sequential_states: 80275,
-                pareto_values: 120617206,
+                sequential_states: 80270,
+                pareto_values: 120616917,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
@@ -401,16 +401,16 @@ fn issue_118() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 576460,
+            finish_states: 576410,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1357305,
-                dropped_nodes: 16110898,
-                pareto_buckets_squared_size_sum: 127341497,
+                processed_nodes: 1343629,
+                dropped_nodes: 15942609,
+                pareto_buckets_squared_size_sum: 121235617,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1931154,
-                sequential_states: 50791,
-                pareto_values: 25432637,
+                sequential_states: 50787,
+                pareto_values: 25432562,
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 258314,


### PR DESCRIPTION
Measurements with `perf stat` for `macro_solver_example`:

Before:
```
         24.413,53 msec task-clock                       #    1,940 CPUs utilized             
            23.030      context-switches                 #  943,330 /sec                      
             1.847      cpu-migrations                   #   75,655 /sec                      
           222.075      page-faults                      #    9,096 K/sec                     
    92.175.601.000      cycles                           #    3,776 GHz                       
    20.390.910.968      stalled-cycles-frontend          #   22,12% frontend cycles idle      
    91.374.651.268      instructions                     #    0,99  insn per cycle            
                                                  #    0,22  stalled cycles per insn   
    16.338.786.710      branches                         #  669,251 M/sec                     
       816.021.957      branch-misses                    #    4,99% of all branches

      12,586939718 seconds time elapsed
```

After:
```
         23.770,81 msec task-clock                       #    1,985 CPUs utilized             
            24.460      context-switches                 #    1,029 K/sec                     
             1.872      cpu-migrations                   #   78,752 /sec                      
           235.189      page-faults                      #    9,894 K/sec                     
    89.703.146.495      cycles                           #    3,774 GHz                       
    16.861.604.587      stalled-cycles-frontend          #   18,80% frontend cycles idle      
    93.843.832.337      instructions                     #    1,05  insn per cycle            
                                                  #    0,18  stalled cycles per insn   
    15.809.251.679      branches                         #  665,070 M/sec                     
       665.274.602      branch-misses                    #    4,21% of all branches           

      11,974739415 seconds time elapsed
```      