### PR TITLE
Fix setup of `random_access` benchmark affecting results

### DIFF
--- a/raphael-data-updater/Cargo.toml
+++ b/raphael-data-updater/Cargo.toml
@@ -8,7 +8,7 @@ workspace = true
 [dependencies]
 tokio = { version = "1.44.2", features = ["full"] }
 reqwest = "0.12.15"
-non_contiguously_indexed_array_builder = { git = "https://github.com/augenfrosch/non_contiguously_indexed_array", rev = "0629de7b6fce8cf364e28fadbf34174110a9f92a", version = "0.2.0"}
+non_contiguously_indexed_array_builder = { git = "https://github.com/augenfrosch/non_contiguously_indexed_array", rev = "59bc352188361ba47bcca66c5a140a2b7580bb47", version = "0.2.0"}
 json = "0.12.4"
 log = { workspace = true }
 env_logger = "0.11.5"

--- a/raphael-data/Cargo.toml
+++ b/raphael-data/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 raphael-sim = { workspace = true }
-non_contiguously_indexed_array = { git = "https://github.com/augenfrosch/non_contiguously_indexed_array", rev = "0629de7b6fce8cf364e28fadbf34174110a9f92a", version = "0.4.0" }
+non_contiguously_indexed_array = { git = "https://github.com/augenfrosch/non_contiguously_indexed_array", rev = "59bc352188361ba47bcca66c5a140a2b7580bb47", version = "0.4.1" }
 serde = { version = "1.0.215", features = ["derive"], optional = true }
 unicode-normalization = "0.1.24"
 


### PR DESCRIPTION
Fixes the setup of the `random_access` game data benchmark causing significantly increased measured times.
This came up when testing the recent changes to `non_contiguously_indexed_array` with Raphael, particularly https://github.com/augenfrosch/non_contiguously_indexed_array/pull/4, where the measured times unexpectedly halved.

The specific setup used by the benchmark was not ideal and presumably affected the results, causing the performance change when switching to the new library versions (most likely due to optimizations enabled by the added `Iterator::size_hint` implementation for the indices iterator).

With the new setup, the library versions perform identically, as expected, and the `NciArray`s actually now outperform the `phf` maps in the `random_access` benchmark.
The indices used in the benchmark are only randomised once and then used cyclically, but this shouldn't significantly affect the result since the access should still be unpredictable / as uncachable as before to the CPU.

I have also added the updated library version to this pull request since the mentioned change should improve performance (and potentially enable optimizations in the case of the `Iterator::size_hint` implementation).