### PR TITLE
Reduce number of StepLbSolver states with TrainedPerfection effect

### DIFF
--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -87,7 +87,8 @@ impl StepLbSolver {
             state.effects.set_muscle_memory(0);
         }
 
-        let reduced_state = ReducedState::from_state(state, step_budget);
+        let reduced_state =
+            ReducedState::from_state(state, &self.settings.simulator_settings, step_budget);
         let pareto_front = match self.solved_states.get(&reduced_state) {
             Some(pareto_front) => pareto_front,
             None => self.solve_state(reduced_state)?,
@@ -129,8 +130,11 @@ impl StepLbSolver {
                         use_action_combo(&self.settings, full_parent_state, action)
                         && !full_child_state.is_final(&self.settings.simulator_settings)
                     {
-                        let child_state =
-                            ReducedState::from_state(full_child_state, child_steps_budget);
+                        let child_state = ReducedState::from_state(
+                            full_child_state,
+                            &self.settings.simulator_settings,
+                            child_steps_budget,
+                        );
                         if !self.solved_states.contains_key(&child_state) {
                             unvisited_states_by_steps[usize::from(action.steps() - 1)]
                                 .insert(child_state);
@@ -191,7 +195,11 @@ impl StepLbSolver {
                 if let Ok(new_step_budget) = NonZeroU8::try_from(new_step_budget)
                     && !new_state.is_final(&self.settings.simulator_settings)
                 {
-                    let new_state = ReducedState::from_state(new_state, new_step_budget);
+                    let new_state = ReducedState::from_state(
+                        new_state,
+                        &self.settings.simulator_settings,
+                        new_step_budget,
+                    );
                     if let Some(pareto_front) = self.solved_states.get(&new_state) {
                         pf_builder.push_slice(pareto_front.iter().map(|value| {
                             ParetoValue::new(value.progress + progress, value.quality + quality)

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -326,10 +326,10 @@ fn issue_216_steplbsolver_crash() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 199538,
+            finish_states: 205025,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 19119,
-                dropped_nodes: 350178,
+                processed_nodes: 19946,
+                dropped_nodes: 364832,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 318520,
@@ -337,8 +337,8 @@ fn issue_216_steplbsolver_crash() {
                 pareto_values: 1267763,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 74728,
-                pareto_values: 330387,
+                states: 61230,
+                pareto_values: 266192,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -332,10 +332,10 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1183317,
+            finish_states: 1192691,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 63042,
-                dropped_nodes: 256167,
+                processed_nodes: 64249,
+                dropped_nodes: 258813,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,
@@ -343,8 +343,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
                 pareto_values: 16494243,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1753944,
-                pareto_values: 20037975,
+                states: 1153291,
+                pareto_values: 12957118,
             },
         }
     "#]];
@@ -383,10 +383,10 @@ fn stuffed_peppers_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 331770,
+            finish_states: 332904,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 2787,
-                dropped_nodes: 42357,
+                processed_nodes: 2824,
+                dropped_nodes: 42948,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 727703,
@@ -394,8 +394,8 @@ fn stuffed_peppers_2() {
                 pareto_values: 8685113,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 843369,
-                pareto_values: 7997948,
+                states: 568886,
+                pareto_values: 5321421,
             },
         }
     "#]];
@@ -436,10 +436,10 @@ fn stuffed_peppers_2_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 445947,
+            finish_states: 448794,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3178,
-                dropped_nodes: 54624,
+                processed_nodes: 3248,
+                dropped_nodes: 55897,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1547790,
@@ -447,8 +447,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_values: 20676360,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1532904,
-                pareto_values: 17146214,
+                states: 1043176,
+                pareto_values: 11604155,
             },
         }
     "#]];
@@ -489,10 +489,10 @@ fn stuffed_peppers_2_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 331771,
+            finish_states: 332905,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 2787,
-                dropped_nodes: 43336,
+                processed_nodes: 2824,
+                dropped_nodes: 43945,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1477069,
@@ -500,8 +500,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_values: 17827198,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1572551,
-                pareto_values: 15555612,
+                states: 1062965,
+                pareto_values: 10406670,
             },
         }
     "#]];
@@ -549,8 +549,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 9640072,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 833285,
-                pareto_values: 8330947,
+                states: 560914,
+                pareto_values: 5598938,
             },
         }
     "#]];
@@ -636,10 +636,10 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 295272,
+            finish_states: 297239,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 25046,
-                dropped_nodes: 390896,
+                processed_nodes: 25196,
+                dropped_nodes: 393113,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 632525,
@@ -647,8 +647,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 4421953,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 308102,
-                pareto_values: 1967887,
+                states: 257154,
+                pareto_values: 1637498,
             },
         }
     "#]];
@@ -685,10 +685,10 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 371099,
+            finish_states: 373265,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 295,
-                dropped_nodes: 4037,
+                processed_nodes: 306,
+                dropped_nodes: 4190,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 654113,
@@ -696,8 +696,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 7088630,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 655500,
-                pareto_values: 5579324,
+                states: 449455,
+                pareto_values: 3802071,
             },
         }
     "#]];
@@ -734,10 +734,10 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 420652,
+            finish_states: 421555,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 929,
-                dropped_nodes: 13806,
+                processed_nodes: 955,
+                dropped_nodes: 14218,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 620174,
@@ -745,8 +745,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 6152904,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 484722,
-                pareto_values: 3995240,
+                states: 335609,
+                pareto_values: 2765482,
             },
         }
     "#]];
@@ -783,10 +783,10 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1130106,
+            finish_states: 1141195,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 14739,
-                dropped_nodes: 224809,
+                processed_nodes: 15021,
+                dropped_nodes: 229298,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 871349,
@@ -794,8 +794,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 12661815,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1097607,
-                pareto_values: 10951821,
+                states: 753949,
+                pareto_values: 7397099,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -332,19 +332,19 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 2387186,
+            finish_states: 2424273,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1483443,
-                dropped_nodes: 9532747,
+                processed_nodes: 1494275,
+                dropped_nodes: 9561951,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
-                sequential_states: 6186,
-                pareto_values: 22061401,
+                sequential_states: 6196,
+                pareto_values: 22061452,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1750689,
-                pareto_values: 35133315,
+                states: 1142945,
+                pareto_values: 22369507,
             },
         }
     "#]];
@@ -383,10 +383,10 @@ fn stuffed_peppers_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 113181,
+            finish_states: 114746,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 158,
-                dropped_nodes: 3253,
+                processed_nodes: 164,
+                dropped_nodes: 3373,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 685374,
@@ -394,8 +394,8 @@ fn stuffed_peppers_2() {
                 pareto_values: 10568081,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 716016,
-                pareto_values: 12192698,
+                states: 480952,
+                pareto_values: 8039782,
             },
         }
     "#]];
@@ -436,10 +436,10 @@ fn stuffed_peppers_2_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 135715,
+            finish_states: 137133,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 168,
-                dropped_nodes: 3953,
+                processed_nodes: 174,
+                dropped_nodes: 4091,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1464188,
@@ -447,8 +447,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_values: 24789603,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1386414,
-                pareto_values: 26436486,
+                states: 932197,
+                pareto_values: 17555223,
             },
         }
     "#]];
@@ -489,10 +489,10 @@ fn stuffed_peppers_2_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 113182,
+            finish_states: 114747,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 158,
-                dropped_nodes: 3376,
+                processed_nodes: 164,
+                dropped_nodes: 3500,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1405659,
@@ -500,8 +500,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_values: 21872304,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1414156,
-                pareto_values: 24372058,
+                states: 951148,
+                pareto_values: 16103062,
             },
         }
     "#]];
@@ -538,10 +538,10 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1209636,
+            finish_states: 1214742,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 20525,
-                dropped_nodes: 330172,
+                processed_nodes: 20650,
+                dropped_nodes: 332569,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 709548,
@@ -549,8 +549,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 11347845,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 902038,
-                pareto_values: 14638942,
+                states: 602747,
+                pareto_values: 9556539,
             },
         }
     "#]];
@@ -636,10 +636,10 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 121980,
+            finish_states: 122633,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 7804,
-                dropped_nodes: 151505,
+                processed_nodes: 7837,
+                dropped_nodes: 152087,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 588992,
@@ -647,8 +647,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 5111464,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 269309,
-                pareto_values: 2610911,
+                states: 221960,
+                pareto_values: 2149522,
             },
         }
     "#]];
@@ -696,8 +696,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 8053602,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 575636,
-                pareto_values: 8434830,
+                states: 385532,
+                pareto_values: 5524972,
             },
         }
     "#]];
@@ -734,10 +734,10 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 666973,
+            finish_states: 669276,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 6369,
-                dropped_nodes: 128343,
+                processed_nodes: 6475,
+                dropped_nodes: 130406,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 579131,
@@ -745,8 +745,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 6864670,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 550832,
-                pareto_values: 7352920,
+                states: 377013,
+                pareto_values: 4910116,
             },
         }
     "#]];
@@ -794,8 +794,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 15607520,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 998131,
-                pareto_values: 17952228,
+                states: 681246,
+                pareto_values: 11979212,
             },
         }
     "#]];
@@ -942,8 +942,8 @@ fn ceviche_4900_4800_no_quality() {
                 pareto_values: 428868,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 76276,
-                pareto_values: 76276,
+                states: 52284,
+                pareto_values: 52284,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -100,10 +100,10 @@ fn stuffed_peppers() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 863226,
+            finish_states: 874814,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 81472,
-                dropped_nodes: 1587724,
+                processed_nodes: 83148,
+                dropped_nodes: 1620117,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2271577,
@@ -111,8 +111,8 @@ fn stuffed_peppers() {
                 pareto_values: 39200086,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 921340,
-                pareto_values: 16665213,
+                states: 615711,
+                pareto_values: 10878191,
             },
         }
     "#]];
@@ -151,10 +151,10 @@ fn test_rare_tacos_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1472394,
+            finish_states: 1472393,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3802112,
-                dropped_nodes: 1381,
+                processed_nodes: 3802095,
+                dropped_nodes: 1379,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490500,
@@ -162,8 +162,8 @@ fn test_rare_tacos_2() {
                 pareto_values: 70123242,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1634999,
-                pareto_values: 37197066,
+                states: 1056941,
+                pareto_values: 23756150,
             },
         }
     "#]];
@@ -310,8 +310,8 @@ fn test_rare_tacos_4628_4410() {
         MacroSolverStats {
             finish_states: 559037,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1055996,
-                dropped_nodes: 2660672,
+                processed_nodes: 1056068,
+                dropped_nodes: 2661977,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2623346,
@@ -319,8 +319,8 @@ fn test_rare_tacos_4628_4410() {
                 pareto_values: 78045031,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 352027,
-                pareto_values: 7690128,
+                states: 220731,
+                pareto_values: 4774973,
             },
         }
     "#]];


### PR DESCRIPTION
Using TrainedPerfection in the StepLbSolver when current durability is at least 20 points below maximum durability is never a good option if either MasterMend or ImmaculateMend are available.

This optimization gets makes sure that no StepLbSolver state has `trained_perfection_active=true` when current durability is at least 20 points below maximum durability.

Overall, this results in noticeable memory savings and speed gains, especially for high-durability configurations.