### PR TITLE
Fully eliminate sequential `StepLbSolver` states

### DIFF
--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -88,6 +88,10 @@ impl<'a> MacroSolver<'a> {
         self.quality_ub_solver.precompute();
         drop(timer);
 
+        let timer = ScopedTimer::new("Step Lb Solver");
+        self.step_lb_solver.precompute();
+        drop(timer);
+
         Ok(self.do_solve(initial_state)?.actions())
     }
 

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -221,12 +221,8 @@ impl QualityUbSolver {
         &mut self,
         mut state: SimulationState,
     ) -> Result<u32, SolverException> {
-        if state.effects.combo() != Combo::None {
-            return Err(SolverException::InternalError(format!(
-                "\"{:?}\" combo in quality upper bound solver",
-                state.effects.combo()
-            )));
-        }
+        #[cfg(test)]
+        assert!(state.effects.combo() == Combo::None);
 
         let mut required_progress = self.settings.max_progress() - state.progress;
         if state.effects.muscle_memory() != 0 {

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -41,9 +41,9 @@ fn test_manipulation_refund() {
 fn check_consistency(solver_settings: SolverSettings) {
     let mut solver = QualityUbSolver::new(solver_settings, Default::default());
     solver.precompute();
-    let mut rng = rand::rng();
-    for _ in 0..100000 {
-        let state = random_state(&solver_settings, &mut rng);
+    for state in generate_random_states(solver_settings, 1_000_000)
+        .filter(|state| state.effects.combo() == Combo::None)
+    {
         let state_upper_bound = solver.quality_upper_bound(state).unwrap();
         for action in FULL_SEARCH_ACTIONS {
             let child_upper_bound = match use_action_combo(&solver_settings, state, action) {

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -38,6 +38,7 @@ pub struct StepLbSolver {
 
 impl StepLbSolver {
     pub fn new(mut settings: SolverSettings, interrupt_signal: utils::AtomicFlag) -> Self {
+        let iq_quality_lut = utils::compute_iq_quality_lut(&settings);
         settings.simulator_settings.adversarial = false;
         ReducedState::optimize_action_mask(&mut settings.simulator_settings);
         Self {
@@ -51,7 +52,7 @@ impl StepLbSolver {
             precompute_templates: Self::generate_precompute_templates(&settings),
             next_precompute_step_budget: NonZeroU8::new(1).unwrap(),
             precomputed_states: 0,
-            iq_quality_lut: utils::compute_iq_quality_lut(&settings),
+            iq_quality_lut,
             largest_progress_increase: largest_single_action_progress_increase(&settings),
         }
     }

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -207,12 +207,8 @@ impl StepLbSolver {
         mut state: SimulationState,
         step_budget: NonZeroU8,
     ) -> Result<Option<u32>, SolverException> {
-        if state.effects.combo() != Combo::None {
-            return Err(SolverException::InternalError(format!(
-                "\"{:?}\" combo in step lower bound solver",
-                state.effects.combo()
-            )));
-        }
+        #[cfg(test)]
+        assert!(state.effects.combo() == Combo::None);
 
         while self.next_precompute_step_budget <= step_budget {
             self.precompute_next_step_budget();

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -13,6 +13,7 @@ use super::*;
 /// It is admissible if the step-lb of a state is never greater than the step count of a reachable final state.
 fn check_consistency(solver_settings: SolverSettings) {
     let mut solver = StepLbSolver::new(solver_settings, AtomicFlag::default());
+    solver.precompute();
     for state in generate_random_states(solver_settings, 1_000_000)
         .filter(|state| state.effects.combo() == Combo::None)
     {

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -13,9 +13,9 @@ use super::*;
 /// It is admissible if the step-lb of a state is never greater than the step count of a reachable final state.
 fn check_consistency(solver_settings: SolverSettings) {
     let mut solver = StepLbSolver::new(solver_settings, AtomicFlag::default());
-    let mut rng = rand::rng();
-    for _ in 0..100000 {
-        let state = random_state(&solver_settings, &mut rng);
+    for state in generate_random_states(solver_settings, 1_000_000)
+        .filter(|state| state.effects.combo() == Combo::None)
+    {
         let state_step_lb = solver.step_lower_bound(state, 0).unwrap();
         for action in FULL_SEARCH_ACTIONS {
             if let Ok(child_state) = use_action_combo(&solver_settings, state, action) {
@@ -38,15 +38,6 @@ fn check_consistency(solver_settings: SolverSettings) {
         }
     }
 }
-
-const REGULAR_ACTIONS: ActionMask = ActionMask::all()
-    .remove(Action::TrainedEye)
-    .remove(Action::HeartAndSoul)
-    .remove(Action::QuickInnovation);
-const NO_MANIPULATION: ActionMask = REGULAR_ACTIONS.remove(Action::Manipulation);
-const WITH_SPECIALIST_ACTIONS: ActionMask = REGULAR_ACTIONS
-    .add(Action::HeartAndSoul)
-    .add(Action::QuickInnovation);
 
 #[test_case::test_matrix(
     [20, 35, 60, 80],

--- a/raphael-solver/src/test_utils.rs
+++ b/raphael-solver/src/test_utils.rs
@@ -1,6 +1,10 @@
+use rand::Rng;
 use raphael_sim::*;
 
-use crate::SolverSettings;
+use crate::{
+    SolverSettings,
+    actions::{FULL_SEARCH_ACTIONS, use_action_combo},
+};
 
 pub const REGULAR_ACTIONS: ActionMask = ActionMask::all()
     .remove(Action::TrainedEye)
@@ -11,45 +15,22 @@ pub const WITH_SPECIALIST_ACTIONS: ActionMask = REGULAR_ACTIONS
     .add(Action::HeartAndSoul)
     .add(Action::QuickInnovation);
 
-fn random_effects(settings: &Settings, rng: &mut impl rand::Rng) -> Effects {
-    let mut effects = Effects::new()
-        .with_muscle_memory(rng.random_range(0..=5))
-        .with_inner_quiet(rng.random_range(0..=10))
-        .with_great_strides(rng.random_range(0..=3))
-        .with_innovation(rng.random_range(0..=4))
-        .with_veneration(rng.random_range(0..=4))
-        .with_waste_not(rng.random_range(0..=8))
-        .with_adversarial_guard(rng.random() && settings.adversarial)
-        .with_allow_quality_actions(rng.random() || !settings.backload_progress);
-    if settings.is_action_allowed::<Manipulation>() {
-        effects.set_manipulation(rng.random_range(0..=8));
+pub fn generate_random_states(
+    settings: SolverSettings,
+    min_num_states: usize,
+) -> impl Iterator<Item = SimulationState> {
+    let mut rng = rand::rng();
+    let mut generated_states = vec![SimulationState::new(&settings.simulator_settings)];
+    while generated_states.len() < min_num_states {
+        let state = generated_states[rng.random_range(0..generated_states.len())];
+        for _ in 0..5 {
+            let action = FULL_SEARCH_ACTIONS[rng.random_range(0..FULL_SEARCH_ACTIONS.len())];
+            if let Ok(new_state) = use_action_combo(&settings, state, action)
+                && !new_state.is_final(&settings.simulator_settings)
+            {
+                generated_states.push(new_state);
+            }
+        }
     }
-    if settings.is_action_allowed::<TrainedPerfection>() {
-        effects.set_trained_perfection_available(rng.random());
-        effects
-            .set_trained_perfection_active(!effects.trained_perfection_available() && rng.random());
-    }
-    if settings.is_action_allowed::<HeartAndSoul>() {
-        effects.set_heart_and_soul_available(rng.random());
-        effects.set_heart_and_soul_active(!effects.heart_and_soul_available() && rng.random());
-    }
-    if settings.is_action_allowed::<QuickInnovation>() {
-        effects.set_quick_innovation_available(rng.random());
-    }
-    effects
-}
-
-pub fn random_state(settings: &SolverSettings, rng: &mut impl rand::Rng) -> SimulationState {
-    SimulationState {
-        cp: rng.random_range(0..=settings.max_cp()),
-        durability: rng
-            .random_range(1..=settings.max_durability())
-            .next_multiple_of(5),
-        progress: rng.random_range(0..settings.max_progress()),
-        quality: rng.random_range(0..=settings.max_quality()),
-        unreliable_quality: 0,
-        effects: random_effects(&settings.simulator_settings, rng),
-    }
-    .try_into()
-    .unwrap()
+    generated_states.into_iter()
 }

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -88,7 +88,6 @@ fn unsolvable() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -136,7 +135,6 @@ fn zero_quality() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -184,7 +182,6 @@ fn max_quality() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 238904,
-                sequential_states: 0,
                 pareto_values: 1635771,
             },
         }
@@ -232,7 +229,6 @@ fn large_progress_quality_increase() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 6336,
-                sequential_states: 0,
                 pareto_values: 6336,
             },
         }
@@ -280,7 +276,6 @@ fn backload_progress_single_delicate_synthesis() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1596,
-                sequential_states: 0,
                 pareto_values: 1596,
             },
         }

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -134,8 +134,8 @@ fn zero_quality() {
                 pareto_values: 109398,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 228416,
+                pareto_values: 1548874,
             },
         }
     "#]];
@@ -181,8 +181,8 @@ fn max_quality() {
                 pareto_values: 2988048,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 238904,
-                pareto_values: 1635771,
+                parallel_states: 239199,
+                pareto_values: 1636066,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -94,8 +94,8 @@ fn rinascita_3700_3280() {
                 pareto_values: 17006469,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 1182529,
+                pareto_values: 12830718,
             },
         }
     "#]];
@@ -141,8 +141,8 @@ fn pactmaker_3240_3130() {
                 pareto_values: 13132245,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 1178119,
+                pareto_values: 12523354,
             },
         }
     "#]];
@@ -190,8 +190,8 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_values: 27637851,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 2628018,
+                pareto_values: 26945403,
             },
         }
     "#]];
@@ -237,8 +237,8 @@ fn diadochos_4021_3660() {
                 pareto_values: 17385016,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 1314510,
+                pareto_values: 16561809,
             },
         }
     "#]];
@@ -284,8 +284,8 @@ fn indagator_3858_4057() {
                 pareto_values: 17456807,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 1037399,
+                pareto_values: 11619982,
             },
         }
     "#]];
@@ -331,8 +331,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_values: 18108944,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2318275,
-                pareto_values: 24996627,
+                parallel_states: 2288175,
+                pareto_values: 24966527,
             },
         }
     "#]];
@@ -380,8 +380,8 @@ fn stuffed_peppers_2() {
                 pareto_values: 9890579,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1493595,
-                pareto_values: 12299858,
+                parallel_states: 1471490,
+                pareto_values: 12277753,
             },
         }
     "#]];
@@ -431,8 +431,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_values: 20676360,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 3361396,
-                pareto_values: 26035232,
+                parallel_states: 3316813,
+                pareto_values: 25990649,
             },
         }
     "#]];
@@ -482,8 +482,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_values: 20284215,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 3071733,
-                pareto_values: 25567704,
+                parallel_states: 3049851,
+                pareto_values: 25545822,
             },
         }
     "#]];
@@ -529,8 +529,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 11255498,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1579065,
-                pareto_values: 13935076,
+                parallel_states: 1560786,
+                pareto_values: 13916797,
             },
         }
     "#]];
@@ -576,8 +576,8 @@ fn black_star_4048_3997() {
                 pareto_values: 3013677,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 168003,
-                pareto_values: 928501,
+                parallel_states: 163956,
+                pareto_values: 924454,
             },
         }
     "#]];
@@ -623,8 +623,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 4877078,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 461630,
-                pareto_values: 2798356,
+                parallel_states: 452635,
+                pareto_values: 2789361,
             },
         }
     "#]];
@@ -670,8 +670,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 8411272,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1336246,
-                pareto_values: 10026036,
+                parallel_states: 1317961,
+                pareto_values: 10007751,
             },
         }
     "#]];
@@ -717,8 +717,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 7334997,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1118641,
-                pareto_values: 8025952,
+                parallel_states: 1101885,
+                pareto_values: 8009196,
             },
         }
     "#]];
@@ -764,8 +764,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 14549573,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1556489,
-                pareto_values: 14722811,
+                parallel_states: 1539116,
+                pareto_values: 14705438,
             },
         }
     "#]];
@@ -811,8 +811,8 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_values: 12431117,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 361555,
-                pareto_values: 3147923,
+                parallel_states: 355665,
+                pareto_values: 3142033,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -95,7 +95,6 @@ fn rinascita_3700_3280() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -143,7 +142,6 @@ fn pactmaker_3240_3130() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -193,7 +191,6 @@ fn pactmaker_3240_3130_heart_and_soul() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -241,7 +238,6 @@ fn diadochos_4021_3660() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -289,7 +285,6 @@ fn indagator_3858_4057() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -337,7 +332,6 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2318275,
-                sequential_states: 0,
                 pareto_values: 24996627,
             },
         }
@@ -387,7 +381,6 @@ fn stuffed_peppers_2() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1493595,
-                sequential_states: 0,
                 pareto_values: 12299858,
             },
         }
@@ -439,7 +432,6 @@ fn stuffed_peppers_2_heart_and_soul() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 3361396,
-                sequential_states: 0,
                 pareto_values: 26035232,
             },
         }
@@ -491,7 +483,6 @@ fn stuffed_peppers_2_quick_innovation() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 3071733,
-                sequential_states: 0,
                 pareto_values: 25567704,
             },
         }
@@ -539,7 +530,6 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1579065,
-                sequential_states: 0,
                 pareto_values: 13935076,
             },
         }
@@ -587,7 +577,6 @@ fn black_star_4048_3997() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 168003,
-                sequential_states: 0,
                 pareto_values: 928501,
             },
         }
@@ -635,7 +624,6 @@ fn claro_walnut_lumber_4900_4800() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 461630,
-                sequential_states: 0,
                 pareto_values: 2798356,
             },
         }
@@ -683,7 +671,6 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1336246,
-                sequential_states: 0,
                 pareto_values: 10026036,
             },
         }
@@ -731,7 +718,6 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1118641,
-                sequential_states: 0,
                 pareto_values: 8025952,
             },
         }
@@ -779,7 +765,6 @@ fn archeo_kingdom_broadsword_4966_4914() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1556489,
-                sequential_states: 0,
                 pareto_values: 14722811,
             },
         }
@@ -827,7 +812,6 @@ fn hardened_survey_plank_5558_5216() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 361555,
-                sequential_states: 0,
                 pareto_values: 3147923,
             },
         }

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -95,7 +95,6 @@ fn rinascita_3700_3280() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -143,7 +142,6 @@ fn pactmaker_3240_3130() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -193,7 +191,6 @@ fn pactmaker_3240_3130_heart_and_soul() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -241,7 +238,6 @@ fn diadochos_4021_3660() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -289,7 +285,6 @@ fn indagator_3858_4057() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -337,7 +332,6 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2227573,
-                sequential_states: 0,
                 pareto_values: 42541737,
             },
         }
@@ -387,7 +381,6 @@ fn stuffed_peppers_2() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1414006,
-                sequential_states: 0,
                 pareto_values: 20622456,
             },
         }
@@ -439,7 +432,6 @@ fn stuffed_peppers_2_heart_and_soul() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 3248950,
-                sequential_states: 0,
                 pareto_values: 42114442,
             },
         }
@@ -491,7 +483,6 @@ fn stuffed_peppers_2_quick_innovation() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2932601,
-                sequential_states: 0,
                 pareto_values: 42760169,
             },
         }
@@ -539,7 +530,6 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1514037,
-                sequential_states: 0,
                 pareto_values: 21948103,
             },
         }
@@ -587,7 +577,6 @@ fn black_star_4048_3997() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 161900,
-                sequential_states: 0,
                 pareto_values: 1332457,
             },
         }
@@ -635,7 +624,6 @@ fn claro_walnut_lumber_4900_4800() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 456982,
-                sequential_states: 0,
                 pareto_values: 4024542,
             },
         }
@@ -683,7 +671,6 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1229899,
-                sequential_states: 0,
                 pareto_values: 15572424,
             },
         }
@@ -731,7 +718,6 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1108877,
-                sequential_states: 0,
                 pareto_values: 13018461,
             },
         }
@@ -779,7 +765,6 @@ fn archeo_kingdom_broadsword_4966_4914() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1517488,
-                sequential_states: 0,
                 pareto_values: 24731412,
             },
         }
@@ -827,7 +812,6 @@ fn hardened_survey_plank_5558_5216() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 386882,
-                sequential_states: 0,
                 pareto_values: 5750093,
             },
         }
@@ -875,7 +859,6 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -924,7 +907,6 @@ fn ceviche_4900_4800_no_quality() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 664576,
-                sequential_states: 0,
                 pareto_values: 664576,
             },
         }
@@ -974,7 +956,6 @@ fn ce_high_progress_zero_achieved_quality() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -94,8 +94,8 @@ fn rinascita_3700_3280() {
                 pareto_values: 23103012,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 1196836,
+                pareto_values: 19843366,
             },
         }
     "#]];
@@ -141,8 +141,8 @@ fn pactmaker_3240_3130() {
                 pareto_values: 17736698,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 1227258,
+                pareto_values: 20087913,
             },
         }
     "#]];
@@ -190,8 +190,8 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_values: 37644777,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 2736850,
+                pareto_values: 41300056,
             },
         }
     "#]];
@@ -237,8 +237,8 @@ fn diadochos_4021_3660() {
                 pareto_values: 23560138,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 1312498,
+                pareto_values: 24311098,
             },
         }
     "#]];
@@ -284,8 +284,8 @@ fn indagator_3858_4057() {
                 pareto_values: 23318404,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 1062339,
+                pareto_values: 17769091,
             },
         }
     "#]];
@@ -331,8 +331,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_values: 24353529,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2227573,
-                pareto_values: 42541737,
+                parallel_states: 2227636,
+                pareto_values: 42541800,
             },
         }
     "#]];
@@ -380,8 +380,8 @@ fn stuffed_peppers_2() {
                 pareto_values: 12109118,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1414006,
-                pareto_values: 20622456,
+                parallel_states: 1414016,
+                pareto_values: 20622466,
             },
         }
     "#]];
@@ -431,8 +431,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_values: 24789603,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 3248950,
-                pareto_values: 42114442,
+                parallel_states: 3248970,
+                pareto_values: 42114462,
             },
         }
     "#]];
@@ -482,8 +482,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_values: 25010269,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2932601,
-                pareto_values: 42760169,
+                parallel_states: 2932622,
+                pareto_values: 42760190,
             },
         }
     "#]];
@@ -529,8 +529,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 13383321,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1514037,
-                pareto_values: 21948103,
+                parallel_states: 1514211,
+                pareto_values: 21948277,
             },
         }
     "#]];
@@ -576,8 +576,8 @@ fn black_star_4048_3997() {
                 pareto_values: 3311964,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 161900,
-                pareto_values: 1332457,
+                parallel_states: 161906,
+                pareto_values: 1332463,
             },
         }
     "#]];
@@ -623,8 +623,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 5653305,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 456982,
-                pareto_values: 4024542,
+                parallel_states: 457074,
+                pareto_values: 4024634,
             },
         }
     "#]];
@@ -670,8 +670,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 9634708,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1229899,
-                pareto_values: 15572424,
+                parallel_states: 1229915,
+                pareto_values: 15572440,
             },
         }
     "#]];
@@ -717,8 +717,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 8283565,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1108877,
-                pareto_values: 13018461,
+                parallel_states: 1108933,
+                pareto_values: 13018517,
             },
         }
     "#]];
@@ -764,8 +764,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 18128867,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1517488,
-                pareto_values: 24731412,
+                parallel_states: 1517881,
+                pareto_values: 24731805,
             },
         }
     "#]];
@@ -811,8 +811,8 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_values: 17429437,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 386882,
-                pareto_values: 5750093,
+                parallel_states: 386898,
+                pareto_values: 5750109,
             },
         }
     "#]];
@@ -858,8 +858,8 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
                 pareto_values: 38834009,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 1775230,
+                pareto_values: 24477318,
             },
         }
     "#]];
@@ -955,8 +955,8 @@ fn ce_high_progress_zero_achieved_quality() {
                 pareto_values: 3925107,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 861822,
+                pareto_values: 3119837,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -110,7 +110,6 @@ fn stuffed_peppers() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 1624750,
-                sequential_states: 0,
                 pareto_values: 20977625,
             },
         }
@@ -160,7 +159,6 @@ fn test_rare_tacos_2() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 2437044,
-                sequential_states: 0,
                 pareto_values: 42904319,
             },
         }
@@ -214,7 +212,6 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 63194,
-                sequential_states: 0,
                 pareto_values: 479061,
             },
         }
@@ -262,7 +259,6 @@ fn test_indagator_3858_4057() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -314,7 +310,6 @@ fn test_rare_tacos_4628_4410() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 450741,
-                sequential_states: 0,
                 pareto_values: 8257333,
             },
         }
@@ -365,7 +360,6 @@ fn issue_113() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 0,
-                sequential_states: 0,
                 pareto_values: 0,
             },
         }
@@ -414,7 +408,6 @@ fn issue_118() {
             },
             step_lb_stats: StepLbSolverStats {
                 parallel_states: 295097,
-                sequential_states: 0,
                 pareto_values: 2766395,
             },
         }

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -109,9 +109,9 @@ fn stuffed_peppers() {
                 pareto_values: 39199991,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1414006,
-                sequential_states: 41,
-                pareto_values: 20622499,
+                parallel_states: 1624750,
+                sequential_states: 0,
+                pareto_values: 20977625,
             },
         }
     "#]];
@@ -159,9 +159,9 @@ fn test_rare_tacos_2() {
                 pareto_values: 70121907,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2227573,
+                parallel_states: 2437044,
                 sequential_states: 0,
-                pareto_values: 42541737,
+                pareto_values: 42904319,
             },
         }
     "#]];
@@ -213,9 +213,9 @@ fn test_mountain_chromite_ingot_no_manipulation() {
                 pareto_values: 16364005,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 52408,
-                sequential_states: 241,
-                pareto_values: 449860,
+                parallel_states: 63194,
+                sequential_states: 0,
+                pareto_values: 479061,
             },
         }
     "#]];
@@ -313,9 +313,9 @@ fn test_rare_tacos_4628_4410() {
                 pareto_values: 78047587,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 420784,
+                parallel_states: 450741,
                 sequential_states: 0,
-                pareto_values: 8205611,
+                pareto_values: 8257333,
             },
         }
     "#]];
@@ -413,9 +413,9 @@ fn issue_118() {
                 pareto_values: 25432562,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 258314,
-                sequential_states: 12,
-                pareto_values: 2699537,
+                parallel_states: 295097,
+                sequential_states: 0,
+                pareto_values: 2766395,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -109,8 +109,8 @@ fn stuffed_peppers() {
                 pareto_values: 39199991,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1624750,
-                pareto_values: 20977625,
+                parallel_states: 1624760,
+                pareto_values: 20977635,
             },
         }
     "#]];
@@ -158,8 +158,8 @@ fn test_rare_tacos_2() {
                 pareto_values: 70121907,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2437044,
-                pareto_values: 42904319,
+                parallel_states: 2437107,
+                pareto_values: 42904382,
             },
         }
     "#]];
@@ -211,8 +211,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
                 pareto_values: 16364005,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 63194,
-                pareto_values: 479061,
+                parallel_states: 63199,
+                pareto_values: 479066,
             },
         }
     "#]];
@@ -258,8 +258,8 @@ fn test_indagator_3858_4057() {
                 pareto_values: 64650515,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 1198681,
+                pareto_values: 18122679,
             },
         }
     "#]];
@@ -309,8 +309,8 @@ fn test_rare_tacos_4628_4410() {
                 pareto_values: 78047587,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 450741,
-                pareto_values: 8257333,
+                parallel_states: 451769,
+                pareto_values: 8258428,
             },
         }
     "#]];
@@ -359,8 +359,8 @@ fn issue_113() {
                 pareto_values: 120616917,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                pareto_values: 0,
+                parallel_states: 3164458,
+                pareto_values: 75245690,
             },
         }
     "#]];


### PR DESCRIPTION
All `StepLbSolver` states are now computed in parallel before the main search loop is entered.

Implements a prerequisite of #193.

