### PR TITLE
Reduce memory usage of `StepLbSolver` and `QualityUbSolver`

### DIFF
--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -1,15 +1,13 @@
-use std::num::NonZeroU8;
+use std::{collections::VecDeque, num::NonZeroU8};
 
 use crate::{
     SolverException, SolverSettings,
-    actions::{ActionCombo, FULL_SEARCH_ACTIONS, use_action_combo},
+    actions::{FULL_SEARCH_ACTIONS, use_action_combo},
     macros::internal_error,
     utils::{self, largest_single_action_progress_increase},
 };
 use raphael_sim::*;
-use rayon::iter::{
-    FromParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
-};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rustc_hash::FxHashSet;
 
 use super::state::ReducedState;
@@ -20,8 +18,7 @@ type SolvedStates = rustc_hash::FxHashMap<ReducedState, Box<[ParetoValue]>>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct StepLbSolverStats {
-    pub parallel_states: usize,
-    pub sequential_states: usize,
+    pub states: usize,
     pub pareto_values: usize,
 }
 
@@ -29,125 +26,147 @@ pub struct StepLbSolver {
     settings: SolverSettings,
     interrupt_signal: utils::AtomicFlag,
     solved_states: SolvedStates,
-    pareto_front_builder: ParetoFrontBuilder,
-    precompute_templates: Vec<Template>,
-    next_precompute_step_budget: NonZeroU8,
-    precomputed_states: usize,
-    iq_quality_lut: [u32; 11],
     largest_progress_increase: u32,
 }
 
 impl StepLbSolver {
     pub fn new(mut settings: SolverSettings, interrupt_signal: utils::AtomicFlag) -> Self {
-        let iq_quality_lut = utils::compute_iq_quality_lut(&settings);
         settings.simulator_settings.adversarial = false;
         ReducedState::optimize_action_mask(&mut settings.simulator_settings);
         Self {
             settings,
             interrupt_signal,
             solved_states: SolvedStates::default(),
-            pareto_front_builder: ParetoFrontBuilder::new(
-                settings.max_progress(),
-                settings.max_quality(),
-            ),
-            precompute_templates: Self::generate_precompute_templates(&settings),
-            next_precompute_step_budget: NonZeroU8::new(1).unwrap(),
-            precomputed_states: 0,
-            iq_quality_lut,
             largest_progress_increase: largest_single_action_progress_increase(&settings),
         }
     }
 
-    fn generate_precompute_templates(settings: &SolverSettings) -> Vec<Template> {
-        let mut templates = rustc_hash::FxHashSet::<Template>::default();
-        let mut queue = std::collections::VecDeque::<Template>::new();
+    pub fn step_lower_bound(
+        &mut self,
+        state: SimulationState,
+        hint: u8,
+    ) -> Result<u8, SolverException> {
+        if self.interrupt_signal.is_set() {
+            return Err(SolverException::Interrupted);
+        }
+        if !state.effects.allow_quality_actions() && state.quality < self.settings.max_quality() {
+            return Ok(u8::MAX);
+        }
+        let mut hint = NonZeroU8::try_from(std::cmp::max(hint, 1)).unwrap();
+        while self
+            .quality_upper_bound(state, hint)?
+            .is_none_or(|quality_ub| quality_ub < self.settings.max_quality())
+        {
+            hint = hint.checked_add(1).unwrap();
+        }
+        Ok(hint.get())
+    }
 
-        let seed_template = Template {
-            durability: settings.max_durability(),
-            effects: Effects::initial(&settings.simulator_settings)
-                .with_adversarial_guard(false)
-                .with_combo(Combo::None),
-        };
-        templates.insert(seed_template);
-        queue.push_back(seed_template);
-
-        while let Some(template) = queue.pop_front() {
-            let state = template.instantiate(NonZeroU8::MAX);
-            for action in FULL_SEARCH_ACTIONS {
-                if let Ok(new_state) = use_action_combo(settings, state.to_state(), action) {
-                    let new_state = ReducedState::from_state(new_state, NonZeroU8::MAX);
-                    if new_state.durability > 0 {
-                        let new_template = Template {
-                            durability: new_state.durability,
-                            effects: new_state.effects,
-                        };
-                        if !templates.contains(&new_template) {
-                            templates.insert(new_template);
-                            queue.push_back(new_template);
-                        }
-                    }
-                }
-            }
+    fn quality_upper_bound(
+        &mut self,
+        mut state: SimulationState,
+        step_budget: NonZeroU8,
+    ) -> Result<Option<u32>, SolverException> {
+        if state.effects.combo() != Combo::None {
+            return Err(internal_error!(
+                "Unexpected combo state.",
+                self.settings,
+                state
+            ));
         }
 
-        templates.into_iter().collect()
+        let mut required_progress = self.settings.max_progress() - state.progress;
+        if state.effects.muscle_memory() != 0 {
+            // Assume MuscleMemory can be used to its max potential and remove the effect to reduce the number of states that need to be solved.
+            required_progress = required_progress.saturating_sub(self.largest_progress_increase);
+            state.effects.set_muscle_memory(0);
+        }
+
+        let reduced_state = ReducedState::from_state(state, step_budget);
+        let pareto_front = match self.solved_states.get(&reduced_state) {
+            Some(pareto_front) => pareto_front,
+            None => self.solve_state(reduced_state)?,
+        };
+        let index = pareto_front.partition_point(|value| value.first < required_progress);
+        let quality_ub = pareto_front
+            .get(index)
+            .map(|value| state.quality + value.second);
+        Ok(quality_ub)
     }
 
-    fn precompute_next_step_budget(&mut self) -> Result<(), SolverException> {
-        // A lot of templates map to the same state at lower step budgets due to effect and durability optimizations.
-        // Here we deduplicate the instantiated templates to avoid solving duplicate states.
-        let instantiated_templates: FxHashSet<ReducedState> = self
-            .precompute_templates
-            .iter()
-            .map(|template| template.instantiate(self.next_precompute_step_budget))
-            .collect();
+    fn solve_state(
+        &mut self,
+        seed_state: ReducedState,
+    ) -> Result<&Box<[ParetoValue]>, SolverException> {
+        let mut unvisited_states_by_steps: VecDeque<FxHashSet<ReducedState>> = VecDeque::new();
+        for _ in 0..seed_state.steps_budget.get() {
+            unvisited_states_by_steps.push_back(FxHashSet::default());
+        }
+        unvisited_states_by_steps[0].insert(seed_state);
 
-        let init =
-            || ParetoFrontBuilder::new(self.settings.max_progress(), self.settings.max_quality());
-        let solved_templates = instantiated_templates
-            .into_par_iter()
-            .map_init(
-                init,
-                |pareto_front_builder, state| -> Result<_, SolverException> {
-                    let pareto_front = self.solve_precompute_state(pareto_front_builder, state)?;
-                    Ok((state, pareto_front))
-                },
-            )
-            .collect::<Result<Vec<_>, SolverException>>()?;
+        // Find all transitive children that still need solving and group them by step budget.
+        // This is done with a simple BFS, skipping all states that have already been solved.
+        let mut unsolved_state_by_steps: Vec<Vec<ReducedState>> = Vec::new();
+        while let Some(unvisited_states) = unvisited_states_by_steps.pop_front() {
+            if unvisited_states.is_empty() {
+                continue;
+            }
+            let currently_visited_states = unvisited_states.into_iter().collect::<Vec<_>>();
+            for parent_state in &currently_visited_states {
+                let full_parent_state = parent_state.to_state();
+                let parent_steps_budget = parent_state.steps_budget.get();
+                FULL_SEARCH_ACTIONS
+                    .into_iter()
+                    .filter(|action| action.steps() < parent_steps_budget)
+                    .for_each(|action| {
+                        let child_steps_budget =
+                            NonZeroU8::try_from(parent_steps_budget - action.steps()).unwrap();
+                        if let Ok(full_child_state) =
+                            use_action_combo(&self.settings, full_parent_state, action)
+                            && !full_child_state.is_final(&self.settings.simulator_settings)
+                        {
+                            let child_state =
+                                ReducedState::from_state(full_child_state, child_steps_budget);
+                            if !self.solved_states.contains_key(&child_state) {
+                                unvisited_states_by_steps[usize::from(action.steps() - 1)]
+                                    .insert(child_state);
+                            }
+                        }
+                    });
+            }
+            unsolved_state_by_steps.push(currently_visited_states);
+        }
 
-        let num_solved_states_before = self.solved_states.len();
-        self.solved_states.extend(solved_templates);
-        self.precomputed_states += self.solved_states.len() - num_solved_states_before;
+        // Solve unsolved states in parallel, batched by step budget to ensure the children
+        // of the current batch have already been solved in one of the previous batches.
+        // This is the wavefront technique for parallelizing dynamic programming.
+        for unsolved_states in unsolved_state_by_steps.into_iter().rev() {
+            let solved_states = unsolved_states
+                .into_par_iter()
+                .map_init(
+                    || {
+                        ParetoFrontBuilder::new(
+                            self.settings.max_progress(),
+                            self.settings.max_quality(),
+                        )
+                    },
+                    |pf_builder, reduced_state| -> Result<_, SolverException> {
+                        let pareto_front = self.do_solve_state(pf_builder, reduced_state)?;
+                        Ok((reduced_state, pareto_front))
+                    },
+                )
+                .collect::<Result<Vec<_>, SolverException>>()?;
+            self.solved_states.extend(solved_states);
+        }
 
-        let filtered_templates = self.precompute_templates.par_iter().filter(|template| {
-            let state = template.instantiate(self.next_precompute_step_budget);
-            let pareto_front = self.solved_states.get(&state).unwrap();
-            // Values are sorted Progress-increaasing and Quality-decreasing.
-            // The last value is the value with the most Progress.
-            let value = pareto_front.last().unwrap();
-            // Estimate the max quality that this state ever needs to achieve.
-            // Over-estimating the max needed quality leads to redundant states being precomputed.
-            // Under-estimating the max needed quality could lead to solver crash during precompute from templates being removed too early.
-            let max_needed_quality = {
-                let min_cur_quality = self.iq_quality_lut[usize::from(state.effects.inner_quiet())];
-                self.settings.max_quality().saturating_sub(min_cur_quality)
-            };
-            value.first < self.settings.max_progress() || value.second < max_needed_quality
-        });
-        self.precompute_templates = Vec::from_par_iter(filtered_templates.copied());
-
-        self.next_precompute_step_budget = self.next_precompute_step_budget.saturating_add(1);
-
-        log::trace!(
-            "StepLbSolver - templates: {}, solved_states: {}",
-            self.precompute_templates.len(),
-            self.solved_states.len()
-        );
-
-        Ok(())
+        self.solved_states.get(&seed_state).ok_or(internal_error!(
+            "State not found in memoization after solving",
+            self.settings,
+            seed_state
+        ))
     }
 
-    fn solve_precompute_state(
+    fn do_solve_state(
         &self,
         pareto_front_builder: &mut ParetoFrontBuilder,
         state: ReducedState,
@@ -195,146 +214,9 @@ impl StepLbSolver {
         Ok(Box::from(pareto_front_builder.peek().unwrap()))
     }
 
-    pub fn step_lower_bound(
-        &mut self,
-        state: SimulationState,
-        hint: u8,
-    ) -> Result<u8, SolverException> {
-        if !state.effects.allow_quality_actions() && state.quality < self.settings.max_quality() {
-            return Ok(u8::MAX);
-        }
-        let mut hint = NonZeroU8::try_from(std::cmp::max(hint, 1)).unwrap();
-        while self
-            .quality_upper_bound(state, hint)?
-            .is_none_or(|quality_ub| quality_ub < self.settings.max_quality())
-        {
-            hint = hint.checked_add(1).unwrap();
-        }
-        Ok(hint.get())
-    }
-
-    fn quality_upper_bound(
-        &mut self,
-        mut state: SimulationState,
-        step_budget: NonZeroU8,
-    ) -> Result<Option<u32>, SolverException> {
-        if state.effects.combo() != Combo::None {
-            return Err(internal_error!(
-                "Unexpected combo state.",
-                self.settings,
-                state
-            ));
-        }
-
-        while self.next_precompute_step_budget <= step_budget {
-            self.precompute_next_step_budget()?;
-        }
-
-        let mut required_progress = self.settings.max_progress() - state.progress;
-        if state.effects.muscle_memory() != 0 {
-            // Assume MuscleMemory can be used to its max potential and remove the effect to reduce the number of states that need to be solved.
-            required_progress = required_progress.saturating_sub(self.largest_progress_increase);
-            state.effects.set_muscle_memory(0);
-        }
-
-        let reduced_state = ReducedState::from_state(state, step_budget);
-
-        if let Some(pareto_front) = self.solved_states.get(&reduced_state) {
-            let index = pareto_front.partition_point(|value| value.first < required_progress);
-            let quality_ub = pareto_front
-                .get(index)
-                .map(|value| state.quality + value.second);
-            return Ok(quality_ub);
-        }
-
-        self.solve_state(reduced_state)?;
-
-        if let Some(pareto_front) = self.solved_states.get(&reduced_state) {
-            let index = pareto_front.partition_point(|value| value.first < required_progress);
-            let quality_ub = pareto_front
-                .get(index)
-                .map(|value| state.quality + value.second);
-            Ok(quality_ub)
-        } else {
-            Err(internal_error!(
-                "State not found in memoization table after solve.",
-                self.settings,
-                reduced_state
-            ))
-        }
-    }
-
-    fn solve_state(&mut self, reduced_state: ReducedState) -> Result<(), SolverException> {
-        if self.interrupt_signal.is_set() {
-            return Err(SolverException::Interrupted);
-        }
-        self.pareto_front_builder.push_empty();
-        for action in FULL_SEARCH_ACTIONS {
-            if action.steps() <= reduced_state.steps_budget.get() {
-                self.build_child_front(reduced_state, action)?;
-                if self.pareto_front_builder.is_max() {
-                    // stop early if both Progress and Quality are maxed out
-                    // this optimization would work even better with better action ordering
-                    // (i.e. if better actions are visited first)
-                    break;
-                }
-            }
-        }
-        let pareto_front = Box::from(self.pareto_front_builder.peek().unwrap());
-        self.solved_states.insert(reduced_state, pareto_front);
-        Ok(())
-    }
-
-    fn build_child_front(
-        &mut self,
-        reduced_state: ReducedState,
-        action: ActionCombo,
-    ) -> Result<(), SolverException> {
-        if let Ok(new_full_state) =
-            use_action_combo(&self.settings, reduced_state.to_state(), action)
-        {
-            let action_progress = new_full_state.progress;
-            let action_quality = new_full_state.quality;
-            let new_step_budget = reduced_state.steps_budget.get() - action.steps();
-            match NonZeroU8::try_from(new_step_budget) {
-                Ok(new_step_budget) if new_full_state.durability > 0 => {
-                    // New state is not final
-                    let new_reduced_state =
-                        ReducedState::from_state(new_full_state, new_step_budget);
-                    if let Some(pareto_front) = self.solved_states.get(&new_reduced_state) {
-                        self.pareto_front_builder.push_slice(pareto_front);
-                    } else {
-                        self.solve_state(new_reduced_state)?;
-                    }
-                    self.pareto_front_builder
-                        .peek_mut()
-                        .unwrap()
-                        .iter_mut()
-                        .for_each(|value| {
-                            value.first += action_progress;
-                            value.second += action_quality;
-                        });
-                    self.pareto_front_builder.merge();
-                }
-                _ if action_progress != 0 => {
-                    // New state is final and last action increased Progress
-                    self.pareto_front_builder
-                        .push_slice(&[ParetoValue::new(action_progress, action_quality)]);
-                    self.pareto_front_builder.merge();
-                }
-                _ => {
-                    // New state is final but last action did not increase Progress
-                    // Skip this state
-                }
-            }
-        }
-        Ok(())
-    }
-
     pub fn runtime_stats(&self) -> StepLbSolverStats {
         StepLbSolverStats {
-            parallel_states: self.precomputed_states,
-            sequential_states: self.solved_states.len() - self.precomputed_states,
+            states: self.solved_states.len(),
             pareto_values: self.solved_states.values().map(|value| value.len()).sum(),
         }
     }
@@ -344,30 +226,9 @@ impl Drop for StepLbSolver {
     fn drop(&mut self) {
         let runtime_stats = self.runtime_stats();
         log::debug!(
-            "StepLbSolver - par_states: {}, seq_states: {}, values: {}",
-            runtime_stats.parallel_states,
-            runtime_stats.sequential_states,
+            "StepLbSolver - states: {}, values: {}",
+            runtime_stats.states,
             runtime_stats.pareto_values
         );
-    }
-}
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-struct Template {
-    durability: u16,
-    effects: Effects,
-}
-
-impl Template {
-    pub fn instantiate(&self, step_budget: NonZeroU8) -> ReducedState {
-        let state = SimulationState {
-            durability: self.durability,
-            effects: self.effects,
-            cp: 0,
-            progress: 0,
-            quality: 0,
-            unreliable_quality: 0,
-        };
-        ReducedState::from_state(state, step_budget)
     }
 }

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -184,7 +184,7 @@ fn max_quality() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 96805,
-                pareto_values: 850815,
+                pareto_values: 589715,
             },
         }
     "#]];

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -179,8 +179,8 @@ fn max_quality() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 389796,
-                sequential_states: 2665,
-                pareto_values: 2988845,
+                sequential_states: 514,
+                pareto_values: 2236380,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 96805,

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -89,8 +89,7 @@ fn unsolvable() {
                 pareto_values: 0,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -137,8 +136,7 @@ fn zero_quality() {
                 pareto_values: 109398,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -185,9 +183,8 @@ fn max_quality() {
                 pareto_values: 2988845,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 238904,
-                sequential_states: 0,
-                pareto_values: 1635771,
+                states: 96805,
+                pareto_values: 850815,
             },
         }
     "#]];
@@ -233,9 +230,8 @@ fn large_progress_quality_increase() {
                 pareto_values: 178982,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 6336,
-                sequential_states: 0,
-                pareto_values: 6336,
+                states: 13,
+                pareto_values: 13,
             },
         }
     "#]];
@@ -281,9 +277,8 @@ fn backload_progress_single_delicate_synthesis() {
                 pareto_values: 8965,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1596,
-                sequential_states: 0,
-                pareto_values: 1596,
+                states: 9,
+                pareto_values: 9,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -91,7 +91,7 @@ fn rinascita_3700_3280() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 957930,
                 sequential_states: 42813,
-                pareto_values: 17006469,
+                pareto_values: 16783500,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,
@@ -138,7 +138,7 @@ fn pactmaker_3240_3130() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 818130,
                 sequential_states: 44933,
-                pareto_values: 13132245,
+                pareto_values: 13132176,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,
@@ -234,7 +234,7 @@ fn diadochos_4021_3660() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 888030,
                 sequential_states: 44397,
-                pareto_values: 17385016,
+                pareto_values: 17344815,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,
@@ -281,7 +281,7 @@ fn indagator_3858_4057() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 971910,
                 sequential_states: 45972,
-                pareto_values: 17456807,
+                pareto_values: 16209295,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,
@@ -327,8 +327,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,
-                sequential_states: 15062,
-                pareto_values: 18148282,
+                sequential_states: 12506,
+                pareto_values: 16494261,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1760061,
@@ -377,7 +377,7 @@ fn stuffed_peppers_2() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 727703,
                 sequential_states: 0,
-                pareto_values: 9890579,
+                pareto_values: 8685113,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 867752,
@@ -479,7 +479,7 @@ fn stuffed_peppers_2_quick_innovation() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1477069,
                 sequential_states: 0,
-                pareto_values: 20284215,
+                pareto_values: 17827198,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1619083,
@@ -526,7 +526,7 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 750109,
                 sequential_states: 1,
-                pareto_values: 11255499,
+                pareto_values: 9640072,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 879299,
@@ -573,7 +573,7 @@ fn black_star_4048_3997() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 448545,
                 sequential_states: 20,
-                pareto_values: 3013677,
+                pareto_values: 2531249,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 102945,
@@ -620,7 +620,7 @@ fn claro_walnut_lumber_4900_4800() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 632525,
                 sequential_states: 39,
-                pareto_values: 4877078,
+                pareto_values: 4421953,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 311790,
@@ -667,7 +667,7 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 654113,
                 sequential_states: 0,
-                pareto_values: 8411272,
+                pareto_values: 7088630,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 683238,
@@ -714,7 +714,7 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 620174,
                 sequential_states: 0,
-                pareto_values: 7334997,
+                pareto_values: 6152904,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 530777,
@@ -761,7 +761,7 @@ fn archeo_kingdom_broadsword_4966_4914() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 871349,
                 sequential_states: 0,
-                pareto_values: 14549573,
+                pareto_values: 12661815,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1113317,
@@ -807,8 +807,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 994029,
-                sequential_states: 12624,
-                pareto_values: 12494114,
+                sequential_states: 9822,
+                pareto_values: 11580676,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 319981,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -332,7 +332,7 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1760061,
-                pareto_values: 22228326,
+                pareto_values: 20065497,
             },
         }
     "#]];
@@ -381,7 +381,7 @@ fn stuffed_peppers_2() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 867752,
-                pareto_values: 9215327,
+                pareto_values: 8186694,
             },
         }
     "#]];
@@ -483,7 +483,7 @@ fn stuffed_peppers_2_quick_innovation() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1619083,
-                pareto_values: 17750258,
+                pareto_values: 15965490,
             },
         }
     "#]];
@@ -530,7 +530,7 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 879299,
-                pareto_values: 10028317,
+                pareto_values: 8796813,
             },
         }
     "#]];
@@ -577,7 +577,7 @@ fn black_star_4048_3997() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 102945,
-                pareto_values: 687452,
+                pareto_values: 559179,
             },
         }
     "#]];
@@ -624,7 +624,7 @@ fn claro_walnut_lumber_4900_4800() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 311790,
-                pareto_values: 2160784,
+                pareto_values: 1982673,
             },
         }
     "#]];
@@ -671,7 +671,7 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 683238,
-                pareto_values: 6769670,
+                pareto_values: 5815405,
             },
         }
     "#]];
@@ -718,7 +718,7 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 530777,
-                pareto_values: 5041780,
+                pareto_values: 4366569,
             },
         }
     "#]];
@@ -765,7 +765,7 @@ fn archeo_kingdom_broadsword_4966_4914() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1113317,
-                pareto_values: 12640867,
+                pareto_values: 11054392,
             },
         }
     "#]];
@@ -812,7 +812,7 @@ fn hardened_survey_plank_5558_5216() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 319981,
-                pareto_values: 2955705,
+                pareto_values: 2763164,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -94,8 +94,7 @@ fn rinascita_3700_3280() {
                 pareto_values: 17006469,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -142,8 +141,7 @@ fn pactmaker_3240_3130() {
                 pareto_values: 13132245,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -192,8 +190,7 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_values: 27637851,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -240,8 +237,7 @@ fn diadochos_4021_3660() {
                 pareto_values: 17385016,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -288,8 +284,7 @@ fn indagator_3858_4057() {
                 pareto_values: 17456807,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -336,9 +331,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_values: 18148282,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2318275,
-                sequential_states: 0,
-                pareto_values: 24996627,
+                states: 1760061,
+                pareto_values: 22228326,
             },
         }
     "#]];
@@ -386,9 +380,8 @@ fn stuffed_peppers_2() {
                 pareto_values: 9890579,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1493595,
-                sequential_states: 0,
-                pareto_values: 12299858,
+                states: 867752,
+                pareto_values: 9215327,
             },
         }
     "#]];
@@ -438,9 +431,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_values: 20676360,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 3361396,
-                sequential_states: 0,
-                pareto_values: 26035232,
+                states: 1588279,
+                pareto_values: 17702595,
             },
         }
     "#]];
@@ -490,9 +482,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_values: 20284215,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 3071733,
-                sequential_states: 0,
-                pareto_values: 25567704,
+                states: 1619083,
+                pareto_values: 17750258,
             },
         }
     "#]];
@@ -538,9 +529,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 11255499,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1579065,
-                sequential_states: 0,
-                pareto_values: 13935076,
+                states: 879299,
+                pareto_values: 10028317,
             },
         }
     "#]];
@@ -586,9 +576,8 @@ fn black_star_4048_3997() {
                 pareto_values: 3013677,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 168003,
-                sequential_states: 0,
-                pareto_values: 928501,
+                states: 102945,
+                pareto_values: 687452,
             },
         }
     "#]];
@@ -634,9 +623,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 4877078,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 461630,
-                sequential_states: 0,
-                pareto_values: 2798356,
+                states: 311790,
+                pareto_values: 2160784,
             },
         }
     "#]];
@@ -682,9 +670,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 8411272,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1336246,
-                sequential_states: 0,
-                pareto_values: 10026036,
+                states: 683238,
+                pareto_values: 6769670,
             },
         }
     "#]];
@@ -730,9 +717,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 7334997,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1118641,
-                sequential_states: 0,
-                pareto_values: 8025952,
+                states: 530777,
+                pareto_values: 5041780,
             },
         }
     "#]];
@@ -778,9 +764,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 14549573,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1556489,
-                sequential_states: 0,
-                pareto_values: 14722811,
+                states: 1113317,
+                pareto_values: 12640867,
             },
         }
     "#]];
@@ -826,9 +811,8 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_values: 12494114,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 361555,
-                sequential_states: 0,
-                pareto_values: 3147923,
+                states: 319981,
+                pareto_values: 2955705,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -332,7 +332,7 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1756906,
-                pareto_values: 38923194,
+                pareto_values: 35183972,
             },
         }
     "#]];
@@ -381,7 +381,7 @@ fn stuffed_peppers_2() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 716016,
-                pareto_values: 13546156,
+                pareto_values: 12192698,
             },
         }
     "#]];
@@ -483,7 +483,7 @@ fn stuffed_peppers_2_quick_innovation() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1414156,
-                pareto_values: 26887995,
+                pareto_values: 24372058,
             },
         }
     "#]];
@@ -530,7 +530,7 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 920961,
-                pareto_values: 17209277,
+                pareto_values: 14882985,
             },
         }
     "#]];
@@ -577,7 +577,7 @@ fn black_star_4048_3997() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 78431,
-                pareto_values: 792990,
+                pareto_values: 665881,
             },
         }
     "#]];
@@ -624,7 +624,7 @@ fn claro_walnut_lumber_4900_4800() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 270482,
-                pareto_values: 2771474,
+                pareto_values: 2619156,
             },
         }
     "#]];
@@ -671,7 +671,7 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 575636,
-                pareto_values: 9814868,
+                pareto_values: 8434830,
             },
         }
     "#]];
@@ -718,7 +718,7 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 577428,
-                pareto_values: 9069050,
+                pareto_values: 7703102,
             },
         }
     "#]];
@@ -765,7 +765,7 @@ fn archeo_kingdom_broadsword_4966_4914() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1000851,
-                pareto_values: 20490783,
+                pareto_values: 17986754,
             },
         }
     "#]];
@@ -812,7 +812,7 @@ fn hardened_survey_plank_5558_5216() {
             },
             step_lb_stats: StepLbSolverStats {
                 states: 341656,
-                pareto_values: 5371012,
+                pareto_values: 4979593,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -91,7 +91,7 @@ fn rinascita_3700_3280() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 946344,
                 sequential_states: 45503,
-                pareto_values: 23103012,
+                pareto_values: 22751757,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,
@@ -138,7 +138,7 @@ fn pactmaker_3240_3130() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 808184,
                 sequential_states: 46099,
-                pareto_values: 17736698,
+                pareto_values: 17736621,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,
@@ -234,7 +234,7 @@ fn diadochos_4021_3660() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 877264,
                 sequential_states: 46836,
-                pareto_values: 23560138,
+                pareto_values: 23497998,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,
@@ -281,7 +281,7 @@ fn indagator_3858_4057() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 960160,
                 sequential_states: 45425,
-                pareto_values: 23318404,
+                pareto_values: 21397668,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,
@@ -327,8 +327,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
-                sequential_states: 9945,
-                pareto_values: 24444837,
+                sequential_states: 6187,
+                pareto_values: 22061405,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1756906,
@@ -377,7 +377,7 @@ fn stuffed_peppers_2() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 685374,
                 sequential_states: 0,
-                pareto_values: 12109118,
+                pareto_values: 10568081,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 716016,
@@ -479,7 +479,7 @@ fn stuffed_peppers_2_quick_innovation() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1405659,
                 sequential_states: 0,
-                pareto_values: 25010269,
+                pareto_values: 21872304,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1414156,
@@ -526,7 +526,7 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 709548,
                 sequential_states: 0,
-                pareto_values: 13383321,
+                pareto_values: 11347845,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 920961,
@@ -573,7 +573,7 @@ fn black_star_4048_3997() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 414395,
                 sequential_states: 0,
-                pareto_values: 3311964,
+                pareto_values: 2776768,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 78431,
@@ -620,7 +620,7 @@ fn claro_walnut_lumber_4900_4800() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 588992,
                 sequential_states: 0,
-                pareto_values: 5653305,
+                pareto_values: 5111464,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 270482,
@@ -667,7 +667,7 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 615546,
                 sequential_states: 0,
-                pareto_values: 9634708,
+                pareto_values: 8053602,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 575636,
@@ -714,7 +714,7 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 579131,
                 sequential_states: 0,
-                pareto_values: 8283565,
+                pareto_values: 6864670,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 577428,
@@ -761,7 +761,7 @@ fn archeo_kingdom_broadsword_4966_4914() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 812878,
                 sequential_states: 0,
-                pareto_values: 18128867,
+                pareto_values: 15607520,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1000851,
@@ -807,8 +807,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,
-                sequential_states: 4824,
-                pareto_values: 17478760,
+                sequential_states: 4019,
+                pareto_values: 16038903,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 341656,
@@ -952,7 +952,7 @@ fn ce_high_progress_zero_achieved_quality() {
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 951755,
                 sequential_states: 0,
-                pareto_values: 3925107,
+                pareto_values: 2232866,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -94,8 +94,7 @@ fn rinascita_3700_3280() {
                 pareto_values: 23103012,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -142,8 +141,7 @@ fn pactmaker_3240_3130() {
                 pareto_values: 17736698,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -192,8 +190,7 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_values: 37644777,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -240,8 +237,7 @@ fn diadochos_4021_3660() {
                 pareto_values: 23560138,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -288,8 +284,7 @@ fn indagator_3858_4057() {
                 pareto_values: 23318404,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -336,9 +331,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_values: 24444837,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2227573,
-                sequential_states: 0,
-                pareto_values: 42541737,
+                states: 1756906,
+                pareto_values: 38923194,
             },
         }
     "#]];
@@ -386,9 +380,8 @@ fn stuffed_peppers_2() {
                 pareto_values: 12109118,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1414006,
-                sequential_states: 0,
-                pareto_values: 20622456,
+                states: 716016,
+                pareto_values: 13546156,
             },
         }
     "#]];
@@ -438,9 +431,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_values: 24789603,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 3248950,
-                sequential_states: 0,
-                pareto_values: 42114442,
+                states: 1386939,
+                pareto_values: 26445723,
             },
         }
     "#]];
@@ -490,9 +482,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_values: 25010269,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2932601,
-                sequential_states: 0,
-                pareto_values: 42760169,
+                states: 1414156,
+                pareto_values: 26887995,
             },
         }
     "#]];
@@ -538,9 +529,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 13383321,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1514037,
-                sequential_states: 0,
-                pareto_values: 21948103,
+                states: 920961,
+                pareto_values: 17209277,
             },
         }
     "#]];
@@ -586,9 +576,8 @@ fn black_star_4048_3997() {
                 pareto_values: 3311964,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 161900,
-                sequential_states: 0,
-                pareto_values: 1332457,
+                states: 78431,
+                pareto_values: 792990,
             },
         }
     "#]];
@@ -634,9 +623,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 5653305,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 456982,
-                sequential_states: 0,
-                pareto_values: 4024542,
+                states: 270482,
+                pareto_values: 2771474,
             },
         }
     "#]];
@@ -682,9 +670,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 9634708,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1229899,
-                sequential_states: 0,
-                pareto_values: 15572424,
+                states: 575636,
+                pareto_values: 9814868,
             },
         }
     "#]];
@@ -730,9 +717,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 8283565,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1108877,
-                sequential_states: 0,
-                pareto_values: 13018461,
+                states: 577428,
+                pareto_values: 9069050,
             },
         }
     "#]];
@@ -778,9 +764,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 18128867,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1517488,
-                sequential_states: 0,
-                pareto_values: 24731412,
+                states: 1000851,
+                pareto_values: 20490783,
             },
         }
     "#]];
@@ -826,9 +811,8 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_values: 17478760,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 386882,
-                sequential_states: 0,
-                pareto_values: 5750093,
+                states: 341656,
+                pareto_values: 5371012,
             },
         }
     "#]];
@@ -874,8 +858,7 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
                 pareto_values: 38834009,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -923,9 +906,8 @@ fn ceviche_4900_4800_no_quality() {
                 pareto_values: 428868,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 664576,
-                sequential_states: 0,
-                pareto_values: 664576,
+                states: 76276,
+                pareto_values: 76276,
             },
         }
     "#]];
@@ -973,8 +955,7 @@ fn ce_high_progress_zero_achieved_quality() {
                 pareto_values: 3925107,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -109,9 +109,8 @@ fn stuffed_peppers() {
                 pareto_values: 39200086,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 1624750,
-                sequential_states: 0,
-                pareto_values: 20977625,
+                states: 944544,
+                pareto_values: 16991075,
             },
         }
     "#]];
@@ -159,9 +158,8 @@ fn test_rare_tacos_2() {
                 pareto_values: 70125298,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 2437044,
-                sequential_states: 0,
-                pareto_values: 42904319,
+                states: 1635706,
+                pareto_values: 37206732,
             },
         }
     "#]];
@@ -213,9 +211,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
                 pareto_values: 16731571,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 63194,
-                sequential_states: 0,
-                pareto_values: 479061,
+                states: 47761,
+                pareto_values: 428964,
             },
         }
     "#]];
@@ -261,8 +258,7 @@ fn test_indagator_3858_4057() {
                 pareto_values: 64650515,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -313,9 +309,8 @@ fn test_rare_tacos_4628_4410() {
                 pareto_values: 78047587,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 450741,
-                sequential_states: 0,
-                pareto_values: 8257333,
+                states: 352035,
+                pareto_values: 7690209,
             },
         }
     "#]];
@@ -364,8 +359,7 @@ fn issue_113() {
                 pareto_values: 120616917,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 0,
-                sequential_states: 0,
+                states: 0,
                 pareto_values: 0,
             },
         }
@@ -413,9 +407,8 @@ fn issue_118() {
                 pareto_values: 25592132,
             },
             step_lb_stats: StepLbSolverStats {
-                parallel_states: 295097,
-                sequential_states: 0,
-                pareto_values: 2766395,
+                states: 208553,
+                pareto_values: 2353263,
             },
         }
     "#]];


### PR DESCRIPTION
`StepLbSolver` now only computes states and corresponding child states as they are requested and no longer preemptively computes states in anticipation that they might be used. Requesting the step lower-bound of a state does the following if the state hasn't already been solved:

1. Discover all unsolved transitive child states using simple BFS (single-threaded).
2. Order discovered states by step-budget and solve them in parallel.

The result is that fewer states have to be solved, resulting in less memory used. The drawback is the parallelization in this method is not as efficient as the parallelization in the previous method, which leads to a slight increase in solve time in some cases.

Another change that reduces the memory usage is that `iq_quality_lut` is now used to prune redundant pareto values in solved states of `StepLbSolver` and `QualityUbSolver`. Previously, only values exceeding `max_progress` or `max_quality` were discarded. `iq_quality_lut` provides a stronger bound than just `max_quality` for quality cutoff.