### PR TITLE
Improve fuzzy string matching

### DIFF
--- a/raphael-data/Cargo.toml
+++ b/raphael-data/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["rlib"]
 raphael-sim = { workspace = true }
 non_contiguously_indexed_array = { git = "https://github.com/augenfrosch/non_contiguously_indexed_array", rev = "59bc352188361ba47bcca66c5a140a2b7580bb47", version = "0.4.1" }
 serde = { version = "1.0.215", features = ["derive"], optional = true }
-unicode-normalization = "0.1.24"
+nucleo-matcher = "0.3.1"
 
 [dev-dependencies]
 expect-test = "1.5.1"

--- a/raphael-data/src/search.rs
+++ b/raphael-data/src/search.rs
@@ -32,7 +32,7 @@ impl<T> AsRef<str> for MatcherCandidate<T> {
 fn preprocess_pattern(pattern: &str) -> String {
     pattern
         .chars()
-        .filter(|&c| !c.is_whitespace() && c != HQ_ICON_CHAR && c != CL_ICON_CHAR)
+        .filter(|&c| c != HQ_ICON_CHAR && c != CL_ICON_CHAR)
         .collect()
 }
 


### PR DESCRIPTION
Replace the current implementation (string subsequence matching) with fuzzy search from the `nucleo-matcher` crate. Search results are sorted by how close they are to the search pattern, with most similar results appearing first.

Before: 
<img width="503" height="257" alt="image" src="https://github.com/user-attachments/assets/dd74da1e-76e3-40d2-a130-9fc886041803" />

After:
<img width="503" height="257" alt="image" src="https://github.com/user-attachments/assets/fe219906-fe83-4a72-ae9a-4c73f92931f4" />
