### PR TITLE
Add CLI build and artifact attestation to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,7 +78,7 @@ jobs:
           asset_name: raphael_x86_64_windows.exe
           asset_content_type: application/octet-stream
   windows-cli:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - name: Use nightly toolchain


### PR DESCRIPTION
Adds the CLI to the release workflow and attest each of the builds with Github.
Artifacts from releases can be verified using `gh attestation verify <filename> --repo KonaeAkira/raphael-rs`.
This is mainly in response to https://github.com/PunishXIV/Artisan/issues/158 and any other use cases that might pop up where Raphael CLI is being embedded