### PR TITLE
Fix solver panic caused by buffer overflow in `ParetoFrontBuilder`

### DIFF
--- a/raphael-solver/Cargo.toml
+++ b/raphael-solver/Cargo.toml
@@ -17,6 +17,7 @@ log = { workspace = true }
 serde = { workspace = true, optional = true }
 web-time = { workspace = true }
 wide = "0.7.33"
+nunny = "0.2.2"
 
 [features]
 serde = ["dep:serde", "raphael-sim/serde"]

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -1,14 +1,14 @@
 use crate::{
-    SolverException, SolverSettings, actions::FULL_SEARCH_ACTIONS, macros::internal_error, utils,
+    SolverException, SolverSettings,
+    actions::FULL_SEARCH_ACTIONS,
+    macros::internal_error,
+    utils::{self, ParetoFrontBuilder, ParetoValue},
 };
 use raphael_sim::*;
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use rustc_hash::FxHashMap;
 
 use super::state::ReducedState;
-
-type ParetoValue = utils::ParetoValue<u32, u32>;
-type ParetoFrontBuilder = utils::ParetoFrontBuilder<u32, u32>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct QualityUbSolverStats {
@@ -23,7 +23,6 @@ pub struct QualityUbSolver {
     solved_states: FxHashMap<ReducedState, Box<[ParetoValue]>>,
     iq_quality_lut: [u32; 11],
     maximal_templates: FxHashMap<TemplateData, u16>,
-    pareto_front_builder: ParetoFrontBuilder,
     durability_cost: u16,
     largest_progress_increase: u32,
     precomputed_states: usize,
@@ -42,7 +41,6 @@ impl QualityUbSolver {
             solved_states: FxHashMap::default(),
             iq_quality_lut: utils::compute_iq_quality_lut(&settings),
             maximal_templates: FxHashMap::default(),
-            pareto_front_builder: ParetoFrontBuilder::new(),
             durability_cost,
             largest_progress_increase: utils::largest_single_action_progress_increase(&settings),
             precomputed_states: 0,
@@ -124,33 +122,30 @@ impl QualityUbSolver {
                 let solved_states = templates
                     .par_iter_mut()
                     .filter_map(|template| template.instantiate(cp).map(|state| (template, state)))
-                    .map_init(
-                        ParetoFrontBuilder::new,
-                        |pf_builder, (template, state)| -> Result<_, SolverException> {
-                            let pareto_front = self.solve_precompute_state(pf_builder, state)?;
-                            let template_is_maximal = {
-                                // A template is "maximal" if there is no benefit of solving it with higher CP
-                                let required_progress = self.settings.max_progress();
-                                let required_quality = self.settings.max_quality().saturating_sub(
-                                    self.iq_quality_lut[usize::from(state.effects.inner_quiet())],
-                                );
-                                if let Some(value) = pareto_front.last() {
-                                    value.first >= required_progress
-                                        && value.second >= required_quality
-                                } else {
-                                    return Err(internal_error!(
-                                        "Unexpected empty pareto front.",
-                                        self.settings,
-                                        state
-                                    ));
-                                }
-                            };
-                            if template_is_maximal {
-                                template.required_cp_for_max_progress_and_quality = Some(cp);
+                    .map(|(template, state)| -> Result<_, SolverException> {
+                        let pareto_front = self.solve_precompute_state(state)?;
+                        let template_is_maximal = {
+                            // A template is "maximal" if there is no benefit of solving it with higher CP
+                            let required_progress = self.settings.max_progress();
+                            let required_quality = self.settings.max_quality().saturating_sub(
+                                self.iq_quality_lut[usize::from(state.effects.inner_quiet())],
+                            );
+                            if let Some(value) = pareto_front.last() {
+                                value.progress >= required_progress
+                                    && value.quality >= required_quality
+                            } else {
+                                return Err(internal_error!(
+                                    "Unexpected empty pareto front.",
+                                    self.settings,
+                                    state
+                                ));
                             }
-                            Ok((state, pareto_front))
-                        },
-                    )
+                        };
+                        if template_is_maximal {
+                            template.required_cp_for_max_progress_and_quality = Some(cp);
+                        }
+                        Ok((state, pareto_front))
+                    })
                     .collect::<Result<Vec<_>, SolverException>>()?;
                 self.solved_states.extend(solved_states);
             }
@@ -173,11 +168,9 @@ impl QualityUbSolver {
 
     fn solve_precompute_state(
         &self,
-        pareto_front_builder: &mut ParetoFrontBuilder,
         state: ReducedState,
     ) -> Result<Box<[ParetoValue]>, SolverException> {
-        pareto_front_builder.clear();
-        pareto_front_builder.push_empty();
+        let mut pareto_front_builder = ParetoFrontBuilder::new();
         let progress_cutoff = self.settings.max_progress();
         let quality_cutoff = self
             .settings
@@ -189,7 +182,7 @@ impl QualityUbSolver {
             {
                 if !new_state.is_final(self.durability_cost) {
                     if let Some(pareto_front) = self.solved_states.get(&new_state) {
-                        pareto_front_builder.push_slice(pareto_front);
+                        pareto_front_builder.push_slice(pareto_front, progress, quality)?;
                     } else {
                         return Err(internal_error!(
                             "Required precompute state does not exist.",
@@ -199,22 +192,12 @@ impl QualityUbSolver {
                             new_state
                         ));
                     }
-                    pareto_front_builder
-                        .peek_mut()
-                        .unwrap()
-                        .iter_mut()
-                        .for_each(|value| {
-                            value.first += progress;
-                            value.second += quality;
-                        });
-                    pareto_front_builder.merge(progress_cutoff, quality_cutoff);
                 } else if progress != 0 {
-                    pareto_front_builder.push_slice(&[ParetoValue::new(progress, quality)]);
-                    pareto_front_builder.merge(progress_cutoff, quality_cutoff);
+                    pareto_front_builder.push(progress, quality);
                 }
             }
         }
-        Ok(Box::from(pareto_front_builder.peek().unwrap()))
+        Ok(pareto_front_builder.build(progress_cutoff, quality_cutoff))
     }
 
     /// Returns an upper-bound on the maximum Quality achievable from this state while also maxing out Progress.
@@ -253,8 +236,8 @@ impl QualityUbSolver {
             };
             if let Some(pareto_front) = self.solved_states.get(&reduced_state)
                 && let Some(value) = pareto_front.last()
-                && value.first >= required_progress
-                && value.second + state.quality >= self.settings.max_quality()
+                && value.progress >= required_progress
+                && value.quality + state.quality >= self.settings.max_quality()
             {
                 return Ok(self.settings.max_quality());
             } else {
@@ -267,21 +250,20 @@ impl QualityUbSolver {
         }
 
         if let Some(pareto_front) = self.solved_states.get(&reduced_state) {
-            let index = pareto_front.partition_point(|value| value.first < required_progress);
+            let index = pareto_front.partition_point(|value| value.progress < required_progress);
             let quality = pareto_front
                 .get(index)
-                .map_or(0, |value| state.quality + value.second);
+                .map_or(0, |value| state.quality + value.quality);
             return Ok(std::cmp::min(self.settings.max_quality(), quality));
         }
 
-        self.pareto_front_builder.clear();
         self.solve_state(reduced_state)?;
 
         if let Some(pareto_front) = self.solved_states.get(&reduced_state) {
-            let index = pareto_front.partition_point(|value| value.first < required_progress);
+            let index = pareto_front.partition_point(|value| value.progress < required_progress);
             let quality = pareto_front
                 .get(index)
-                .map_or(0, |value| state.quality + value.second);
+                .map_or(0, |value| state.quality + value.quality);
             Ok(std::cmp::min(self.settings.max_quality(), quality))
         } else {
             Err(internal_error!(
@@ -296,51 +278,57 @@ impl QualityUbSolver {
         if self.interrupt_signal.is_set() {
             return Err(SolverException::Interrupted);
         }
-        self.pareto_front_builder.push_empty();
+
         let progress_cutoff = self.settings.max_progress();
         let quality_cutoff = self
             .settings
             .max_quality()
             .saturating_sub(self.iq_quality_lut[usize::from(state.effects.inner_quiet())]);
-        for action in FULL_SEARCH_ACTIONS {
-            if let Some((new_state, progress, quality)) =
-                state.use_action(action, &self.settings, self.durability_cost)
+
+        let child_states = FULL_SEARCH_ACTIONS
+            .iter()
+            .filter_map(|&action| state.use_action(action, &self.settings, self.durability_cost))
+            .collect::<Vec<_>>();
+
+        for (child_state, action_progress, action_quality) in &child_states {
+            if !child_state.is_final(self.durability_cost)
+                && !self.solved_states.contains_key(child_state)
             {
-                if !new_state.is_final(self.durability_cost) {
-                    if let Some(pareto_front) = self.solved_states.get(&new_state) {
-                        self.pareto_front_builder.push_slice(pareto_front);
-                    } else {
-                        self.solve_state(new_state)?;
-                    }
-                    self.pareto_front_builder
-                        .peek_mut()
-                        .unwrap()
-                        .iter_mut()
-                        .for_each(|value| {
-                            value.first += progress;
-                            value.second += quality;
-                        });
-                    self.pareto_front_builder
-                        .merge(progress_cutoff, quality_cutoff);
-                } else if progress != 0 {
-                    // last action must be a progress increase
-                    self.pareto_front_builder
-                        .push_slice(&[ParetoValue::new(progress, quality)]);
-                    self.pareto_front_builder
-                        .merge(progress_cutoff, quality_cutoff);
+                self.solve_state(*child_state)?;
+                let child_pareto_front = self.solved_states.get(&child_state).ok_or(
+                    internal_error!("State not found in memoization table after solving.",),
+                )?;
+                let is_maximal = |value: &ParetoValue| {
+                    value.progress + action_progress >= progress_cutoff
+                        && value.quality + action_quality >= quality_cutoff
+                };
+                if child_pareto_front.iter().any(is_maximal) {
+                    self.solved_states.insert(
+                        state,
+                        [ParetoValue::new(progress_cutoff, quality_cutoff)].into(),
+                    );
+                    return Ok(());
                 }
             }
-            if self
-                .pareto_front_builder
-                .is_max(progress_cutoff, quality_cutoff)
-            {
-                // stop early if both Progress and Quality are maxed out
-                // this optimization would work even better with better action ordering
-                // (i.e. if better actions are visited first)
-                break;
+        }
+
+        let mut pareto_front_builder = ParetoFrontBuilder::new();
+        for (child_state, action_progress, action_quality) in child_states {
+            if !child_state.is_final(self.durability_cost) {
+                let child_pareto_front = self.solved_states.get(&child_state).ok_or(
+                    internal_error!("State not found in memoization table after solving.",),
+                )?;
+                pareto_front_builder.push_slice(
+                    child_pareto_front,
+                    action_progress,
+                    action_quality,
+                )?;
+            } else if action_progress != 0 {
+                pareto_front_builder.push(action_progress, action_quality);
             }
         }
-        let pareto_front = Box::from(self.pareto_front_builder.peek().unwrap());
+
+        let pareto_front = pareto_front_builder.build(progress_cutoff, quality_cutoff);
         self.solved_states.insert(state, pareto_front);
         Ok(())
     }

--- a/raphael-solver/src/utils/pareto_front_builder.rs
+++ b/raphael-solver/src/utils/pareto_front_builder.rs
@@ -1,373 +1,116 @@
+use std::collections::BinaryHeap;
+
+use crate::{SolverException, macros::internal_error};
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct ParetoValue<T, U> {
-    pub first: T,
-    pub second: U,
+pub struct ParetoValue {
+    pub progress: u32,
+    pub quality: u32,
 }
 
-impl<T, U> ParetoValue<T, U> {
-    pub const fn new(first: T, second: U) -> Self {
-        Self { first, second }
+impl ParetoValue {
+    pub const fn new(progress: u32, quality: u32) -> Self {
+        Self { progress, quality }
     }
 }
 
-pub struct ParetoFrontBuilder<T, U>
-where
-    T: Copy + std::cmp::Ord + std::default::Default + std::fmt::Debug,
-    U: Copy + std::cmp::Ord + std::default::Default + std::fmt::Debug,
-{
-    segments: Vec<usize>, // indices to the beginning of each segment
-    buffer: Vec<ParetoValue<T, U>>,
-    merge_buffer: [ParetoValue<T, U>; 512],
+impl std::ops::Add for ParetoValue {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(self.progress + rhs.progress, self.quality + rhs.quality)
+    }
 }
 
-impl<T, U> ParetoFrontBuilder<T, U>
-where
-    T: Copy + std::cmp::Ord + std::default::Default + std::fmt::Debug,
-    U: Copy + std::cmp::Ord + std::default::Default + std::fmt::Debug,
-{
+#[derive(PartialEq, Eq)]
+struct Segment<'a> {
+    head: ParetoValue,
+    values: &'a [ParetoValue],
+    offset: ParetoValue,
+}
+
+impl<'a> Segment<'a> {
+    fn new(values: &'a [ParetoValue], offset: ParetoValue) -> Result<Self, SolverException> {
+        match values.split_first() {
+            Some((head, values)) => Ok(Self {
+                head: *head + offset,
+                values,
+                offset,
+            }),
+            None => Err(internal_error!(
+                "Cannot create ParetoFrontBuilder segment from empty Pareto front.",
+            )),
+        }
+    }
+}
+
+impl<'a> std::cmp::PartialOrd for Segment<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.head.quality.cmp(&other.head.quality))
+    }
+}
+
+impl<'a> std::cmp::Ord for Segment<'a> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.head.quality.cmp(&other.head.quality)
+    }
+}
+
+pub struct ParetoFrontBuilder<'a> {
+    segments: Vec<Segment<'a>>,
+}
+
+impl<'a> ParetoFrontBuilder<'a> {
     pub fn new() -> Self {
         Self {
             segments: Vec::new(),
-            buffer: Vec::new(),
-            merge_buffer: [ParetoValue::default(); 512],
         }
     }
 
-    pub fn clear(&mut self) {
-        self.segments.clear();
-        self.buffer.clear();
-    }
-
-    pub fn push_empty(&mut self) {
-        self.segments.push(self.buffer.len());
-    }
-
-    pub fn push_slice(&mut self, values: &[ParetoValue<T, U>]) {
-        self.segments.push(self.buffer.len());
-        self.buffer.extend_from_slice(values);
-    }
-
-    /// Merges the last two segments into one.
-    /// Panics in case there are fewer than two segments.
-    pub fn merge(&mut self, max_first: T, max_second: U) {
-        assert!(self.segments.len() >= 2);
-        let begin_b = self.segments.pop().unwrap();
-        let begin_a = self.segments.last().copied().unwrap();
-
-        let mut begin_c = 0;
-        let mut end_c = {
-            assert!(begin_a <= begin_b && begin_b <= self.buffer.len());
-            let (buffer, slice_b) = self.buffer.split_at_mut(begin_b);
-            let (_buffer, slice_a) = buffer.split_at_mut(begin_a);
-
-            // look for the first non-dominated element in slice_b
-            // slice_a[..idx_a] + slice_b[idx_b] form the first elements in the merged segment
-            // slice_b[..idx_b] are dominated by elements in slice_a and should be discarded
-            let (idx_a, idx_b) = Self::find_first_non_dominated(slice_a, slice_b);
-
-            if idx_b >= slice_b.len() {
-                // slice_a fully dominates slice_b
-                self.buffer.truncate(begin_b);
-                return;
-            }
-
-            if idx_a >= slice_a.len() {
-                // merge result is all of slice_a and slice_b[idx_b..]
-                let cnt_a = slice_a.len();
-                self.merge_buffer[..cnt_a].copy_from_slice(slice_a);
-                let cnt_b = slice_b.len() - idx_b;
-                self.merge_buffer[cnt_a..cnt_a + cnt_b].copy_from_slice(&slice_b[idx_b..]);
-                cnt_a + cnt_b
-            } else {
-                // normal merge case
-                let (merged, slice_a) = slice_a.split_at_mut(idx_a);
-                self.merge_buffer[..idx_a].copy_from_slice(merged);
-                let (_discarded, slice_b) = slice_b.split_at_mut(idx_b);
-                let (merged, slice_b) = slice_b.split_first_mut().unwrap();
-                self.merge_buffer[idx_a] = *merged;
-                Self::merge_mixed(
-                    slice_a,
-                    slice_b,
-                    &mut self.merge_buffer,
-                    idx_a + 1,
-                    merged.first,
-                )
-            }
+    pub fn push(&mut self, progress: u32, quality: u32) {
+        let segment = Segment {
+            head: ParetoValue::new(progress, quality),
+            values: &[],
+            offset: ParetoValue::new(0, 0),
         };
-
-        assert!(end_c <= self.merge_buffer.len());
-        while begin_c + 1 < end_c && self.merge_buffer[begin_c + 1].second >= max_second {
-            begin_c += 1;
-        }
-        while begin_c + 1 < end_c && self.merge_buffer[end_c - 2].first >= max_first {
-            end_c -= 1;
-        }
-
-        let length_c = end_c - begin_c;
-        self.buffer.truncate(begin_a + length_c);
-        self.buffer[begin_a..].copy_from_slice(&self.merge_buffer[begin_c..end_c]);
+        self.segments.push(segment);
     }
 
-    /// Find the first element of slice_b that is not dominated by slice_a
-    #[inline(always)]
-    fn find_first_non_dominated(
-        // slice_a and slice_b are marked &mut to tell the compiler that they are disjoint
-        slice_a: &mut [ParetoValue<T, U>],
-        slice_b: &mut [ParetoValue<T, U>],
-    ) -> (usize, usize) {
-        if slice_b.is_empty() {
-            return (slice_a.len(), slice_b.len());
-        }
-        let mut idx_a = 0;
-        let mut idx_b = 0;
-        while idx_a < slice_a.len() {
-            let a = slice_a[idx_a];
-            loop {
-                let b = slice_b[idx_b];
-                if a.first >= b.first && a.second >= b.second {
-                    idx_b += 1;
-                    if idx_b >= slice_b.len() {
-                        return (slice_a.len(), slice_b.len());
-                    }
-                } else if b.second >= a.second {
-                    return (idx_a, idx_b);
-                } else {
-                    break;
-                }
-            }
-            idx_a += 1;
-        }
-        (slice_a.len(), idx_b)
+    pub fn push_slice(
+        &mut self,
+        values: &'a [ParetoValue],
+        progress_offset: u32,
+        quality_offset: u32,
+    ) -> Result<(), SolverException> {
+        let segment = Segment::new(values, ParetoValue::new(progress_offset, quality_offset))?;
+        self.segments.push(segment);
+        Ok(())
     }
 
-    #[inline(always)]
-    fn merge_mixed(
-        // slices are marked &mut to tell the compiler that they are disjoint
-        slice_a: &mut [ParetoValue<T, U>],
-        slice_b: &mut [ParetoValue<T, U>],
-        slice_c: &mut [ParetoValue<T, U>],
-        mut idx_c: usize,
-        mut rolling_max: T,
-    ) -> usize {
-        assert!(slice_a.len() + slice_b.len() <= slice_c.len());
-
-        let mut idx_a = 0;
-        let mut idx_b = 0;
-
-        let mut try_insert = |x: ParetoValue<T, U>| {
-            if rolling_max < x.first {
-                rolling_max = x.first;
-                unsafe {
-                    #[cfg(test)]
-                    assert!(idx_c < slice_c.len());
-                    // SAFETY: the number of elements added to slice_c is not greater than the total number of elements in slice_a and slice_b
-                    *slice_c.get_unchecked_mut(idx_c) = x;
-                }
-                idx_c += 1;
+    pub fn build(self, max_progress: u32, max_quality: u32) -> Box<[ParetoValue]> {
+        let mut result = Vec::<ParetoValue>::new();
+        let mut segments = BinaryHeap::from(self.segments);
+        while let Some(mut segment) = segments.pop() {
+            let value = ParetoValue::new(
+                std::cmp::min(max_progress, segment.head.progress),
+                std::cmp::min(max_quality, segment.head.quality),
+            );
+            while result.last().is_some_and(|last_value| {
+                last_value.progress <= value.progress && last_value.quality <= value.quality
+            }) {
+                result.pop();
             }
-        };
-
-        while idx_a < slice_a.len() && idx_b < slice_b.len() {
-            let a = slice_a[idx_a];
-            let b = slice_b[idx_b];
-            match (a.first.cmp(&b.first), a.second.cmp(&b.second)) {
-                (_, std::cmp::Ordering::Greater) => {
-                    try_insert(a);
-                    idx_a += 1;
-                }
-                (std::cmp::Ordering::Greater, std::cmp::Ordering::Equal) => {
-                    try_insert(a);
-                    idx_a += 1;
-                    idx_b += 1;
-                }
-                (_, std::cmp::Ordering::Equal) => {
-                    try_insert(b);
-                    idx_a += 1;
-                    idx_b += 1;
-                }
-                _ => {
-                    try_insert(b);
-                    idx_b += 1;
-                }
+            if result
+                .last()
+                .is_none_or(|last_value| last_value.progress < value.progress)
+            {
+                result.push(value);
+            }
+            if let Some(new_head) = segment.values.split_off_first() {
+                segment.head = *new_head + segment.offset;
+                segments.push(segment);
             }
         }
-
-        while idx_a < slice_a.len() {
-            try_insert(slice_a[idx_a]);
-            idx_a += 1;
-        }
-
-        while idx_b < slice_b.len() {
-            try_insert(slice_b[idx_b]);
-            idx_b += 1;
-        }
-
-        idx_c
-    }
-
-    pub fn peek(&self) -> Option<&[ParetoValue<T, U>]> {
-        self.segments
-            .last()
-            .map(|&segment_begin| &self.buffer[segment_begin..])
-    }
-
-    pub fn peek_mut(&mut self) -> Option<&mut [ParetoValue<T, U>]> {
-        self.segments
-            .last()
-            .map(|&segment_begin| &mut self.buffer[segment_begin..])
-    }
-
-    pub fn is_max(&self, max_first: T, max_second: U) -> bool {
-        match self.segments.last().copied() {
-            Some(segment_begin) if segment_begin + 1 == self.buffer.len() => {
-                let element = self.buffer.last().unwrap();
-                element.first >= max_first && element.second >= max_second
-            }
-            _ => false,
-        }
-    }
-
-    #[cfg(test)]
-    fn check_invariants(&self) {
-        for window in self.segments.windows(2) {
-            // segments must have left-to-right ordering
-            assert!(window[0] <= window[1]);
-        }
-        let mut segment_end = self.buffer.len();
-        for segment_begin in self.segments.iter().rev().copied() {
-            assert!(segment_begin <= segment_end);
-            // each segment must form a valid pareto front:
-            // - first value strictly increasing
-            // - second value strictly decreasing
-            let slice = &self.buffer[segment_begin..segment_end];
-            for window in slice.windows(2) {
-                assert!(window[0].first < window[1].first);
-                assert!(window[0].second > window[1].second);
-            }
-            segment_end = segment_begin;
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rand::seq::SliceRandom;
-
-    const SAMPLE_FRONT_1: &[ParetoValue<u16, u16>] = &[
-        ParetoValue::new(100, 300),
-        ParetoValue::new(200, 200),
-        ParetoValue::new(300, 100),
-    ];
-
-    const SAMPLE_FRONT_2: &[ParetoValue<u16, u16>] = &[
-        ParetoValue::new(50, 270),
-        ParetoValue::new(150, 250),
-        ParetoValue::new(250, 150),
-        ParetoValue::new(300, 50),
-    ];
-
-    #[test]
-    fn test_merge_empty() {
-        let mut builder: ParetoFrontBuilder<u16, u16> = ParetoFrontBuilder::new();
-        builder.push_empty();
-        builder.push_empty();
-        builder.merge(1000, 2000);
-        let front = builder.peek().unwrap();
-        assert!(front.as_ref().is_empty());
-        builder.check_invariants();
-    }
-
-    #[test]
-    fn test_merge() {
-        let mut builder: ParetoFrontBuilder<u16, u16> = ParetoFrontBuilder::new();
-        builder.push_slice(SAMPLE_FRONT_1);
-        builder.push_slice(SAMPLE_FRONT_2);
-        builder.merge(1000, 2000);
-        let front = builder.peek().unwrap();
-        assert_eq!(
-            *front,
-            [
-                ParetoValue::new(100, 300),
-                ParetoValue::new(150, 250),
-                ParetoValue::new(200, 200),
-                ParetoValue::new(250, 150),
-                ParetoValue::new(300, 100),
-            ]
-        );
-        builder.check_invariants();
-    }
-
-    #[test]
-    fn test_merge_truncate() {
-        let mut builder: ParetoFrontBuilder<u16, u16> = ParetoFrontBuilder::new();
-        builder.push_slice(&[
-            ParetoValue::new(1100, 2300),
-            ParetoValue::new(1200, 2200),
-            ParetoValue::new(1300, 2100),
-        ]);
-        builder.push_slice(&[
-            ParetoValue::new(1050, 2270),
-            ParetoValue::new(1150, 2250),
-            ParetoValue::new(1250, 2150),
-            ParetoValue::new(1300, 2050),
-        ]);
-        builder.merge(1000, 2000);
-        let front = builder.peek().unwrap();
-        assert_eq!(*front, [ParetoValue::new(1300, 2100)]);
-        builder.check_invariants();
-    }
-
-    #[test]
-    fn test_merge_fuzz() {
-        let mut rng = rand::rng();
-        let mut values_first: Vec<usize> = (1..100).collect();
-        let mut values_second: Vec<usize> = (1..100).collect();
-        let mut random_values = |n: usize| -> Vec<ParetoValue<_, _>> {
-            values_first.shuffle(&mut rng);
-            values_second.shuffle(&mut rng);
-            let mut values_first: Vec<_> = values_first.iter().copied().take(n).collect();
-            let mut values_second: Vec<_> = values_second.iter().copied().take(n).collect();
-            values_first.sort();
-            values_second.sort_by_key(|x| std::cmp::Reverse(*x));
-            values_first
-                .iter()
-                .zip(values_second.iter())
-                .map(|(x, y)| ParetoValue::new(*x, *y))
-                .collect()
-        };
-
-        for _ in 0..1000 {
-            let values_a = random_values(10);
-            let values_b = random_values(10);
-
-            let mut lut = [0; 101];
-            let mut expected_result = Vec::new();
-            for a in values_a.iter().copied() {
-                lut[a.first] = std::cmp::max(lut[a.first], a.second);
-            }
-            for b in values_b.iter().copied() {
-                lut[b.first] = std::cmp::max(lut[b.first], b.second);
-            }
-            for i in (0..100).rev() {
-                lut[i] = std::cmp::max(lut[i], lut[i + 1]);
-            }
-            for i in 0..100 {
-                if lut[i] != lut[i + 1] {
-                    expected_result.push(ParetoValue::new(i, lut[i]));
-                }
-            }
-
-            let mut builder = ParetoFrontBuilder::new();
-            builder.push_slice(&values_a);
-            builder.check_invariants();
-            builder.push_slice(&values_b);
-            builder.check_invariants();
-            builder.merge(usize::MAX, usize::MAX);
-            builder.check_invariants();
-
-            let result = builder.peek().unwrap();
-            assert_eq!(result, &expected_result);
-        }
+        result.into_boxed_slice()
     }
 }

--- a/raphael-solver/src/utils/pareto_front_builder.rs
+++ b/raphael-solver/src/utils/pareto_front_builder.rs
@@ -31,30 +31,38 @@ struct Segment<'a> {
 
 impl<'a> std::cmp::PartialOrd for Segment<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.head.quality.cmp(&other.head.quality))
+        Some(self.cmp(other))
     }
 }
 
 impl<'a> std::cmp::Ord for Segment<'a> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.head.quality.cmp(&other.head.quality)
+        self.head
+            .quality
+            .cmp(&other.head.quality)
+            .then(self.head.progress.cmp(&other.head.progress))
     }
 }
 
 pub struct ParetoFrontBuilder<'a> {
     segments: Vec<Segment<'a>>,
+    cutoff: ParetoValue,
 }
 
 impl<'a> ParetoFrontBuilder<'a> {
-    pub fn new() -> Self {
+    pub fn new(progress_cutoff: u32, quality_cutoff: u32) -> Self {
         Self {
             segments: Vec::new(),
+            cutoff: ParetoValue::new(progress_cutoff, quality_cutoff),
         }
     }
 
     pub fn push(&mut self, progress: u32, quality: u32) {
         let segment = Segment {
-            head: ParetoValue::new(progress, quality),
+            head: ParetoValue::new(
+                std::cmp::min(self.cutoff.progress, progress),
+                std::cmp::min(self.cutoff.quality, quality),
+            ),
             values: &[],
             offset: ParetoValue::new(0, 0),
         };
@@ -67,36 +75,47 @@ impl<'a> ParetoFrontBuilder<'a> {
         progress_offset: u32,
         quality_offset: u32,
     ) {
-        let (&head, values) = values.split_first();
-        let offset = ParetoValue::new(progress_offset, quality_offset);
+        let (mut head, mut values) = values.split_first();
+        while let Some((next_head, next_values)) = values.split_first()
+            && next_head.quality + quality_offset >= self.cutoff.quality
+        {
+            head = next_head;
+            values = next_values;
+        }
+        let head = ParetoValue::new(
+            std::cmp::min(self.cutoff.progress, head.progress + progress_offset),
+            std::cmp::min(self.cutoff.quality, head.quality + quality_offset),
+        );
         self.segments.push(Segment {
-            head: head + offset,
+            head,
             values,
-            offset,
+            offset: ParetoValue::new(progress_offset, quality_offset),
         });
     }
 
-    pub fn build(self, max_progress: u32, max_quality: u32) -> Box<[ParetoValue]> {
+    pub fn build(self) -> Box<[ParetoValue]> {
         let mut result = Vec::<ParetoValue>::new();
         let mut segments = BinaryHeap::from(self.segments);
         while let Some(mut segment) = segments.pop() {
-            let value = ParetoValue::new(
-                std::cmp::min(max_progress, segment.head.progress),
-                std::cmp::min(max_quality, segment.head.quality),
-            );
-            while result.last().is_some_and(|last_value| {
-                last_value.progress <= value.progress && last_value.quality <= value.quality
-            }) {
-                result.pop();
-            }
             if result
                 .last()
-                .is_none_or(|last_value| last_value.progress < value.progress)
+                .is_none_or(|last_value| last_value.progress < segment.head.progress)
             {
-                result.push(value);
+                result.push(segment.head);
             }
-            if let Some(new_head) = segment.values.split_off_first() {
-                segment.head = *new_head + segment.offset;
+            if segment.head.progress < self.cutoff.progress
+                && let Some(new_head) = segment.values.split_off_first()
+            {
+                segment.head = ParetoValue::new(
+                    std::cmp::min(
+                        self.cutoff.progress,
+                        new_head.progress + segment.offset.progress,
+                    ),
+                    std::cmp::min(
+                        self.cutoff.quality,
+                        new_head.quality + segment.offset.quality,
+                    ),
+                );
                 segments.push(segment);
             }
         }

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -176,8 +176,8 @@ fn max_quality() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 389796,
-                sequential_states: 514,
-                pareto_values: 2236380,
+                sequential_states: 544,
+                pareto_values: 2236421,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 95563,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -321,8 +321,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,
-                sequential_states: 12499,
-                pareto_values: 16494243,
+                sequential_states: 13660,
+                pareto_values: 16498675,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1753944,
@@ -791,8 +791,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 994029,
-                sequential_states: 9767,
-                pareto_values: 11580525,
+                sequential_states: 10870,
+                pareto_values: 11583512,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 319667,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -321,8 +321,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
-                sequential_states: 6186,
-                pareto_values: 22061401,
+                sequential_states: 7650,
+                pareto_values: 22067764,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1750689,
@@ -791,8 +791,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,
-                sequential_states: 4016,
-                pareto_values: 16038900,
+                sequential_states: 4553,
+                pareto_values: 16040926,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 341313,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -104,8 +104,8 @@ fn stuffed_peppers() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2271577,
-                sequential_states: 16,
-                pareto_values: 39200086,
+                sequential_states: 26,
+                pareto_values: 39200096,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 921340,
@@ -152,8 +152,8 @@ fn test_rare_tacos_2() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490500,
-                sequential_states: 77965,
-                pareto_values: 70123242,
+                sequential_states: 78098,
+                pareto_values: 70126284,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1634999,
@@ -204,8 +204,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1800421,
-                sequential_states: 39248,
-                pareto_values: 16731251,
+                sequential_states: 41879,
+                pareto_values: 16751061,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 47456,
@@ -396,8 +396,8 @@ fn issue_118() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1930860,
-                sequential_states: 61612,
-                pareto_values: 25588015,
+                sequential_states: 71100,
+                pareto_values: 25740940,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 208451,


### PR DESCRIPTION
Fixes #230

Re-implemented the `ParetoFrontBuilder` from scratch.

The old implementation was optimized for single-threaded DFS-style exploration of the game tree and had a merge buffer with a hard-coded size to avoid allocations and unnecessary copying of data. Hard-coding the buffer size to `512` proved to be a mistake as it isn't big enough for all cases.

The decision to fully replace the old implementation came from the fact that most of the work involving the `ParetoFrontBuilder` happens in parallel and in a BFS-style instead of a DFS-style, making the merge buffer unnecessary. The new implementation is much simpler and has roughly the same performance as the old implementation.