### PR TITLE
Skip unnecessary field transformations in `raphael-data-updater`

### DIFF
--- a/raphael-data-updater/src/consumable.rs
+++ b/raphael-data-updater/src/consumable.rs
@@ -42,7 +42,7 @@ impl SheetData for ItemFood {
     const SHEET: &'static str = "ItemFood";
     const REQUIRED_FIELDS: &[&str] = &[
         "IsRelative",
-        "BaseParam",
+        "BaseParam@as(raw)",
         "Max",
         "MaxHQ",
         "Value",
@@ -61,9 +61,9 @@ impl SheetData for ItemFood {
                 .members()
                 .map(|value| value.as_bool().unwrap())
                 .collect(),
-            param: fields["BaseParam"]
+            param: fields["BaseParam@as(raw)"]
                 .members()
-                .map(|value| value["value"].as_u32().unwrap())
+                .map(|value| value.as_u32().unwrap())
                 .collect(),
             max: fields["Max"]
                 .members()

--- a/raphael-data-updater/src/item.rs
+++ b/raphael-data-updater/src/item.rs
@@ -11,7 +11,12 @@ pub struct Item {
 
 impl SheetData for Item {
     const SHEET: &'static str = "Item";
-    const REQUIRED_FIELDS: &[&str] = &["LevelItem", "ItemAction", "CanBeHq", "AlwaysCollectable"];
+    const REQUIRED_FIELDS: &[&str] = &[
+        "LevelItem@as(raw)",
+        "ItemAction@as(raw)",
+        "CanBeHq",
+        "AlwaysCollectable",
+    ];
 
     fn row_id(&self) -> u32 {
         self.id
@@ -21,8 +26,8 @@ impl SheetData for Item {
         let fields = &value["fields"];
         Some(Self {
             id: value["row_id"].as_u32().unwrap(),
-            item_level: fields["LevelItem"]["value"].as_u32().unwrap(),
-            item_action: fields["ItemAction"]["value"].as_u32().unwrap(),
+            item_level: fields["LevelItem@as(raw)"].as_u32().unwrap(),
+            item_action: fields["ItemAction@as(raw)"].as_u32().unwrap(),
             can_be_hq: fields["CanBeHq"].as_bool().unwrap(),
             always_collectable: fields["AlwaysCollectable"].as_bool().unwrap(),
         })

--- a/raphael-data-updater/src/level_adjust_table.rs
+++ b/raphael-data-updater/src/level_adjust_table.rs
@@ -8,7 +8,7 @@ pub struct LevelAdjustTableEntry {
 
 impl SheetData for LevelAdjustTableEntry {
     const SHEET: &'static str = "GathererCrafterLvAdjustTable";
-    const REQUIRED_FIELDS: &[&str] = &["RecipeLevel"];
+    const REQUIRED_FIELDS: &[&str] = &["RecipeLevel@as(raw)"];
 
     fn row_id(&self) -> u32 {
         self.level
@@ -18,7 +18,7 @@ impl SheetData for LevelAdjustTableEntry {
         let fields = &value["fields"];
         Some(Self {
             level: value["row_id"].as_u32().unwrap(),
-            rlvl: fields["RecipeLevel"]["value"].as_u32().unwrap(),
+            rlvl: fields["RecipeLevel@as(raw)"].as_u32().unwrap(),
         })
     }
 }

--- a/raphael-data-updater/src/recipe.rs
+++ b/raphael-data-updater/src/recipe.rs
@@ -28,16 +28,16 @@ pub struct Recipe {
 impl SheetData for Recipe {
     const SHEET: &'static str = "Recipe";
     const REQUIRED_FIELDS: &[&str] = &[
-        "CraftType",
-        "ItemResult",
-        "MaxAdjustableJobLevel",
-        "RecipeLevelTable",
+        "CraftType@as(raw)",
+        "ItemResult@as(raw)",
+        "MaxAdjustableJobLevel@as(raw)",
+        "RecipeLevelTable@as(raw)",
         "DifficultyFactor",
         "QualityFactor",
         "DurabilityFactor",
         "MaterialQualityFactor",
         "IsExpert",
-        "Ingredient",
+        "Ingredient@as(raw)",
         "AmountIngredient",
         "RequiredCraftsmanship",
         "RequiredControl",
@@ -49,22 +49,22 @@ impl SheetData for Recipe {
 
     fn from_json(value: &json::JsonValue) -> Option<Self> {
         let fields = &value["fields"];
-        let ingredients = fields["Ingredient"]
+        let ingredients = fields["Ingredient@as(raw)"]
             .members()
             .zip(fields["AmountIngredient"].members())
             .filter_map(|(item, amount)| {
                 Some(Ingredient {
-                    item_id: item["value"].as_u32()?,
+                    item_id: item.as_u32()?,
                     amount: amount.as_u32()?,
                 })
             })
             .collect();
         Some(Self {
             id: value["row_id"].as_u32().unwrap(),
-            job_id: fields["CraftType"]["value"].as_u32().unwrap(),
-            item_id: fields["ItemResult"]["value"].as_u32().unwrap(),
-            max_level_scaling: fields["MaxAdjustableJobLevel"]["value"].as_u32().unwrap(),
-            recipe_level: fields["RecipeLevelTable"]["value"].as_u32().unwrap(),
+            job_id: fields["CraftType@as(raw)"].as_u32().unwrap(),
+            item_id: fields["ItemResult@as(raw)"].as_u32().unwrap(),
+            max_level_scaling: fields["MaxAdjustableJobLevel@as(raw)"].as_u32().unwrap(),
+            recipe_level: fields["RecipeLevelTable@as(raw)"].as_u32().unwrap(),
             progress_factor: fields["DifficultyFactor"].as_u32().unwrap(),
             quality_factor: fields["QualityFactor"].as_u32().unwrap(),
             durability_factor: fields["DurabilityFactor"].as_u32().unwrap(),

--- a/raphael-data-updater/src/stellar_mission.rs
+++ b/raphael-data-updater/src/stellar_mission.rs
@@ -9,7 +9,10 @@ pub struct StellarMission {
 
 impl SheetData for StellarMission {
     const SHEET: &'static str = "WKSMissionUnit";
-    const REQUIRED_FIELDS: &[&str] = &["ClassJobCategory", "WKSMissionRecipe"];
+    const REQUIRED_FIELDS: &[&str] = &[
+        "ClassJobCategory@as(raw)",
+        "WKSMissionRecipe.Recipe@as(raw)",
+    ];
 
     fn row_id(&self) -> u32 {
         self.id
@@ -17,10 +20,10 @@ impl SheetData for StellarMission {
 
     fn from_json(value: &json::JsonValue) -> Option<Self> {
         let fields = &value["fields"];
-        let job_ids: Vec<u32> = fields["ClassJobCategory"]
+        let job_ids: Vec<u32> = fields["ClassJobCategory@as(raw)"]
             .members()
             .filter_map(|class_job_category| {
-                let id = class_job_category["value"].as_u32()?;
+                let id = class_job_category.as_u32()?;
                 if (9..17).contains(&id) {
                     Some(id - 9)
                 } else {
@@ -29,9 +32,9 @@ impl SheetData for StellarMission {
             })
             .collect();
         assert!(job_ids.len() <= 1);
-        let recipe_ids = fields["WKSMissionRecipe"]["fields"]["Recipe"]
+        let recipe_ids = fields["WKSMissionRecipe"]["fields"]["Recipe@as(raw)"]
             .members()
-            .filter_map(|recipe| recipe["value"].as_u32().filter(|recipe_id| *recipe_id > 0))
+            .filter_map(|recipe| recipe.as_u32().filter(|recipe_id| *recipe_id > 0))
             .collect();
         Some(Self {
             id: value["row_id"].as_u32().unwrap(),


### PR DESCRIPTION
Adds the suffix `@as(raw)` to fields where their transformations are disregarded and only their raw values are used.
XIVAPI transforms references to other sheets by nesting the entries from them in the response JSON, which `raphael-data-updater` in all but one case ignored.

Relevant XIVAPI documentation/guide: https://v2.xivapi.com/docs/guides/sheets/#astransform

With the transformation skipped, the updater now runs significantly faster, finishing in less than 20s, and it (hopefully) no longer causes unnecessary work for the API server.