### PR TITLE
Restore early stop behavior

### DIFF
--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -195,6 +195,9 @@ impl QualityUbSolver {
                 } else if progress != 0 {
                     pf_builder.push(action_offset);
                 }
+                if pf_builder.is_maximal(cutoff) {
+                    break;
+                }
             }
         }
         pf_builder

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -163,19 +163,23 @@ impl QualityUbSolver {
         &self,
         state: ReducedState,
     ) -> Result<Box<nunny::Slice<ParetoValue>>, SolverException> {
-        let progress_cutoff = self.settings.max_progress();
-        let quality_cutoff = self
-            .settings
-            .max_quality()
-            .saturating_sub(self.iq_quality_lut[usize::from(state.effects.inner_quiet())]);
-        let mut pareto_front_builder = ParetoFrontBuilder::new(progress_cutoff, quality_cutoff);
+        let cutoff = ParetoValue::new(
+            self.settings.max_progress(),
+            self.settings
+                .max_quality()
+                .saturating_sub(self.iq_quality_lut[usize::from(state.effects.inner_quiet())]),
+        );
+        let mut pareto_front_builder = ParetoFrontBuilder::new();
+        pareto_front_builder.initialize_with_cutoff(cutoff);
         for action in FULL_SEARCH_ACTIONS {
             if let Some((new_state, progress, quality)) =
                 state.use_action(action, &self.settings, self.durability_cost)
             {
+                let action_offset = ParetoValue::new(progress, quality);
                 if !new_state.is_final(self.durability_cost) {
                     if let Some(pareto_front) = self.solved_states.get(&new_state) {
-                        pareto_front_builder.push_slice(pareto_front, progress, quality);
+                        pareto_front_builder
+                            .push_slice(pareto_front.iter().map(|value| *value + action_offset));
                     } else {
                         return Err(internal_error!(
                             "Required precompute state does not exist.",
@@ -186,12 +190,12 @@ impl QualityUbSolver {
                         ));
                     }
                 } else if progress != 0 {
-                    pareto_front_builder.push(progress, quality);
+                    pareto_front_builder.push(action_offset);
                 }
             }
         }
         pareto_front_builder
-            .build()
+            .result()
             .try_into()
             .map_err(|_| internal_error!("Empty precompute Pareto front.", self.settings, state))
     }
@@ -274,56 +278,45 @@ impl QualityUbSolver {
             return Err(SolverException::Interrupted);
         }
 
-        let progress_cutoff = self.settings.max_progress();
-        let quality_cutoff = self
-            .settings
-            .max_quality()
-            .saturating_sub(self.iq_quality_lut[usize::from(state.effects.inner_quiet())]);
+        let cutoff = ParetoValue::new(
+            self.settings.max_progress(),
+            self.settings
+                .max_quality()
+                .saturating_sub(self.iq_quality_lut[usize::from(state.effects.inner_quiet())]),
+        );
+        let mut pareto_front_builder = ParetoFrontBuilder::new();
+        pareto_front_builder.initialize_with_cutoff(cutoff);
 
-        let child_states = FULL_SEARCH_ACTIONS
-            .iter()
-            .filter_map(|&action| state.use_action(action, &self.settings, self.durability_cost))
-            .collect::<Vec<_>>();
-
-        for (child_state, action_progress, action_quality) in &child_states {
-            if !child_state.is_final(self.durability_cost)
-                && !self.solved_states.contains_key(child_state)
+        for action in FULL_SEARCH_ACTIONS {
+            if let Some((child_state, progress, quality)) =
+                state.use_action(action, &self.settings, self.durability_cost)
             {
-                self.solve_state(*child_state)?;
-                let child_pareto_front = self.solved_states.get(child_state).ok_or(
-                    internal_error!("State not found in memoization table after solving.",),
-                )?;
-                let is_maximal = |value: &ParetoValue| {
-                    value.progress + action_progress >= progress_cutoff
-                        && value.quality + action_quality >= quality_cutoff
-                };
-                if child_pareto_front.iter().any(is_maximal) {
-                    self.solved_states.insert(
-                        state,
-                        nunny::slice![ParetoValue::new(progress_cutoff, quality_cutoff)].into(),
+                let action_offset = ParetoValue::new(progress, quality);
+                if !child_state.is_final(self.durability_cost) {
+                    let child_pareto_front =
+                        if let Some(child_pareto_front) = self.solved_states.get(&child_state) {
+                            child_pareto_front
+                        } else {
+                            self.solve_state(child_state)?;
+                            self.solved_states.get(&child_state).ok_or(internal_error!(
+                                "State not found in memoization table after solving.",
+                            ))?
+                        };
+                    pareto_front_builder.push_slice(
+                        child_pareto_front
+                            .iter()
+                            .map(|value| *value + action_offset),
                     );
-                    return Ok(());
+                    if pareto_front_builder.is_maximal(cutoff) {
+                        break;
+                    }
+                } else if action_offset.progress != 0 {
+                    pareto_front_builder.push(action_offset);
                 }
             }
         }
 
-        let mut pareto_front_builder = ParetoFrontBuilder::new(progress_cutoff, quality_cutoff);
-        for (child_state, action_progress, action_quality) in child_states {
-            if !child_state.is_final(self.durability_cost) {
-                let child_pareto_front = self.solved_states.get(&child_state).ok_or(
-                    internal_error!("State not found in memoization table after solving.",),
-                )?;
-                pareto_front_builder.push_slice(
-                    child_pareto_front,
-                    action_progress,
-                    action_quality,
-                );
-            } else if action_progress != 0 {
-                pareto_front_builder.push(action_progress, action_quality);
-            }
-        }
-
-        let pareto_front = pareto_front_builder.build().try_into().map_err(|_| {
+        let pareto_front = pareto_front_builder.result().try_into().map_err(|_| {
             internal_error!("Solver produced empty Pareto front.", self.settings, state)
         });
         self.solved_states.insert(state, pareto_front?);

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -147,10 +147,13 @@ impl StepLbSolver {
         for unsolved_states in unsolved_state_by_steps.into_iter().rev() {
             let solved_states = unsolved_states
                 .into_par_iter()
-                .map(|reduced_state| -> Result<_, SolverException> {
-                    let pareto_front = self.do_solve_state(reduced_state)?;
-                    Ok((reduced_state, pareto_front))
-                })
+                .map_init(
+                    ParetoFrontBuilder::new,
+                    |pf_builder, reduced_state| -> Result<_, SolverException> {
+                        let pareto_front = self.do_solve_state(pf_builder, reduced_state)?;
+                        Ok((reduced_state, pareto_front))
+                    },
+                )
                 .collect::<Result<Vec<_>, SolverException>>()?;
             self.solved_states.extend(solved_states);
         }
@@ -167,6 +170,7 @@ impl StepLbSolver {
 
     fn do_solve_state(
         &self,
+        pf_builder: &mut ParetoFrontBuilder,
         state: ReducedState,
     ) -> Result<Box<nunny::Slice<ParetoValue>>, SolverException> {
         let cutoff = ParetoValue::new(
@@ -175,8 +179,7 @@ impl StepLbSolver {
                 .max_quality()
                 .saturating_sub(self.iq_quality_lut[usize::from(state.effects.inner_quiet())]),
         );
-        let mut pareto_front_builder = ParetoFrontBuilder::new();
-        pareto_front_builder.initialize_with_cutoff(cutoff);
+        pf_builder.initialize_with_cutoff(cutoff);
         for action in FULL_SEARCH_ACTIONS {
             if state.steps_budget.get() < action.steps() {
                 continue;
@@ -190,7 +193,7 @@ impl StepLbSolver {
                 {
                     let new_state = ReducedState::from_state(new_state, new_step_budget);
                     if let Some(pareto_front) = self.solved_states.get(&new_state) {
-                        pareto_front_builder.push_slice(pareto_front.iter().map(|value| {
+                        pf_builder.push_slice(pareto_front.iter().map(|value| {
                             ParetoValue::new(value.progress + progress, value.quality + quality)
                         }));
                     } else {
@@ -203,11 +206,11 @@ impl StepLbSolver {
                         ));
                     }
                 } else if progress != 0 {
-                    pareto_front_builder.push(ParetoValue::new(progress, quality));
+                    pf_builder.push(ParetoValue::new(progress, quality));
                 }
             }
         }
-        pareto_front_builder.result().try_into().map_err(|_| {
+        pf_builder.result().try_into().map_err(|_| {
             internal_error!("Solver produced empty Pareto front.", self.settings, state)
         })
     }

--- a/raphael-solver/src/utils/pareto_front_builder.rs
+++ b/raphael-solver/src/utils/pareto_front_builder.rs
@@ -43,57 +43,12 @@ impl ParetoFrontBuilder {
     }
 
     pub fn push_slice(&mut self, values: impl Iterator<Item = ParetoValue>) {
-        let (mut slice_a, mut slice_b) = {
-            let slice_a_len = self.result.len();
-            self.result.extend(values);
-            self.result.split_at_mut(slice_a_len)
-        };
-
-        slice_b = trim_slice(slice_b, self.cutoff);
-
-        loop {
-            match (slice_a.first(), slice_b.first()) {
-                (None, None) => break,
-                (None, Some(_)) => {
-                    let idx = self.merge_buffer.last().map_or(0, |merge_tail| {
-                        slice_b.partition_point(|v| v.progress <= merge_tail.progress)
-                    });
-                    self.merge_buffer.extend_from_slice(&slice_b[idx..]);
-                    break;
-                }
-                (Some(_), None) => {
-                    let idx = self.merge_buffer.last().map_or(0, |merge_tail| {
-                        slice_a.partition_point(|v| v.progress <= merge_tail.progress)
-                    });
-                    self.merge_buffer.extend_from_slice(&slice_a[idx..]);
-                    break;
-                }
-                (Some(a), Some(b)) => {
-                    if a.quality > b.quality || (a.quality == b.quality && a.progress >= b.progress)
-                    {
-                        if self
-                            .merge_buffer
-                            .last()
-                            .is_none_or(|merge_tail| a.progress > merge_tail.progress)
-                        {
-                            self.merge_buffer.push(*a);
-                        }
-                        slice_a.split_off_first_mut();
-                    } else {
-                        if self
-                            .merge_buffer
-                            .last()
-                            .is_none_or(|merge_tail| b.progress > merge_tail.progress)
-                        {
-                            self.merge_buffer.push(*b);
-                        }
-                        slice_b.split_off_first_mut();
-                    }
-                }
-            }
-        }
-
         std::mem::swap(&mut self.result, &mut self.merge_buffer);
+        let slice_b_begin = self.merge_buffer.len();
+        self.merge_buffer.extend(values);
+        let (slice_a, mut slice_b) = self.merge_buffer.split_at_mut(slice_b_begin);
+        slice_b = trim(slice_b, self.cutoff);
+        merge(slice_a, slice_b, &mut self.result);
         self.merge_buffer.clear();
     }
 
@@ -108,7 +63,7 @@ impl ParetoFrontBuilder {
     }
 }
 
-fn trim_slice(mut slice: &mut [ParetoValue], cutoff: ParetoValue) -> &mut [ParetoValue] {
+fn trim(mut slice: &mut [ParetoValue], cutoff: ParetoValue) -> &mut [ParetoValue] {
     if slice.len() >= 1 {
         if slice[0].quality > cutoff.quality {
             while slice.len() >= 2 && slice[1].quality >= cutoff.quality {
@@ -124,4 +79,49 @@ fn trim_slice(mut slice: &mut [ParetoValue], cutoff: ParetoValue) -> &mut [Paret
         }
     }
     slice
+}
+
+fn merge(
+    mut slice_a: &mut [ParetoValue],
+    mut slice_b: &mut [ParetoValue],
+    result: &mut Vec<ParetoValue>,
+) {
+    loop {
+        match (slice_a.first(), slice_b.first()) {
+            (None, None) => break,
+            (None, Some(_)) => {
+                let idx = result.last().map_or(0, |merge_tail| {
+                    slice_b.partition_point(|v| v.progress <= merge_tail.progress)
+                });
+                result.extend_from_slice(&slice_b[idx..]);
+                break;
+            }
+            (Some(_), None) => {
+                let idx = result.last().map_or(0, |merge_tail| {
+                    slice_a.partition_point(|v| v.progress <= merge_tail.progress)
+                });
+                result.extend_from_slice(&slice_a[idx..]);
+                break;
+            }
+            (Some(a), Some(b)) => {
+                if a.quality > b.quality || (a.quality == b.quality && a.progress >= b.progress) {
+                    if result
+                        .last()
+                        .is_none_or(|merge_tail| a.progress > merge_tail.progress)
+                    {
+                        result.push(*a);
+                    }
+                    slice_a.split_off_first_mut();
+                } else {
+                    if result
+                        .last()
+                        .is_none_or(|merge_tail| b.progress > merge_tail.progress)
+                    {
+                        result.push(*b);
+                    }
+                    slice_b.split_off_first_mut();
+                }
+            }
+        }
+    }
 }

--- a/raphael-solver/src/utils/pareto_front_builder.rs
+++ b/raphael-solver/src/utils/pareto_front_builder.rs
@@ -64,7 +64,7 @@ impl ParetoFrontBuilder {
 }
 
 fn trim(mut slice: &mut [ParetoValue], cutoff: ParetoValue) -> &mut [ParetoValue] {
-    if slice.len() >= 1 {
+    if !slice.is_empty() {
         if slice[0].quality > cutoff.quality {
             while slice.len() >= 2 && slice[1].quality >= cutoff.quality {
                 slice.split_off_first_mut();

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -176,8 +176,8 @@ fn max_quality() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 389796,
-                sequential_states: 544,
-                pareto_values: 2236421,
+                sequential_states: 514,
+                pareto_values: 2236380,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 95563,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -321,8 +321,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,
-                sequential_states: 13660,
-                pareto_values: 16498675,
+                sequential_states: 12499,
+                pareto_values: 16494243,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1753944,
@@ -791,8 +791,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 994029,
-                sequential_states: 10870,
-                pareto_values: 11583512,
+                sequential_states: 9767,
+                pareto_values: 11580525,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 319667,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -321,8 +321,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
-                sequential_states: 7650,
-                pareto_values: 22067764,
+                sequential_states: 6186,
+                pareto_values: 22061401,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1750689,
@@ -791,8 +791,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,
-                sequential_states: 4553,
-                pareto_values: 16040926,
+                sequential_states: 4016,
+                pareto_values: 16038900,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 341313,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -104,8 +104,8 @@ fn stuffed_peppers() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2271577,
-                sequential_states: 26,
-                pareto_values: 39200096,
+                sequential_states: 16,
+                pareto_values: 39200086,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 921340,
@@ -152,8 +152,8 @@ fn test_rare_tacos_2() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490500,
-                sequential_states: 78098,
-                pareto_values: 70126284,
+                sequential_states: 77965,
+                pareto_values: 70123242,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 1634999,
@@ -204,8 +204,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1800421,
-                sequential_states: 41879,
-                pareto_values: 16751061,
+                sequential_states: 39248,
+                pareto_values: 16731251,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 47456,
@@ -396,8 +396,8 @@ fn issue_118() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1930860,
-                sequential_states: 71100,
-                pareto_values: 25740940,
+                sequential_states: 61612,
+                pareto_values: 25588015,
             },
             step_lb_stats: StepLbSolverStats {
                 states: 208451,


### PR DESCRIPTION
Restores the early stop behavior of the inner solvers before `ParetoFrontBuilder` was changed in #231.