### PR TITLE
Self-partitioning Pareto front & Use SIMD for dominance check

### DIFF
--- a/raphael-solver/Cargo.toml
+++ b/raphael-solver/Cargo.toml
@@ -16,6 +16,7 @@ rayon = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, optional = true }
 web-time = { workspace = true }
+wide = "0.7.33"
 
 [features]
 serde = ["dep:serde", "raphael-sim/serde"]

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -17,8 +17,6 @@ const EFFECTS_KEY_MASK: u32 = !EFFECTS_VALUE_MASK;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 struct Key {
     progress: u32,
-    cp: u16,
-    durability: u16,
     effects: u32,
 }
 
@@ -26,8 +24,6 @@ impl From<&SimulationState> for Key {
     fn from(state: &SimulationState) -> Self {
         Self {
             progress: state.progress,
-            cp: state.cp.next_multiple_of(64),
-            durability: state.durability.next_multiple_of(15),
             effects: state.effects.into_bits() & EFFECTS_KEY_MASK,
         }
     }

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -96,7 +96,7 @@ pub struct ParetoFront {
 
 impl ParetoFront {
     pub fn insert(&mut self, state: SimulationState) -> bool {
-        const MAX_LEAF_SIZE: usize = 500;
+        const MAX_LEAF_SIZE: usize = 200;
         let new_value = Value::from(&state);
         let mut node = self.buckets.entry(Key::from(&state)).or_default();
         while let TreeNode::Intermediate(intermediate) = node {

--- a/raphael-solver/src/macro_solver/search_queue.rs
+++ b/raphael-solver/src/macro_solver/search_queue.rs
@@ -61,7 +61,6 @@ struct SearchNode {
 pub struct SearchQueueStats {
     pub processed_nodes: usize,
     pub dropped_nodes: usize,
-    pub pareto_buckets_squared_size_sum: usize,
 }
 
 pub struct SearchQueue {
@@ -170,7 +169,6 @@ impl SearchQueue {
         SearchQueueStats {
             processed_nodes: self.processed_nodes,
             dropped_nodes: self.dropped_nodes,
-            pareto_buckets_squared_size_sum: self.pareto_front.buckets_squared_size_sum(),
         }
     }
 }

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -128,7 +128,7 @@ fn zero_quality() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 41,
                 dropped_nodes: 12,
-                pareto_buckets_squared_size_sum: 73,
+                pareto_buckets_squared_size_sum: 97,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 31147,
@@ -171,11 +171,11 @@ fn max_quality() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 245618,
+            finish_states: 239711,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 5843,
-                dropped_nodes: 68720,
-                pareto_buckets_squared_size_sum: 36691,
+                processed_nodes: 5567,
+                dropped_nodes: 66122,
+                pareto_buckets_squared_size_sum: 116580,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 389796,
@@ -183,8 +183,8 @@ fn max_quality() {
                 pareto_values: 2236380,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 96805,
-                pareto_values: 589715,
+                states: 95563,
+                pareto_values: 586735,
             },
         }
     "#]];
@@ -313,11 +313,11 @@ fn issue_216_steplbsolver_crash() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 212737,
+            finish_states: 199538,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 21441,
-                dropped_nodes: 393413,
-                pareto_buckets_squared_size_sum: 384142,
+                processed_nodes: 19113,
+                dropped_nodes: 350079,
+                pareto_buckets_squared_size_sum: 1312972,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 318520,
@@ -325,8 +325,8 @@ fn issue_216_steplbsolver_crash() {
                 pareto_values: 1267763,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 77688,
-                pareto_values: 341355,
+                states: 74728,
+                pareto_values: 330387,
             },
         }
     "#]];

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -310,8 +310,8 @@ fn issue_216_steplbsolver_crash() {
         MacroSolverStats {
             finish_states: 199538,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 19113,
-                dropped_nodes: 350079,
+                processed_nodes: 19119,
+                dropped_nodes: 350178,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 318520,

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -81,7 +81,6 @@ fn unsolvable() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 0,
                 dropped_nodes: 0,
-                pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 0,
@@ -128,7 +127,6 @@ fn zero_quality() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 41,
                 dropped_nodes: 12,
-                pareto_buckets_squared_size_sum: 97,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 31147,
@@ -175,7 +173,6 @@ fn max_quality() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 5567,
                 dropped_nodes: 66122,
-                pareto_buckets_squared_size_sum: 116580,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 389796,
@@ -222,7 +219,6 @@ fn large_progress_quality_increase() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 0,
                 dropped_nodes: 23,
-                pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 178982,
@@ -269,7 +265,6 @@ fn backload_progress_single_delicate_synthesis() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 0,
                 dropped_nodes: 14,
-                pareto_buckets_squared_size_sum: 0,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 8965,
@@ -317,7 +312,6 @@ fn issue_216_steplbsolver_crash() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 19113,
                 dropped_nodes: 350079,
-                pareto_buckets_squared_size_sum: 1312972,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 318520,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -82,11 +82,11 @@ fn rinascita_3700_3280() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 212417,
+            finish_states: 212167,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 459,
-                dropped_nodes: 4545,
-                pareto_buckets_squared_size_sum: 1781,
+                processed_nodes: 456,
+                dropped_nodes: 4523,
+                pareto_buckets_squared_size_sum: 8004,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 957930,
@@ -129,11 +129,11 @@ fn pactmaker_3240_3130() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 267636,
+            finish_states: 267472,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 4623,
-                dropped_nodes: 34199,
-                pareto_buckets_squared_size_sum: 171614,
+                processed_nodes: 4600,
+                dropped_nodes: 34040,
+                pareto_buckets_squared_size_sum: 839521,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 818130,
@@ -182,7 +182,7 @@ fn pactmaker_3240_3130_heart_and_soul() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 577,
                 dropped_nodes: 6649,
-                pareto_buckets_squared_size_sum: 3863,
+                pareto_buckets_squared_size_sum: 17601,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1690660,
@@ -225,11 +225,11 @@ fn diadochos_4021_3660() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 426813,
+            finish_states: 426778,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1630,
-                dropped_nodes: 5157,
-                pareto_buckets_squared_size_sum: 24480,
+                processed_nodes: 1626,
+                dropped_nodes: 5140,
+                pareto_buckets_squared_size_sum: 126370,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 888030,
@@ -272,11 +272,11 @@ fn indagator_3858_4057() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 346009,
+            finish_states: 346005,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3359,
-                dropped_nodes: 19188,
-                pareto_buckets_squared_size_sum: 65123,
+                processed_nodes: 3357,
+                dropped_nodes: 19183,
+                pareto_buckets_squared_size_sum: 408097,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 971910,
@@ -319,20 +319,20 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1197808,
+            finish_states: 1177480,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 65094,
-                dropped_nodes: 265540,
-                pareto_buckets_squared_size_sum: 4726300,
+                processed_nodes: 60066,
+                dropped_nodes: 247368,
+                pareto_buckets_squared_size_sum: 33375101,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,
-                sequential_states: 12506,
-                pareto_values: 16494261,
+                sequential_states: 12496,
+                pareto_values: 16494230,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1760061,
-                pareto_values: 20065497,
+                states: 1753849,
+                pareto_values: 20037701,
             },
         }
     "#]];
@@ -368,11 +368,11 @@ fn stuffed_peppers_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 354023,
+            finish_states: 331770,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3145,
-                dropped_nodes: 47888,
-                pareto_buckets_squared_size_sum: 31195,
+                processed_nodes: 2787,
+                dropped_nodes: 42357,
+                pareto_buckets_squared_size_sum: 138311,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 727703,
@@ -380,8 +380,8 @@ fn stuffed_peppers_2() {
                 pareto_values: 8685113,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 867752,
-                pareto_values: 8186694,
+                states: 843369,
+                pareto_values: 7997948,
             },
         }
     "#]];
@@ -419,11 +419,11 @@ fn stuffed_peppers_2_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 479880,
+            finish_states: 445947,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3679,
-                dropped_nodes: 63489,
-                pareto_buckets_squared_size_sum: 36165,
+                processed_nodes: 3178,
+                dropped_nodes: 54624,
+                pareto_buckets_squared_size_sum: 167681,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1547790,
@@ -431,8 +431,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_values: 20676360,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1588279,
-                pareto_values: 17702595,
+                states: 1532904,
+                pareto_values: 17146214,
             },
         }
     "#]];
@@ -470,11 +470,11 @@ fn stuffed_peppers_2_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 354024,
+            finish_states: 331771,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3145,
-                dropped_nodes: 49074,
-                pareto_buckets_squared_size_sum: 31195,
+                processed_nodes: 2787,
+                dropped_nodes: 43336,
+                pareto_buckets_squared_size_sum: 138311,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1477069,
@@ -482,8 +482,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_values: 17827198,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1619083,
-                pareto_values: 15965490,
+                states: 1572551,
+                pareto_values: 15555612,
             },
         }
     "#]];
@@ -517,11 +517,11 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 605814,
+            finish_states: 592766,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 292,
-                dropped_nodes: 3564,
-                pareto_buckets_squared_size_sum: 644,
+                processed_nodes: 260,
+                dropped_nodes: 3188,
+                pareto_buckets_squared_size_sum: 2000,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 750109,
@@ -529,8 +529,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 9640072,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 879299,
-                pareto_values: 8796813,
+                states: 833285,
+                pareto_values: 8330947,
             },
         }
     "#]];
@@ -564,11 +564,11 @@ fn black_star_4048_3997() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 136859,
+            finish_states: 127123,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 9079,
-                dropped_nodes: 111869,
-                pareto_buckets_squared_size_sum: 356414,
+                processed_nodes: 8156,
+                dropped_nodes: 100402,
+                pareto_buckets_squared_size_sum: 1076395,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 448545,
@@ -576,8 +576,8 @@ fn black_star_4048_3997() {
                 pareto_values: 2531249,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 102945,
-                pareto_values: 559179,
+                states: 99751,
+                pareto_values: 543891,
             },
         }
     "#]];
@@ -611,11 +611,11 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 315154,
+            finish_states: 293888,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 27817,
-                dropped_nodes: 430405,
-                pareto_buckets_squared_size_sum: 1595686,
+                processed_nodes: 24660,
+                dropped_nodes: 384352,
+                pareto_buckets_squared_size_sum: 6630183,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 632525,
@@ -623,8 +623,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 4421953,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 311790,
-                pareto_values: 1982673,
+                states: 308090,
+                pareto_values: 1967852,
             },
         }
     "#]];
@@ -658,11 +658,11 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 395204,
+            finish_states: 371099,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 357,
-                dropped_nodes: 4875,
-                pareto_buckets_squared_size_sum: 679,
+                processed_nodes: 295,
+                dropped_nodes: 4037,
+                pareto_buckets_squared_size_sum: 1477,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 654113,
@@ -670,8 +670,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 7088630,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 683238,
-                pareto_values: 5815405,
+                states: 655500,
+                pareto_values: 5579324,
             },
         }
     "#]];
@@ -705,11 +705,11 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 457491,
+            finish_states: 420652,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1202,
-                dropped_nodes: 18056,
-                pareto_buckets_squared_size_sum: 4650,
+                processed_nodes: 929,
+                dropped_nodes: 13806,
+                pareto_buckets_squared_size_sum: 15087,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 620174,
@@ -717,8 +717,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 6152904,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 530777,
-                pareto_values: 4366569,
+                states: 484722,
+                pareto_values: 3995240,
             },
         }
     "#]];
@@ -752,11 +752,11 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1171247,
+            finish_states: 1129890,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 16606,
-                dropped_nodes: 251621,
-                pareto_buckets_squared_size_sum: 433633,
+                processed_nodes: 14680,
+                dropped_nodes: 223882,
+                pareto_buckets_squared_size_sum: 2761690,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 871349,
@@ -764,8 +764,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 12661815,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1113317,
-                pareto_values: 11054392,
+                states: 1097602,
+                pareto_values: 10951795,
             },
         }
     "#]];
@@ -799,20 +799,20 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 584023,
+            finish_states: 577933,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 161594,
-                dropped_nodes: 720978,
-                pareto_buckets_squared_size_sum: 27623705,
+                processed_nodes: 153823,
+                dropped_nodes: 685761,
+                pareto_buckets_squared_size_sum: 107697428,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 994029,
-                sequential_states: 9822,
-                pareto_values: 11580676,
+                sequential_states: 9767,
+                pareto_values: 11580525,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 319981,
-                pareto_values: 2763164,
+                states: 319663,
+                pareto_values: 2762456,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -86,7 +86,6 @@ fn rinascita_3700_3280() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 456,
                 dropped_nodes: 4523,
-                pareto_buckets_squared_size_sum: 8004,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 957930,
@@ -133,7 +132,6 @@ fn pactmaker_3240_3130() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 4600,
                 dropped_nodes: 34040,
-                pareto_buckets_squared_size_sum: 839521,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 818130,
@@ -182,7 +180,6 @@ fn pactmaker_3240_3130_heart_and_soul() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 577,
                 dropped_nodes: 6649,
-                pareto_buckets_squared_size_sum: 17601,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1690660,
@@ -229,7 +226,6 @@ fn diadochos_4021_3660() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 1626,
                 dropped_nodes: 5140,
-                pareto_buckets_squared_size_sum: 126370,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 888030,
@@ -276,7 +272,6 @@ fn indagator_3858_4057() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 3357,
                 dropped_nodes: 19183,
-                pareto_buckets_squared_size_sum: 408097,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 971910,
@@ -319,11 +314,10 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1177480,
+            finish_states: 1178357,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 60066,
-                dropped_nodes: 247368,
-                pareto_buckets_squared_size_sum: 33375101,
+                processed_nodes: 60808,
+                dropped_nodes: 251373,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,
@@ -372,7 +366,6 @@ fn stuffed_peppers_2() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 2787,
                 dropped_nodes: 42357,
-                pareto_buckets_squared_size_sum: 138311,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 727703,
@@ -423,7 +416,6 @@ fn stuffed_peppers_2_heart_and_soul() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 3178,
                 dropped_nodes: 54624,
-                pareto_buckets_squared_size_sum: 167681,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1547790,
@@ -474,7 +466,6 @@ fn stuffed_peppers_2_quick_innovation() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 2787,
                 dropped_nodes: 43336,
-                pareto_buckets_squared_size_sum: 138311,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1477069,
@@ -521,7 +512,6 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 260,
                 dropped_nodes: 3188,
-                pareto_buckets_squared_size_sum: 2000,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 750109,
@@ -568,7 +558,6 @@ fn black_star_4048_3997() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 8156,
                 dropped_nodes: 100402,
-                pareto_buckets_squared_size_sum: 1076395,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 448545,
@@ -611,11 +600,10 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 293888,
+            finish_states: 293940,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 24660,
-                dropped_nodes: 384352,
-                pareto_buckets_squared_size_sum: 6630183,
+                processed_nodes: 24678,
+                dropped_nodes: 384672,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 632525,
@@ -662,7 +650,6 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 295,
                 dropped_nodes: 4037,
-                pareto_buckets_squared_size_sum: 1477,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 654113,
@@ -709,7 +696,6 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 929,
                 dropped_nodes: 13806,
-                pareto_buckets_squared_size_sum: 15087,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 620174,
@@ -752,11 +738,10 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1129890,
+            finish_states: 1129907,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 14680,
-                dropped_nodes: 223882,
-                pareto_buckets_squared_size_sum: 2761690,
+                processed_nodes: 14683,
+                dropped_nodes: 223930,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 871349,
@@ -799,11 +784,10 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 577933,
+            finish_states: 578870,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 153823,
-                dropped_nodes: 685761,
-                pareto_buckets_squared_size_sum: 107697428,
+                processed_nodes: 158334,
+                dropped_nodes: 708042,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 994029,
@@ -811,8 +795,8 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_values: 11580525,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 319663,
-                pareto_values: 2762456,
+                states: 319665,
+                pareto_values: 2762458,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -128,10 +128,10 @@ fn pactmaker_3240_3130() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 267472,
+            finish_states: 267531,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 4600,
-                dropped_nodes: 34040,
+                processed_nodes: 4630,
+                dropped_nodes: 34331,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 818130,
@@ -270,8 +270,8 @@ fn indagator_3858_4057() {
         MacroSolverStats {
             finish_states: 346005,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3357,
-                dropped_nodes: 19183,
+                processed_nodes: 3359,
+                dropped_nodes: 19200,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 971910,
@@ -314,19 +314,19 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1178357,
+            finish_states: 1183317,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 60808,
-                dropped_nodes: 251373,
+                processed_nodes: 63042,
+                dropped_nodes: 262543,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,
-                sequential_states: 12496,
-                pareto_values: 16494230,
+                sequential_states: 12499,
+                pareto_values: 16494243,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1753849,
-                pareto_values: 20037701,
+                states: 1753944,
+                pareto_values: 20037975,
             },
         }
     "#]];
@@ -554,10 +554,10 @@ fn black_star_4048_3997() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 127123,
+            finish_states: 127127,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 8156,
-                dropped_nodes: 100402,
+                processed_nodes: 8158,
+                dropped_nodes: 100430,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 448545,
@@ -600,10 +600,10 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 293940,
+            finish_states: 295272,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 24678,
-                dropped_nodes: 384672,
+                processed_nodes: 25046,
+                dropped_nodes: 390896,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 632525,
@@ -611,8 +611,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 4421953,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 308090,
-                pareto_values: 1967852,
+                states: 308102,
+                pareto_values: 1967887,
             },
         }
     "#]];
@@ -738,10 +738,10 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1129907,
+            finish_states: 1130106,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 14683,
-                dropped_nodes: 223930,
+                processed_nodes: 14739,
+                dropped_nodes: 224809,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 871349,
@@ -749,8 +749,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 12661815,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1097602,
-                pareto_values: 10951795,
+                states: 1097607,
+                pareto_values: 10951821,
             },
         }
     "#]];
@@ -784,10 +784,10 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 578870,
+            finish_states: 582393,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 158334,
-                dropped_nodes: 708042,
+                processed_nodes: 169988,
+                dropped_nodes: 761577,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 994029,
@@ -795,8 +795,8 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_values: 11580525,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 319665,
-                pareto_values: 2762458,
+                states: 319667,
+                pareto_values: 2762461,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -314,10 +314,10 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 2386848,
+            finish_states: 2387186,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1466804,
-                dropped_nodes: 9994206,
+                processed_nodes: 1483443,
+                dropped_nodes: 10107736,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
@@ -325,8 +325,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_values: 22061401,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1750683,
-                pareto_values: 35133297,
+                states: 1750689,
+                pareto_values: 35133315,
             },
         }
     "#]];
@@ -510,8 +510,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
         MacroSolverStats {
             finish_states: 1209636,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 20524,
-                dropped_nodes: 330165,
+                processed_nodes: 20525,
+                dropped_nodes: 330172,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 709548,
@@ -784,10 +784,10 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 859369,
+            finish_states: 859926,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1785217,
-                dropped_nodes: 13044055,
+                processed_nodes: 1820997,
+                dropped_nodes: 13336465,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,
@@ -795,8 +795,8 @@ fn hardened_survey_plank_5558_5216() {
                 pareto_values: 16038900,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 341307,
-                pareto_values: 4977992,
+                states: 341313,
+                pareto_values: 4978005,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -86,7 +86,6 @@ fn rinascita_3700_3280() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 3718,
                 dropped_nodes: 47099,
-                pareto_buckets_squared_size_sum: 82625,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 946344,
@@ -133,7 +132,6 @@ fn pactmaker_3240_3130() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 5239,
                 dropped_nodes: 65490,
-                pareto_buckets_squared_size_sum: 220159,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 808184,
@@ -182,7 +180,6 @@ fn pactmaker_3240_3130_heart_and_soul() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 1020,
                 dropped_nodes: 16380,
-                pareto_buckets_squared_size_sum: 19732,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1668344,
@@ -229,7 +226,6 @@ fn diadochos_4021_3660() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 6043,
                 dropped_nodes: 36050,
-                pareto_buckets_squared_size_sum: 147900,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 877264,
@@ -276,7 +272,6 @@ fn indagator_3858_4057() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 341,
                 dropped_nodes: 5021,
-                pareto_buckets_squared_size_sum: 1113,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 960160,
@@ -319,11 +314,10 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 2386785,
+            finish_states: 2386848,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1463009,
-                dropped_nodes: 9964883,
-                pareto_buckets_squared_size_sum: 441665830,
+                processed_nodes: 1466804,
+                dropped_nodes: 9994206,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
@@ -372,7 +366,6 @@ fn stuffed_peppers_2() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 158,
                 dropped_nodes: 3253,
-                pareto_buckets_squared_size_sum: 522,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 685374,
@@ -423,7 +416,6 @@ fn stuffed_peppers_2_heart_and_soul() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 168,
                 dropped_nodes: 3953,
-                pareto_buckets_squared_size_sum: 562,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1464188,
@@ -474,7 +466,6 @@ fn stuffed_peppers_2_quick_innovation() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 158,
                 dropped_nodes: 3376,
-                pareto_buckets_squared_size_sum: 522,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1405659,
@@ -521,7 +512,6 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 20524,
                 dropped_nodes: 330165,
-                pareto_buckets_squared_size_sum: 789821,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 709548,
@@ -568,7 +558,6 @@ fn black_star_4048_3997() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 1727,
                 dropped_nodes: 26236,
-                pareto_buckets_squared_size_sum: 35394,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 414395,
@@ -615,7 +604,6 @@ fn claro_walnut_lumber_4900_4800() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 7804,
                 dropped_nodes: 151505,
-                pareto_buckets_squared_size_sum: 194855,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 588992,
@@ -662,7 +650,6 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 74,
                 dropped_nodes: 1486,
-                pareto_buckets_squared_size_sum: 122,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 615546,
@@ -709,7 +696,6 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 6369,
                 dropped_nodes: 128343,
-                pareto_buckets_squared_size_sum: 90959,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 579131,
@@ -756,7 +742,6 @@ fn archeo_kingdom_broadsword_4966_4914() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 7627,
                 dropped_nodes: 151949,
-                pareto_buckets_squared_size_sum: 110095,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 812878,
@@ -799,11 +784,10 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 859311,
+            finish_states: 859369,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1778459,
-                dropped_nodes: 12974129,
-                pareto_buckets_squared_size_sum: 434154578,
+                processed_nodes: 1785217,
+                dropped_nodes: 13044055,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,
@@ -850,7 +834,6 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 28099,
                 dropped_nodes: 315380,
-                pareto_buckets_squared_size_sum: 586714,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2397570,
@@ -898,7 +881,6 @@ fn ceviche_4900_4800_no_quality() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 29,
                 dropped_nodes: 552,
-                pareto_buckets_squared_size_sum: 43,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 428868,
@@ -947,7 +929,6 @@ fn ce_high_progress_zero_achieved_quality() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 397,
                 dropped_nodes: 0,
-                pareto_buckets_squared_size_sum: 1033,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 951755,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -82,11 +82,11 @@ fn rinascita_3700_3280() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 321264,
+            finish_states: 321209,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3720,
-                dropped_nodes: 47101,
-                pareto_buckets_squared_size_sum: 20840,
+                processed_nodes: 3718,
+                dropped_nodes: 47099,
+                pareto_buckets_squared_size_sum: 82625,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 946344,
@@ -129,11 +129,11 @@ fn pactmaker_3240_3130() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 298565,
+            finish_states: 298477,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 5246,
-                dropped_nodes: 65584,
-                pareto_buckets_squared_size_sum: 54474,
+                processed_nodes: 5239,
+                dropped_nodes: 65490,
+                pareto_buckets_squared_size_sum: 220159,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 808184,
@@ -182,7 +182,7 @@ fn pactmaker_3240_3130_heart_and_soul() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 1020,
                 dropped_nodes: 16380,
-                pareto_buckets_squared_size_sum: 4700,
+                pareto_buckets_squared_size_sum: 19732,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1668344,
@@ -225,11 +225,11 @@ fn diadochos_4021_3660() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 522802,
+            finish_states: 522737,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 6058,
-                dropped_nodes: 36110,
-                pareto_buckets_squared_size_sum: 36854,
+                processed_nodes: 6043,
+                dropped_nodes: 36050,
+                pareto_buckets_squared_size_sum: 147900,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 877264,
@@ -276,7 +276,7 @@ fn indagator_3858_4057() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 341,
                 dropped_nodes: 5021,
-                pareto_buckets_squared_size_sum: 559,
+                pareto_buckets_squared_size_sum: 1113,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 960160,
@@ -319,20 +319,20 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 2411529,
+            finish_states: 2386785,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1591900,
-                dropped_nodes: 10803132,
-                pareto_buckets_squared_size_sum: 64404105,
+                processed_nodes: 1463009,
+                dropped_nodes: 9964883,
+                pareto_buckets_squared_size_sum: 441665830,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
-                sequential_states: 6187,
-                pareto_values: 22061405,
+                sequential_states: 6186,
+                pareto_values: 22061401,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1756906,
-                pareto_values: 35183972,
+                states: 1750683,
+                pareto_values: 35133297,
             },
         }
     "#]];
@@ -368,11 +368,11 @@ fn stuffed_peppers_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 113261,
+            finish_states: 113181,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 160,
-                dropped_nodes: 3297,
-                pareto_buckets_squared_size_sum: 256,
+                processed_nodes: 158,
+                dropped_nodes: 3253,
+                pareto_buckets_squared_size_sum: 522,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 685374,
@@ -419,11 +419,11 @@ fn stuffed_peppers_2_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 135817,
+            finish_states: 135715,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 170,
-                dropped_nodes: 4003,
-                pareto_buckets_squared_size_sum: 272,
+                processed_nodes: 168,
+                dropped_nodes: 3953,
+                pareto_buckets_squared_size_sum: 562,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1464188,
@@ -431,8 +431,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_values: 24789603,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1386939,
-                pareto_values: 26445723,
+                states: 1386414,
+                pareto_values: 26436486,
             },
         }
     "#]];
@@ -470,11 +470,11 @@ fn stuffed_peppers_2_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 113262,
+            finish_states: 113182,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 160,
-                dropped_nodes: 3422,
-                pareto_buckets_squared_size_sum: 256,
+                processed_nodes: 158,
+                dropped_nodes: 3376,
+                pareto_buckets_squared_size_sum: 522,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1405659,
@@ -517,11 +517,11 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1224118,
+            finish_states: 1209636,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 22404,
-                dropped_nodes: 359646,
-                pareto_buckets_squared_size_sum: 187676,
+                processed_nodes: 20524,
+                dropped_nodes: 330165,
+                pareto_buckets_squared_size_sum: 789821,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 709548,
@@ -529,8 +529,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 11347845,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 920961,
-                pareto_values: 14882985,
+                states: 902038,
+                pareto_values: 14638942,
             },
         }
     "#]];
@@ -564,11 +564,11 @@ fn black_star_4048_3997() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 49606,
+            finish_states: 49527,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1739,
-                dropped_nodes: 26431,
-                pareto_buckets_squared_size_sum: 15755,
+                processed_nodes: 1727,
+                dropped_nodes: 26236,
+                pareto_buckets_squared_size_sum: 35394,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 414395,
@@ -611,11 +611,11 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 127733,
+            finish_states: 121980,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 8296,
-                dropped_nodes: 161278,
-                pareto_buckets_squared_size_sum: 79064,
+                processed_nodes: 7804,
+                dropped_nodes: 151505,
+                pareto_buckets_squared_size_sum: 194855,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 588992,
@@ -623,8 +623,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 5111464,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 270482,
-                pareto_values: 2619156,
+                states: 269309,
+                pareto_values: 2610911,
             },
         }
     "#]];
@@ -662,7 +662,7 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 74,
                 dropped_nodes: 1486,
-                pareto_buckets_squared_size_sum: 90,
+                pareto_buckets_squared_size_sum: 122,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 615546,
@@ -705,11 +705,11 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 690212,
+            finish_states: 666973,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 7153,
-                dropped_nodes: 144383,
-                pareto_buckets_squared_size_sum: 27336,
+                processed_nodes: 6369,
+                dropped_nodes: 128343,
+                pareto_buckets_squared_size_sum: 90959,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 579131,
@@ -717,8 +717,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 6864670,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 577428,
-                pareto_values: 7703102,
+                states: 550832,
+                pareto_values: 7352920,
             },
         }
     "#]];
@@ -752,11 +752,11 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 870640,
+            finish_states: 865500,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 7820,
-                dropped_nodes: 155839,
-                pareto_buckets_squared_size_sum: 37628,
+                processed_nodes: 7627,
+                dropped_nodes: 151949,
+                pareto_buckets_squared_size_sum: 110095,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 812878,
@@ -764,8 +764,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 15607520,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1000851,
-                pareto_values: 17986754,
+                states: 998131,
+                pareto_values: 17952228,
             },
         }
     "#]];
@@ -799,20 +799,20 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 867357,
+            finish_states: 859311,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1889237,
-                dropped_nodes: 13613015,
-                pareto_buckets_squared_size_sum: 142776403,
+                processed_nodes: 1778459,
+                dropped_nodes: 12974129,
+                pareto_buckets_squared_size_sum: 434154578,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,
-                sequential_states: 4019,
-                pareto_values: 16038903,
+                sequential_states: 4016,
+                pareto_values: 16038900,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 341656,
-                pareto_values: 4979593,
+                states: 341307,
+                pareto_values: 4977992,
             },
         }
     "#]];
@@ -846,16 +846,16 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 270612,
+            finish_states: 270368,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 28159,
-                dropped_nodes: 316039,
-                pareto_buckets_squared_size_sum: 310984,
+                processed_nodes: 28099,
+                dropped_nodes: 315380,
+                pareto_buckets_squared_size_sum: 586714,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2397570,
-                sequential_states: 106175,
-                pareto_values: 38834009,
+                sequential_states: 106158,
+                pareto_values: 38833493,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,
@@ -898,7 +898,7 @@ fn ceviche_4900_4800_no_quality() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 29,
                 dropped_nodes: 552,
-                pareto_buckets_squared_size_sum: 31,
+                pareto_buckets_squared_size_sum: 43,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 428868,
@@ -947,7 +947,7 @@ fn ce_high_progress_zero_achieved_quality() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 397,
                 dropped_nodes: 0,
-                pareto_buckets_squared_size_sum: 635,
+                pareto_buckets_squared_size_sum: 1033,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 951755,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -145,10 +145,10 @@ fn test_rare_tacos_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1472341,
+            finish_states: 1472394,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3782699,
-                dropped_nodes: 31852008,
+                processed_nodes: 3802112,
+                dropped_nodes: 31992658,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490785,
@@ -156,8 +156,8 @@ fn test_rare_tacos_2() {
                 pareto_values: 70125086,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1635034,
-                pareto_values: 37197377,
+                states: 1634999,
+                pareto_values: 37197066,
             },
         }
     "#]];
@@ -293,15 +293,15 @@ fn test_rare_tacos_4628_4410() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 559002,
+            finish_states: 559037,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1053872,
-                dropped_nodes: 2659947,
+                processed_nodes: 1055996,
+                dropped_nodes: 2660672,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2623634,
-                sequential_states: 69168,
-                pareto_values: 78047432,
+                sequential_states: 69175,
+                pareto_values: 78047665,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 352027,
@@ -342,15 +342,15 @@ fn issue_113() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1968947,
+            finish_states: 1968968,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1408306,
-                dropped_nodes: 19820943,
+                processed_nodes: 1410226,
+                dropped_nodes: 19845641,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 3043554,
-                sequential_states: 80265,
-                pareto_values: 120616600,
+                sequential_states: 80266,
+                pareto_values: 120616673,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,
@@ -389,15 +389,15 @@ fn issue_118() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 574516,
+            finish_states: 574590,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1311232,
-                dropped_nodes: 15541987,
+                processed_nodes: 1333842,
+                dropped_nodes: 15839134,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1931154,
-                sequential_states: 61507,
-                pareto_values: 25591667,
+                sequential_states: 61509,
+                pareto_values: 25591708,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 208451,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -97,11 +97,11 @@ fn stuffed_peppers() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 890638,
+            finish_states: 863226,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 90783,
-                dropped_nodes: 1770876,
-                pareto_buckets_squared_size_sum: 805040,
+                processed_nodes: 81472,
+                dropped_nodes: 1587724,
+                pareto_buckets_squared_size_sum: 3422298,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2271577,
@@ -109,8 +109,8 @@ fn stuffed_peppers() {
                 pareto_values: 39200086,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 944544,
-                pareto_values: 16991075,
+                states: 921340,
+                pareto_values: 16665213,
             },
         }
     "#]];
@@ -146,20 +146,20 @@ fn test_rare_tacos_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1474064,
+            finish_states: 1472334,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3907014,
-                dropped_nodes: 33021901,
-                pareto_buckets_squared_size_sum: 140922931,
+                processed_nodes: 3781127,
+                dropped_nodes: 31840780,
+                pareto_buckets_squared_size_sum: 622685080,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490785,
-                sequential_states: 77760,
-                pareto_values: 70125298,
+                sequential_states: 77748,
+                pareto_values: 70125086,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1635706,
-                pareto_values: 37206732,
+                states: 1635060,
+                pareto_values: 37197707,
             },
         }
     "#]];
@@ -199,20 +199,20 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 78637,
+            finish_states: 74980,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 31661,
-                dropped_nodes: 414254,
-                pareto_buckets_squared_size_sum: 348836,
+                processed_nodes: 28373,
+                dropped_nodes: 369958,
+                pareto_buckets_squared_size_sum: 1010743,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1800446,
-                sequential_states: 39390,
-                pareto_values: 16731571,
+                sequential_states: 39362,
+                pareto_values: 16731453,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 47761,
-                pareto_values: 428964,
+                states: 47456,
+                pareto_values: 427587,
             },
         }
     "#]];
@@ -246,11 +246,11 @@ fn test_indagator_3858_4057() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 513344,
+            finish_states: 513152,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 20921,
-                dropped_nodes: 203673,
-                pareto_buckets_squared_size_sum: 155735,
+                processed_nodes: 20793,
+                dropped_nodes: 202626,
+                pareto_buckets_squared_size_sum: 653969,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2515306,
@@ -297,20 +297,20 @@ fn test_rare_tacos_4628_4410() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 560266,
+            finish_states: 559002,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1083077,
-                dropped_nodes: 2702408,
-                pareto_buckets_squared_size_sum: 30741678,
+                processed_nodes: 1053842,
+                dropped_nodes: 2659940,
+                pareto_buckets_squared_size_sum: 113760950,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2623634,
-                sequential_states: 69174,
-                pareto_values: 78047587,
+                sequential_states: 69168,
+                pareto_values: 78047432,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 352035,
-                pareto_values: 7690209,
+                states: 352027,
+                pareto_values: 7690128,
             },
         }
     "#]];
@@ -347,16 +347,16 @@ fn issue_113() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1969837,
+            finish_states: 1968947,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1443874,
-                dropped_nodes: 20339022,
-                pareto_buckets_squared_size_sum: 36070522,
+                processed_nodes: 1408275,
+                dropped_nodes: 19820493,
+                pareto_buckets_squared_size_sum: 138635912,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 3043554,
-                sequential_states: 80270,
-                pareto_values: 120616917,
+                sequential_states: 80265,
+                pareto_values: 120616600,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 0,
@@ -395,20 +395,20 @@ fn issue_118() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 576410,
+            finish_states: 574504,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1343629,
-                dropped_nodes: 15942609,
-                pareto_buckets_squared_size_sum: 121235617,
+                processed_nodes: 1306064,
+                dropped_nodes: 15471138,
+                pareto_buckets_squared_size_sum: 337405717,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1931154,
-                sequential_states: 61560,
-                pareto_values: 25592132,
+                sequential_states: 61506,
+                pareto_values: 25591649,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 208553,
-                pareto_values: 2353263,
+                states: 208451,
+                pareto_values: 2352793,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -101,7 +101,6 @@ fn stuffed_peppers() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 81472,
                 dropped_nodes: 1587724,
-                pareto_buckets_squared_size_sum: 3422298,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2271577,
@@ -146,11 +145,10 @@ fn test_rare_tacos_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1472334,
+            finish_states: 1472341,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3781127,
-                dropped_nodes: 31840780,
-                pareto_buckets_squared_size_sum: 622685080,
+                processed_nodes: 3782699,
+                dropped_nodes: 31852008,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490785,
@@ -158,8 +156,8 @@ fn test_rare_tacos_2() {
                 pareto_values: 70125086,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1635060,
-                pareto_values: 37197707,
+                states: 1635034,
+                pareto_values: 37197377,
             },
         }
     "#]];
@@ -203,7 +201,6 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 28373,
                 dropped_nodes: 369958,
-                pareto_buckets_squared_size_sum: 1010743,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1800446,
@@ -250,7 +247,6 @@ fn test_indagator_3858_4057() {
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 20793,
                 dropped_nodes: 202626,
-                pareto_buckets_squared_size_sum: 653969,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2515306,
@@ -299,9 +295,8 @@ fn test_rare_tacos_4628_4410() {
         MacroSolverStats {
             finish_states: 559002,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1053842,
-                dropped_nodes: 2659940,
-                pareto_buckets_squared_size_sum: 113760950,
+                processed_nodes: 1053872,
+                dropped_nodes: 2659947,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2623634,
@@ -349,9 +344,8 @@ fn issue_113() {
         MacroSolverStats {
             finish_states: 1968947,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1408275,
-                dropped_nodes: 19820493,
-                pareto_buckets_squared_size_sum: 138635912,
+                processed_nodes: 1408306,
+                dropped_nodes: 19820943,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 3043554,
@@ -395,16 +389,15 @@ fn issue_118() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 574504,
+            finish_states: 574516,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1306064,
-                dropped_nodes: 15471138,
-                pareto_buckets_squared_size_sum: 337405717,
+                processed_nodes: 1311232,
+                dropped_nodes: 15541987,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1931154,
-                sequential_states: 61506,
-                pareto_values: 25591649,
+                sequential_states: 61507,
+                pareto_values: 25591667,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 208451,


### PR DESCRIPTION
Instead of using a hard-coded rule to use CP to partition Pareto fronts into buckets, instead the Pareto front now automatically splits when hitting a certain size (`N > 200`). This makes the `pareto_buckets_squared_size_sum` statistic redundant as there is now a limit on the maximum Pareto front size.

The `N > 200` was chosen because it seems like to sweet spot between runtime and nodes filtered. Increasing the limit increases runtime but decreases memory usage. Decreasing the limit does the opposite.

On `x86_64`, a `u128` subtraction generates a `sub` instruction and a `sbb` instruction, where the `sbb` instruction uses the carry flag (CF) from the `sub` instruction. This means there's a data dependency between the 2 instructions which could lead to bad pipelining.

Changing the dominance check from using `u128` arithmetic to using `wide::u32x4` SIMD arithmetic gets rid of the above-mentioned data dependency and improves the overall performance of the example program by ~2.5%.

https://godbolt.org/z/h536bW41a