### PR TITLE
New solver option: `allow_non_max_quality_solutions`

### DIFF
--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -338,6 +338,7 @@ pub fn execute(args: &SolveArgs) {
 
     let solver_settings = SolverSettings {
         simulator_settings: settings,
+        allow_non_max_quality_solutions: true,
     };
 
     let mut solver = MacroSolver::new(

--- a/raphael-solver/examples/macro_solver_example.rs
+++ b/raphael-solver/examples/macro_solver_example.rs
@@ -20,7 +20,10 @@ fn main() {
         backload_progress: false,
     };
 
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: false,
+    };
 
     let mut solver = MacroSolver::new(
         solver_settings,

--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -62,6 +62,7 @@ mod macros {
 #[derive(Clone, Copy, Debug)]
 pub struct SolverSettings {
     pub simulator_settings: raphael_sim::Settings,
+    pub allow_non_max_quality_solutions: bool,
 }
 
 impl SolverSettings {

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -132,6 +132,12 @@ impl<'a> MacroSolver<'a> {
                             )
                         };
 
+                        if !self.settings.allow_non_max_quality_solutions
+                            && quality_upper_bound < self.settings.max_quality()
+                        {
+                            continue;
+                        }
+
                         let step_lb_hint = score
                             .steps_lower_bound
                             .saturating_sub(score.current_steps + action.steps());

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -11,7 +11,10 @@ use super::QualityUbSolver;
 fn solve(simulator_settings: Settings, actions: &[Action]) -> u32 {
     let mut state = SimulationState::from_macro(&simulator_settings, actions).unwrap();
     state.effects.set_combo(Combo::None);
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let mut solver = QualityUbSolver::new(solver_settings, Default::default());
     solver.quality_upper_bound(state).unwrap()
 }
@@ -81,6 +84,9 @@ fn consistency(max_durability: u16, allowed_actions: ActionMask) {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     check_consistency(solver_settings);
 }

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -56,6 +56,9 @@ fn consistency(max_durability: u16, allowed_actions: ActionMask) {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     check_consistency(solver_settings);
 }

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -69,7 +69,10 @@ fn unsolvable() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Err(
             NoSolution,
@@ -110,7 +113,10 @@ fn zero_quality() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -156,7 +162,10 @@ fn max_quality() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -202,7 +211,10 @@ fn large_progress_quality_increase() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -248,7 +260,10 @@ fn backload_progress_single_delicate_synthesis() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -295,7 +310,10 @@ fn issue_216_steplbsolver_crash() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -69,7 +69,10 @@ fn rinascita_3700_3280() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -115,7 +118,10 @@ fn pactmaker_3240_3130() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -163,7 +169,10 @@ fn pactmaker_3240_3130_heart_and_soul() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -209,7 +218,10 @@ fn diadochos_4021_3660() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -255,7 +267,10 @@ fn indagator_3858_4057() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -301,7 +316,10 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -349,7 +367,10 @@ fn stuffed_peppers_2() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -399,7 +420,10 @@ fn stuffed_peppers_2_heart_and_soul() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -449,7 +473,10 @@ fn stuffed_peppers_2_quick_innovation() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -495,7 +522,10 @@ fn rakaznar_lapidary_hammer_4462_4391() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -541,7 +571,10 @@ fn black_star_4048_3997() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -587,7 +620,10 @@ fn claro_walnut_lumber_4900_4800() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -633,7 +669,10 @@ fn rakaznar_lapidary_hammer_4900_4800() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -679,7 +718,10 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -725,7 +767,10 @@ fn archeo_kingdom_broadsword_4966_4914() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -771,7 +816,10 @@ fn hardened_survey_plank_5558_5216() {
         adversarial: false,
         backload_progress: true,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -318,7 +318,7 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     };
     let solver_settings = SolverSettings {
         simulator_settings,
-        allow_non_max_quality_solutions: true,
+        allow_non_max_quality_solutions: false,
     };
     let expected_score = expect![[r#"
         Ok(
@@ -335,7 +335,7 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             finish_states: 1183317,
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 63042,
-                dropped_nodes: 262543,
+                dropped_nodes: 256167,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -69,7 +69,10 @@ fn rinascita_3700_3280() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -115,7 +118,10 @@ fn pactmaker_3240_3130() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -163,7 +169,10 @@ fn pactmaker_3240_3130_heart_and_soul() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -209,7 +218,10 @@ fn diadochos_4021_3660() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -255,7 +267,10 @@ fn indagator_3858_4057() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -301,7 +316,10 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -349,7 +367,10 @@ fn stuffed_peppers_2() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -399,7 +420,10 @@ fn stuffed_peppers_2_heart_and_soul() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -449,7 +473,10 @@ fn stuffed_peppers_2_quick_innovation() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -495,7 +522,10 @@ fn rakaznar_lapidary_hammer_4462_4391() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -541,7 +571,10 @@ fn black_star_4048_3997() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -587,7 +620,10 @@ fn claro_walnut_lumber_4900_4800() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -633,7 +669,10 @@ fn rakaznar_lapidary_hammer_4900_4800() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -679,7 +718,10 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -725,7 +767,10 @@ fn archeo_kingdom_broadsword_4966_4914() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -771,7 +816,10 @@ fn hardened_survey_plank_5558_5216() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -817,7 +865,10 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -864,7 +915,10 @@ fn ceviche_4900_4800_no_quality() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -912,7 +966,10 @@ fn ce_high_progress_zero_achieved_quality() {
         adversarial: false,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -318,7 +318,7 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     };
     let solver_settings = SolverSettings {
         simulator_settings,
-        allow_non_max_quality_solutions: true,
+        allow_non_max_quality_solutions: false,
     };
     let expected_score = expect![[r#"
         Ok(
@@ -335,7 +335,7 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             finish_states: 2387186,
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 1483443,
-                dropped_nodes: 10107736,
+                dropped_nodes: 9532747,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
@@ -818,7 +818,7 @@ fn hardened_survey_plank_5558_5216() {
     };
     let solver_settings = SolverSettings {
         simulator_settings,
-        allow_non_max_quality_solutions: true,
+        allow_non_max_quality_solutions: false,
     };
     let expected_score = expect![[r#"
         Ok(
@@ -835,7 +835,7 @@ fn hardened_survey_plank_5558_5216() {
             finish_states: 859926,
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 1820997,
-                dropped_nodes: 13336465,
+                dropped_nodes: 12419415,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -137,7 +137,7 @@ fn test_rare_tacos_2() {
     };
     let solver_settings = SolverSettings {
         simulator_settings,
-        allow_non_max_quality_solutions: true,
+        allow_non_max_quality_solutions: false,
     };
     let expected_score = expect![[r#"
         Ok(
@@ -154,7 +154,7 @@ fn test_rare_tacos_2() {
             finish_states: 1472394,
             search_queue_stats: SearchQueueStats {
                 processed_nodes: 3802112,
-                dropped_nodes: 31992658,
+                dropped_nodes: 1381,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490500,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -84,7 +84,10 @@ fn stuffed_peppers() {
         base_quality: 360,
         ..SETTINGS
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -132,7 +135,10 @@ fn test_rare_tacos_2() {
         adversarial: true,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -184,7 +190,10 @@ fn test_mountain_chromite_ingot_no_manipulation() {
         adversarial: true,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -230,7 +239,10 @@ fn test_indagator_3858_4057() {
         adversarial: true,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -280,7 +292,10 @@ fn test_rare_tacos_4628_4410() {
         adversarial: true,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -329,7 +344,10 @@ fn issue_113() {
         adversarial: true,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
@@ -376,7 +394,10 @@ fn issue_118() {
         adversarial: true,
         backload_progress: false,
     };
-    let solver_settings = SolverSettings { simulator_settings };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: true,
+    };
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {

--- a/src/context.rs
+++ b/src/context.rs
@@ -21,6 +21,8 @@ pub struct SolverConfig {
     pub quality_target: QualityTarget,
     pub backload_progress: bool,
     pub adversarial: bool,
+    #[serde(default)]
+    pub must_reach_target_quality: bool,
 }
 
 pub struct AppContext {


### PR DESCRIPTION
Using `allow_non_max_quality_solutions=true` gives the same behavior as before.

Currently, candidate solutions that are known to not reach max quality are still saved so that the solver can still find the best rotation in case there is no solution that reaches max quality.

Setting `allow_non_max_quality_solutions=false` makes the solver throw away solutions immediately after proving they cannot reach max quality, so you either get a max-quality solution or no solution at all.

This reduces memory consumption because the solver has to keep track of fewer states.