### PR TITLE
Handle web version's exceptions in JavaScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
         <link data-trunk rel="copy-dir" href="assets/action-icons/" />
         <link data-trunk rel="copy-dir" href="assets/fonts/" />
 
+        <meta name="color-scheme" content="dark light" />
         <meta
             name="theme-color"
             media="(prefers-color-scheme: light)"
@@ -40,6 +41,30 @@
         />
 
         <style>
+            :root {
+                color-scheme: light dark;
+
+                /* Colors and style roughly matching egui's default themes */
+                /* https://github.com/emilk/egui/blob/main/crates/egui/src/style.rs#L1387 */
+                --hyperlink-dark: rgb(90, 170, 255);
+                --window-panel-fill-dark: rgb(27, 27, 27);
+                --window-separator-stroke-dark: rgb(60, 60, 60);
+                --shadow-dark: rgb(0, 0, 0, 0.3765); /* a=96 */
+                /* https://github.com/emilk/egui/blob/main/crates/egui/src/style.rs#L1499 */
+                --selection-bg-fill-dark: rgb(0, 92, 128);
+                /* https://github.com/emilk/egui/blob/main/crates/egui/src/style.rs#L1521 */
+                --noninteractive-fg-stroke-dark: rgb(140, 140, 140);
+                --active-fg-stroke-dark: white;
+
+                --hyperlink-light: rgb(0, 155, 255);
+                --window-panel-fill-light: rgb(248, 248, 248);
+                --window-separator-stroke-light: rgb(190, 190, 190);
+                --shadow-light: rgb(0, 0, 0, 0.0980); /* a=25 */
+                --selection-bg-fill-light: rgb(144, 209, 255);
+                --noninteractive-fg-stroke-light: rgb(80, 80, 80);
+                --active-fg-stroke-light: black;
+            }
+
             html {
                 /* Remove touch delay: */
                 touch-action: manipulation;
@@ -57,20 +82,6 @@
                         or where the egui canvas is translucent. */
                     background: #404040;
                 }
-            }
-
-            .centered {
-                margin-right: auto;
-                margin-left: auto;
-                display: block;
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
-                color: #f0f0f0;
-                font-size: 24px;
-                font-family: Ubuntu-Light, Helvetica, sans-serif;
-                text-align: center;
             }
 
             /* Allow canvas to fill entire web page: */
@@ -92,16 +103,74 @@
                 height: 100%;
             }
 
+            .centering {
+                position: absolute;
+                display: grid;
+                inset: 0;
+                place-items: center;
+
+                pointer-events: none;
+            }
+
             /* Loading animation from https://cssloaders.github.io/ */
-            .loader {
+            #loader {
                 width: 32px;
                 height: 32px;
                 border: 5px solid #fff;
                 border-bottom-color: transparent;
                 border-radius: 50%;
-                display: inline-block;
                 box-sizing: border-box;
                 animation: rotation 1s linear infinite;
+            }
+
+
+            .modal {
+                background-color: light-dark(var(--window-panel-fill-light), var(--window-panel-fill-dark));
+                padding-block: 0.2em;
+                padding-inline: 0.4em;
+
+                border: 0.1em solid light-dark(var(--window-separator-stroke-light), var(--window-separator-stroke-dark));
+                border-radius: 0.5em;
+
+                box-shadow: 0.3em 0.5em 0.4em light-dark(var(--shadow-light), var(--shadow-dark));
+
+                font: lighter 0.8em sans-serif;
+
+                pointer-events: all;
+            }
+
+            .modal ::selection {
+                background-color: light-dark(var(--selection-bg-fill-light), var(--selection-bg-fill-dark));
+            }
+
+            .modal > hr {
+                border-color: light-dark(var(--window-separator-stroke-light), var(--window-separator-stroke-dark));
+            }
+
+            .modal > p {
+                width: fit-content;
+                margin-block: 0.4em;
+            }
+
+            .modal > p:hover {
+                cursor: text;
+            }
+
+            .modal > a, a:visited {
+                color: light-dark(var(--hyperlink-light), var(--hyperlink-dark));
+                text-decoration: none;
+            }
+
+            .modal > a:hover {
+                text-decoration: underline;
+            }
+
+            .strong-text {
+                color: light-dark(var(--active-fg-stroke-light), var(--active-fg-stroke-dark));
+            }
+
+            .weak-text {
+                color: light-dark(var(--noninteractive-fg-stroke-light), var(--noninteractive-fg-stroke-dark));
             }
 
             @keyframes rotation {
@@ -116,12 +185,47 @@
     </head>
 
     <body>
-        <div id="spinner" class="centered">
-            <span class="loader"></span>
+        <div id="spinner" class="centering">
+            <span id="loader"></span>
+        </div>
+        <div class="centering">
+            <div id="memory_error_modal" class="modal weak-text" style="display: none;">
+                <p class="strong-text">Error: <span>Solver ran out of memory!</span></p>
+                <hr />
+                <p>The solver reached the 4GB memory limit of 32-bit web assembly and crashed.</p>
+                <p>Consider enabling fewer memory intensive options.</p>
+                <br />
+                <p>Alternatively, a native version is available from the release page on GitHub.</p>
+                <p>The native version doesn't have the 4GB limit, in addition to better performance.</p>
+                <a href="https://github.com/KonaeAkira/raphael-rs/releases/latest">View latest release on GitHub</a>
+                <hr />
+                <p style="margin-inline: auto;">Reload the page to reset the app</p>
+            </div>
+             <div id="webgl_error_modal" class="modal weak-text" style="display: none;">
+                <p class="strong-text">Error: <span id="start-failure-message">WebGL is not available!</span></p>
+                <hr />
+                <p>Please enable WebGL support in your browser.</p>
+                <hr />
+                <p style="margin-inline: auto;">Reload the page after to try again</p>
+            </div>
         </div>
         <!-- The WASM code will resize the canvas dynamically -->
         <!-- the id is hardcoded in main.rs . so, make sure both match. -->
         <canvas id="the_canvas_id"></canvas>
+
+        <script>
+            const main_wasm_regex = /raphael-xiv.*.wasm/;
+            const main_js_regex = /raphael-xiv.*.js/;
+            window.addEventListener("error", (event) => {
+                console.error(event);
+
+                if (main_wasm_regex.test(event.filename) && event.message === "RuntimeError: unreachable executed") {
+                    memory_error_modal.removeAttribute("style");
+                } else if (main_js_regex.test(event.filename) && event.message === "uncaught exception: WebGL isn't supported") {
+                    webgl_error_modal.removeAttribute("style");
+                }
+            });
+        </script>
     </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -180,26 +180,20 @@
                 }
             }
         </style>
-        <meta name="theme-color" />
+        <meta name="theme-color" content="var(--window-panel-fill-color)" />
         <script>
             const theme_color_meta_element = document.querySelector('meta[name="theme-color"]');
             const theme_preference = /theme_preference:(System|Dark|Light),/.exec(localStorage.egui_memory_ron);
             if (theme_preference) {
                 switch (theme_preference[1]) {
                     case "Dark":
-                        theme_color_meta_element.setAttribute("content", "var(--window-panel-fill-dark)");
                         document.documentElement.classList = ["dark"];
                         break;
                     case "Light":
-                        theme_color_meta_element.setAttribute("content", "var(--window-panel-fill-light)");
                         document.documentElement.classList = ["light"];
                         break;
                     default:
-                        theme_color_meta_element.setAttribute("content", "light-dark(var(--window-panel-fill-light), var(--window-panel-fill-dark))");
-                        document.documentElement.classList = [];
                 }
-            } else {
-                theme_color_meta_element.setAttribute("content", "light-dark(var(--window-panel-fill-light), var(--window-panel-fill-dark))");
             }
         </script>
     </head>

--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
                 <br />
                 <p>Alternatively, a native version is available from the release page on GitHub.</p>
                 <p>The native version doesn't have the 4GB limit, in addition to better performance.</p>
-                <a href="https://github.com/KonaeAkira/raphael-rs/releases/latest">View latest release on GitHub</a>
+                <a target="_blank" href="https://github.com/KonaeAkira/raphael-rs/releases/latest">View latest release on GitHub</a>
                 <hr />
                 <p style="margin-inline: auto;">Reload the page to reset the app</p>
             </div>

--- a/index.html
+++ b/index.html
@@ -29,17 +29,6 @@
         <link data-trunk rel="copy-dir" href="assets/fonts/" />
 
         <meta name="color-scheme" content="dark light" />
-        <meta
-            name="theme-color"
-            media="(prefers-color-scheme: light)"
-            content="white"
-        />
-        <meta
-            name="theme-color"
-            media="(prefers-color-scheme: dark)"
-            content="#404040"
-        />
-
         <style>
             :root {
                 color-scheme: light dark;
@@ -65,23 +54,24 @@
                 --active-fg-stroke-light: black;
             }
 
+            .light {
+                color-scheme: light;
+            }
+
+            .dark {
+                color-scheme: dark;
+            }
+
+
             html {
                 /* Remove touch delay: */
                 touch-action: manipulation;
             }
 
             body {
-                /* Light mode background color for what is not covered by the egui canvas,
+                /* Background color for what is not covered by the egui canvas,
                     or where the egui canvas is translucent. */
-                background: #909090;
-            }
-
-            @media (prefers-color-scheme: dark) {
-                body {
-                    /* Dark mode background color for what is not covered by the egui canvas,
-                        or where the egui canvas is translucent. */
-                    background: #404040;
-                }
+                background: light-dark(var(--window-panel-fill-light), var(--window-panel-fill-dark));
             }
 
             /* Allow canvas to fill entire web page: */
@@ -116,13 +106,12 @@
             #loader {
                 width: 32px;
                 height: 32px;
-                border: 5px solid #fff;
+                border: 5px solid light-dark(var(--active-fg-stroke-light), var(--active-fg-stroke-dark));
                 border-bottom-color: transparent;
                 border-radius: 50%;
                 box-sizing: border-box;
-                animation: rotation 1s linear infinite;
+                animation: rotation 1s linear infinite, fade-in 3s ease-in forwards;
             }
-
 
             .modal {
                 background-color: light-dark(var(--window-panel-fill-light), var(--window-panel-fill-dark));
@@ -181,14 +170,45 @@
                     transform: rotate(360deg);
                 }
             }
+
+            @keyframes fade-in {
+                0% {
+                    opacity: 0;
+                }
+                100% {
+                    transform: 1;
+                }
+            }
         </style>
+        <meta name="theme-color" />
+        <script>
+            const theme_color_meta_element = document.querySelector('meta[name="theme-color"]');
+            const theme_preference = /theme_preference:(System|Dark|Light),/.exec(localStorage.egui_memory_ron);
+            if (theme_preference) {
+                switch (theme_preference[1]) {
+                    case "Dark":
+                        theme_color_meta_element.setAttribute("content", "var(--window-panel-fill-dark)");
+                        document.documentElement.classList = ["dark"];
+                        break;
+                    case "Light":
+                        theme_color_meta_element.setAttribute("content", "var(--window-panel-fill-light)");
+                        document.documentElement.classList = ["light"];
+                        break;
+                    default:
+                        theme_color_meta_element.setAttribute("content", "light-dark(var(--window-panel-fill-light), var(--window-panel-fill-dark))");
+                        document.documentElement.classList = [];
+                }
+            } else {
+                theme_color_meta_element.setAttribute("content", "light-dark(var(--window-panel-fill-light), var(--window-panel-fill-dark))");
+            }
+        </script>
     </head>
 
     <body>
         <div id="spinner" class="centering">
             <span id="loader"></span>
         </div>
-        <div class="centering">
+        <div id="modal_container" class="centering" style="display: none;">
             <div id="memory_error_modal" class="modal weak-text" style="display: none;">
                 <p class="strong-text">Error: <span>Solver ran out of memory!</span></p>
                 <hr />
@@ -218,7 +238,7 @@
             const main_js_regex = /raphael-xiv.*.js/;
             window.addEventListener("error", (event) => {
                 console.error(event);
-
+                modal_container.removeAttribute("style");
                 if (main_wasm_regex.test(event.filename) && event.message === "RuntimeError: unreachable executed") {
                     memory_error_modal.removeAttribute("style");
                 } else if (main_js_regex.test(event.filename) && event.message === "uncaught exception: WebGL isn't supported") {

--- a/index.html
+++ b/index.html
@@ -35,23 +35,17 @@
 
                 /* Colors and style roughly matching egui's default themes */
                 /* https://github.com/emilk/egui/blob/main/crates/egui/src/style.rs#L1387 */
-                --hyperlink-dark: rgb(90, 170, 255);
+                --hyperlink-color: light-dark(rgb(0, 155, 255), rgb(90, 170, 255));
                 --window-panel-fill-dark: rgb(27, 27, 27);
-                --window-separator-stroke-dark: rgb(60, 60, 60);
-                --shadow-dark: rgb(0, 0, 0, 0.3765); /* a=96 */
-                /* https://github.com/emilk/egui/blob/main/crates/egui/src/style.rs#L1499 */
-                --selection-bg-fill-dark: rgb(0, 92, 128);
-                /* https://github.com/emilk/egui/blob/main/crates/egui/src/style.rs#L1521 */
-                --noninteractive-fg-stroke-dark: rgb(140, 140, 140);
-                --active-fg-stroke-dark: white;
-
-                --hyperlink-light: rgb(0, 155, 255);
                 --window-panel-fill-light: rgb(248, 248, 248);
-                --window-separator-stroke-light: rgb(190, 190, 190);
-                --shadow-light: rgb(0, 0, 0, 0.0980); /* a=25 */
-                --selection-bg-fill-light: rgb(144, 209, 255);
-                --noninteractive-fg-stroke-light: rgb(80, 80, 80);
-                --active-fg-stroke-light: black;
+                --window-panel-fill-color: light-dark(var(--window-panel-fill-light), var(--window-panel-fill-dark));
+                --window-separator-stroke-color: light-dark(rgb(190, 190, 190), rgb(60, 60, 60));
+                --shadow-color: light-dark(rgb(0, 0, 0, 0.0980), rgb(0, 0, 0, 0.3765)); /*  a=25, a=96 */
+                /* https://github.com/emilk/egui/blob/main/crates/egui/src/style.rs#L1499 */
+                --selection-bg-fill-color: light-dark(rgb(144, 209, 255), rgb(0, 92, 128));
+                /* https://github.com/emilk/egui/blob/main/crates/egui/src/style.rs#L1521 */
+                --noninteractive-fg-stroke-color: light-dark(rgb(80, 80, 80), rgb(140, 140, 140));
+                --active-fg-stroke-color: light-dark(black, white);
             }
 
             .light {
@@ -71,7 +65,7 @@
             body {
                 /* Background color for what is not covered by the egui canvas,
                     or where the egui canvas is translucent. */
-                background: light-dark(var(--window-panel-fill-light), var(--window-panel-fill-dark));
+                background: var(--window-panel-fill-color);
             }
 
             /* Allow canvas to fill entire web page: */
@@ -106,22 +100,26 @@
             #loader {
                 width: 32px;
                 height: 32px;
-                border: 5px solid light-dark(var(--active-fg-stroke-light), var(--active-fg-stroke-dark));
+                border: 5px solid var(--active-fg-stroke-color);
                 border-bottom-color: transparent;
                 border-radius: 50%;
                 box-sizing: border-box;
                 animation: rotation 1s linear infinite, fade-in 3s ease-in forwards;
             }
 
+            #modal_container {
+                backdrop-filter: brightness(60%);
+            }
+
             .modal {
-                background-color: light-dark(var(--window-panel-fill-light), var(--window-panel-fill-dark));
+                background-color: var(--window-panel-fill-color);
                 padding-block: 0.2em;
                 padding-inline: 0.4em;
 
-                border: 0.1em solid light-dark(var(--window-separator-stroke-light), var(--window-separator-stroke-dark));
+                border: 0.1em solid var(--window-separator-stroke-color);
                 border-radius: 0.5em;
 
-                box-shadow: 0.3em 0.5em 0.4em light-dark(var(--shadow-light), var(--shadow-dark));
+                box-shadow: 0.3em 0.5em 0.4em var(--shadow-color);
 
                 font: lighter 0.8em sans-serif;
 
@@ -129,11 +127,13 @@
             }
 
             .modal ::selection {
-                background-color: light-dark(var(--selection-bg-fill-light), var(--selection-bg-fill-dark));
+                background-color: var(--selection-bg-fill-color);
             }
 
             .modal > hr {
-                border-color: light-dark(var(--window-separator-stroke-light), var(--window-separator-stroke-dark));
+                border-top-width: 0;
+                border-style: solid;
+                border-color: var(--window-separator-stroke-color);
             }
 
             .modal > p {
@@ -146,7 +146,7 @@
             }
 
             .modal > a, a:visited {
-                color: light-dark(var(--hyperlink-light), var(--hyperlink-dark));
+                color: var(--hyperlink-color);
                 text-decoration: none;
             }
 
@@ -155,11 +155,11 @@
             }
 
             .strong-text {
-                color: light-dark(var(--active-fg-stroke-light), var(--active-fg-stroke-dark));
+                color: var(--active-fg-stroke-color);
             }
 
             .weak-text {
-                color: light-dark(var(--noninteractive-fg-stroke-light), var(--noninteractive-fg-stroke-dark));
+                color: var(--noninteractive-fg-stroke-color);
             }
 
             @keyframes rotation {
@@ -210,7 +210,7 @@
         </div>
         <div id="modal_container" class="centering" style="display: none;">
             <div id="memory_error_modal" class="modal weak-text" style="display: none;">
-                <p class="strong-text">Error: <span>Solver ran out of memory!</span></p>
+                <p class="strong-text">Error: Solver ran out of memory!</p>
                 <hr />
                 <p>The solver reached the 4GB memory limit of 32-bit web assembly and crashed.</p>
                 <p>Consider enabling fewer memory intensive options.</p>
@@ -222,7 +222,7 @@
                 <p style="margin-inline: auto;">Reload the page to reset the app</p>
             </div>
              <div id="webgl_error_modal" class="modal weak-text" style="display: none;">
-                <p class="strong-text">Error: <span id="start-failure-message">WebGL is not available!</span></p>
+                <p class="strong-text">Error: WebGL is not available!</p>
                 <hr />
                 <p>Please enable WebGL support in your browser.</p>
                 <hr />

--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@
                 console.error(event);
                 modal_container.removeAttribute("style");
                 const raphael_related = /raphael-xiv.*.wasm/.test(event.filename) || /raphael-xiv.*.js/.test(event.filename);
-                if (raphael_related && event.error.name === "RuntimeError") {
+                if (raphael_related && event.error === "OOM panic") {
                     memory_error_modal.removeAttribute("style");
                 } else if (raphael_related && event.error === "WebGL isn't supported") {
                     webgl_error_modal.removeAttribute("style");

--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
             <div id="memory_error_modal" class="modal weak-text" style="display: none;">
                 <p class="strong-text">Error: Solver ran out of memory!</p>
                 <hr />
-                <p>The solver reached the 4GB memory limit of 32-bit web assembly and crashed.</p>
+                <p>The solver reached the 4GB memory limit of 32-bit WebAssembly and crashed.</p>
                 <p>Consider enabling fewer memory intensive options.</p>
                 <br />
                 <p>Alternatively, a native version is available from the release page on GitHub.</p>
@@ -228,14 +228,13 @@
         <canvas id="the_canvas_id"></canvas>
 
         <script>
-            const main_wasm_regex = /raphael-xiv.*.wasm/;
-            const main_js_regex = /raphael-xiv.*.js/;
             window.addEventListener("error", (event) => {
                 console.error(event);
                 modal_container.removeAttribute("style");
-                if (main_wasm_regex.test(event.filename) && event.message === "RuntimeError: unreachable executed") {
+                const raphael_related = /raphael-xiv.*.wasm/.test(event.filename) || /raphael-xiv.*.js/.test(event.filename);
+                if (raphael_related && event.error.name === "RuntimeError") {
                     memory_error_modal.removeAttribute("style");
-                } else if (main_js_regex.test(event.filename) && event.message === "uncaught exception: WebGL isn't supported") {
+                } else if (raphael_related && event.error === "WebGL isn't supported") {
                     webgl_error_modal.removeAttribute("style");
                 }
             });

--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -24,8 +24,6 @@ pub enum SolverException {
     NoSolution,
     Interrupted,
     InternalError(String),
-    #[cfg(target_arch = "wasm32")]
-    AllocError,
 }
 
 impl std::fmt::Debug for SolverException {
@@ -34,8 +32,6 @@ impl std::fmt::Debug for SolverException {
             Self::NoSolution => write!(f, "NoSolution"),
             Self::Interrupted => write!(f, "Interrupted"),
             Self::InternalError(message) => f.write_str(message),
-            #[cfg(target_arch = "wasm32")]
-            Self::AllocError => write!(f, "AllocError"),
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -179,6 +179,10 @@ impl eframe::App for MacroSolverApp {
         }
 
         if self.solver_pending {
+            #[cfg(target_arch = "wasm32")]
+            if crate::OOM_PANIC_OCCURED.load(std::sync::atomic::Ordering::Relaxed) {
+                eframe::wasm_bindgen::throw_val("OOM panic".into());
+            }
             let interrupt_pending = self.solver_interrupt.is_set();
             egui::Modal::new(egui::Id::new("solver_busy")).show(ctx, |ui| {
                 ui.style_mut().spacing.item_spacing = egui::vec2(8.0, 3.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,3 @@ mod config;
 mod context;
 mod thread_pool;
 mod widgets;
-
-#[cfg(target_arch = "wasm32")]
-pub static OOM_PANIC_OCCURED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,7 @@ mod config;
 mod context;
 mod thread_pool;
 mod widgets;
+
+#[cfg(target_arch = "wasm32")]
+pub static OOM_PANIC_OCCURED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents a console from being opened on Windows
 // This attribute is ignored for all other platforms
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+#![cfg_attr(target_arch = "wasm32", feature(alloc_error_hook))]
 
 #[cfg(all(target_os = "windows", not(debug_assertions)))]
 fn init_logging() {
@@ -96,6 +97,12 @@ fn main() -> eframe::Result<()> {
 
 #[cfg(target_arch = "wasm32")]
 fn main() {
+    fn custom_alloc_error_hook(_layout: std::alloc::Layout) {
+        raphael_xiv::OOM_PANIC_OCCURED.store(true, std::sync::atomic::Ordering::Relaxed);
+        eframe::wasm_bindgen::throw_val("OOM panic".into());
+    }
+    std::alloc::set_alloc_error_hook(custom_alloc_error_hook);
+
     init_logging();
 
     fn get_canvas() -> Option<web_sys::HtmlCanvasElement> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 // Prevents a console from being opened on Windows
 // This attribute is ignored for all other platforms
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-#![cfg_attr(target_arch = "wasm32", feature(alloc_error_hook))]
 
 #[cfg(all(target_os = "windows", not(debug_assertions)))]
 fn init_logging() {
@@ -97,11 +96,6 @@ fn main() -> eframe::Result<()> {
 
 #[cfg(target_arch = "wasm32")]
 fn main() {
-    fn custom_alloc_error_hook(_layout: std::alloc::Layout) {
-        raphael_xiv::OOM_PANIC_OCCURED.store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-    std::alloc::set_alloc_error_hook(custom_alloc_error_hook);
-
     init_logging();
 
     fn get_canvas() -> Option<web_sys::HtmlCanvasElement> {
@@ -131,14 +125,7 @@ fn main() {
             .await;
         remove_loading_spinner();
         if let Err(error) = start_result {
-            let mut message = format!("Failed to start app: {error:?}");
-            log::error!("{message}");
-            message.push_str("\n\nIn case the error is \"WebGL not supported\":");
-            message.push_str("\nPlease enable WebGL support in your browser.");
-            web_sys::window()
-                .unwrap()
-                .alert_with_message(&message)
-                .unwrap();
+            eframe::wasm_bindgen::throw_val(error);
         }
     });
 }


### PR DESCRIPTION
Moves the logic and UI for handling the web version's exclusive exceptions, that WebGL is not enabled and the Wasm crashing due to the 4GB memory limit, to JavaScript and HTML.

Over time, it seems like the `alloc_error_hook` unstable feature has been working less reliably for its intended use case in Raphael's web version. While it could sometimes fail to display the error message when it was first added, I was unable to find a configuration in the current preview version for which it actually works.

Handling it in JavaScript currently works consistently in my testing. The main downside is that the added HTML & CSS increase the size of `index.html` (I managed to keep it below 10kB). Note that exceptions caused by normal panics seem to be caught by some other mechanism (most likely by `wasm-bindgen`) and are not handled.

Since the basic system was already there, I also added support for handling the "WebGL not being enabled" exception.

**Preview:**
<img width="1282" height="791" alt="Screenshot 2025-09-21 at 21 29 04" src="https://github.com/user-attachments/assets/9978bef1-fe8d-421b-b2dd-40229b89b0e5" />
<img width="1282" height="786" alt="Screenshot 2025-09-21 at 21 31 14" src="https://github.com/user-attachments/assets/be2ad4c6-aed1-4163-9497-1cfaf236e775" />

Additionally, while adding support for using the user-selected theme, I changed the HTML body's background color to use egui's background color and made the spinner fade in. Both of which result in a (in my opinion) less jarring (re)loading animation. If this change is not wanted, I can revert it.