### PR TITLE
Prune states with both Innovation and Veneration effects in `StepLbSolver`

### DIFF
--- a/raphael-solver/src/step_lower_bound_solver/state.rs
+++ b/raphael-solver/src/step_lower_bound_solver/state.rs
@@ -56,6 +56,15 @@ impl ReducedState {
             effects.set_waste_not(8);
         }
 
+        // If Innovation and Veneration are both active, set both effects to the same value.
+        // This greatly decreases the number of unique states and in practice does not decrease the lower bound
+        // tightness much.
+        if effects.innovation() != 0 && effects.veneration() != 0 {
+            let innovation_veneration = std::cmp::max(effects.innovation(), effects.veneration());
+            effects.set_innovation(innovation_veneration);
+            effects.set_veneration(innovation_veneration);
+        }
+
         // Clamp all effects down to the steps budget to reduce the number of unique states.
         if effects.manipulation() > steps_budget.get() - 1 {
             effects.set_manipulation(steps_budget.get() - 1);

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -140,8 +140,8 @@ fn zero_quality() {
                 pareto_values: 109398,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 33737,
-                pareto_values: 250232,
+                states: 26538,
+                pareto_values: 194222,
             },
         }
     "#]];
@@ -178,10 +178,10 @@ fn max_quality() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 239711,
+            finish_states: 251317,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 5568,
-                dropped_nodes: 66119,
+                processed_nodes: 6915,
+                dropped_nodes: 87768,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 389796,
@@ -189,8 +189,8 @@ fn max_quality() {
                 pareto_values: 2236380,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 105076,
-                pareto_values: 678134,
+                states: 77448,
+                pareto_values: 486877,
             },
         }
     "#]];
@@ -326,10 +326,10 @@ fn issue_216_steplbsolver_crash() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 199546,
+            finish_states: 221234,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 19121,
-                dropped_nodes: 350197,
+                processed_nodes: 21746,
+                dropped_nodes: 400463,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 318520,
@@ -337,8 +337,8 @@ fn issue_216_steplbsolver_crash() {
                 pareto_values: 1267763,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 84580,
-                pareto_values: 369990,
+                states: 65748,
+                pareto_values: 289165,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -96,8 +96,8 @@ fn rinascita_3700_3280() {
                 pareto_values: 16783500,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 835012,
-                pareto_values: 9658861,
+                states: 579412,
+                pareto_values: 6563554,
             },
         }
     "#]];
@@ -145,8 +145,8 @@ fn pactmaker_3240_3130() {
                 pareto_values: 13132176,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 835012,
-                pareto_values: 9339298,
+                states: 579412,
+                pareto_values: 6355536,
             },
         }
     "#]];
@@ -196,8 +196,8 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_values: 27637851,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1569034,
-                pareto_values: 19343619,
+                states: 1089001,
+                pareto_values: 13225920,
             },
         }
     "#]];
@@ -245,8 +245,8 @@ fn diadochos_4021_3660() {
                 pareto_values: 17344815,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 921542,
-                pareto_values: 12468961,
+                states: 638953,
+                pareto_values: 8453810,
             },
         }
     "#]];
@@ -294,8 +294,8 @@ fn indagator_3858_4057() {
                 pareto_values: 16209295,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 661982,
-                pareto_values: 7970301,
+                states: 460345,
+                pareto_values: 5446159,
             },
         }
     "#]];
@@ -332,19 +332,19 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1183302,
+            finish_states: 1228033,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 63046,
-                dropped_nodes: 256179,
+                processed_nodes: 70818,
+                dropped_nodes: 283302,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 945752,
-                sequential_states: 12499,
-                pareto_values: 16494243,
+                sequential_states: 12609,
+                pareto_values: 16494731,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1756521,
-                pareto_values: 20040742,
+                states: 1218157,
+                pareto_values: 14294761,
             },
         }
     "#]];
@@ -394,8 +394,8 @@ fn stuffed_peppers_2() {
                 pareto_values: 8685113,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 845033,
-                pareto_values: 7999724,
+                states: 595448,
+                pareto_values: 5727333,
             },
         }
     "#]];
@@ -447,8 +447,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_values: 20676360,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1534568,
-                pareto_values: 17147999,
+                states: 1086046,
+                pareto_values: 12388376,
             },
         }
     "#]];
@@ -500,8 +500,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_values: 17827198,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1574215,
-                pareto_values: 15557388,
+                states: 1094482,
+                pareto_values: 10934179,
             },
         }
     "#]];
@@ -549,8 +549,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 9640072,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 834949,
-                pareto_values: 8332746,
+                states: 589309,
+                pareto_values: 6075722,
             },
         }
     "#]];
@@ -587,10 +587,10 @@ fn black_star_4048_3997() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 127123,
+            finish_states: 149636,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 8158,
-                dropped_nodes: 100417,
+                processed_nodes: 10245,
+                dropped_nodes: 127947,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 448545,
@@ -598,8 +598,8 @@ fn black_star_4048_3997() {
                 pareto_values: 2531249,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 100295,
-                pareto_values: 544498,
+                states: 74001,
+                pareto_values: 388325,
             },
         }
     "#]];
@@ -636,10 +636,10 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 295272,
+            finish_states: 332249,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 25047,
-                dropped_nodes: 390893,
+                processed_nodes: 28603,
+                dropped_nodes: 447071,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 632525,
@@ -647,8 +647,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 4421953,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 309305,
-                pareto_values: 1969161,
+                states: 225388,
+                pareto_values: 1402012,
             },
         }
     "#]];
@@ -685,10 +685,10 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 371099,
+            finish_states: 375623,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 296,
-                dropped_nodes: 4034,
+                processed_nodes: 362,
+                dropped_nodes: 5152,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 654113,
@@ -696,8 +696,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 7088630,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 656936,
-                pareto_values: 5580863,
+                states: 469090,
+                pareto_values: 4047950,
             },
         }
     "#]];
@@ -745,8 +745,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 6152904,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 485930,
-                pareto_values: 3996540,
+                states: 347252,
+                pareto_values: 2906499,
             },
         }
     "#]];
@@ -783,10 +783,10 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1130111,
+            finish_states: 1140976,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 14736,
-                dropped_nodes: 224738,
+                processed_nodes: 15512,
+                dropped_nodes: 237517,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 871349,
@@ -794,8 +794,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 12661815,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1099531,
-                pareto_values: 10953907,
+                states: 773971,
+                pareto_values: 7813209,
             },
         }
     "#]];
@@ -832,19 +832,19 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 582389,
+            finish_states: 590396,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 169952,
-                dropped_nodes: 761053,
+                processed_nodes: 172660,
+                dropped_nodes: 772895,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 994029,
-                sequential_states: 9767,
-                pareto_values: 11580525,
+                sequential_states: 9788,
+                pareto_values: 11580610,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 322384,
-                pareto_values: 2765323,
+                states: 234210,
+                pareto_values: 2038001,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -96,8 +96,8 @@ fn rinascita_3700_3280() {
                 pareto_values: 22751757,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 911906,
-                pareto_values: 16293287,
+                states: 631128,
+                pareto_values: 11674974,
             },
         }
     "#]];
@@ -145,8 +145,8 @@ fn pactmaker_3240_3130() {
                 pareto_values: 17736621,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 911906,
-                pareto_values: 16188009,
+                states: 631128,
+                pareto_values: 11652491,
             },
         }
     "#]];
@@ -196,8 +196,8 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 pareto_values: 37644777,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1705299,
-                pareto_values: 31987870,
+                states: 1178831,
+                pareto_values: 23063578,
             },
         }
     "#]];
@@ -245,8 +245,8 @@ fn diadochos_4021_3660() {
                 pareto_values: 23497998,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1003608,
-                pareto_values: 20165810,
+                states: 693970,
+                pareto_values: 14559312,
             },
         }
     "#]];
@@ -294,8 +294,8 @@ fn indagator_3858_4057() {
                 pareto_values: 21397668,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 728532,
-                pareto_values: 13410816,
+                states: 505459,
+                pareto_values: 9590744,
             },
         }
     "#]];
@@ -332,19 +332,19 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 2387185,
+            finish_states: 2433096,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1483404,
-                dropped_nodes: 9532534,
+                processed_nodes: 1597673,
+                dropped_nodes: 10292663,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 932788,
-                sequential_states: 6186,
-                pareto_values: 22061401,
+                sequential_states: 6315,
+                pareto_values: 22061921,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1793175,
-                pareto_values: 36121786,
+                states: 1240691,
+                pareto_values: 26206132,
             },
         }
     "#]];
@@ -383,10 +383,10 @@ fn stuffed_peppers_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 113181,
+            finish_states: 114155,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 159,
-                dropped_nodes: 3252,
+                processed_nodes: 180,
+                dropped_nodes: 3683,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 685374,
@@ -394,8 +394,8 @@ fn stuffed_peppers_2() {
                 pareto_values: 10568081,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 742470,
-                pareto_values: 12671314,
+                states: 522680,
+                pareto_values: 8852280,
             },
         }
     "#]];
@@ -436,10 +436,10 @@ fn stuffed_peppers_2_heart_and_soul() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 135715,
+            finish_states: 136794,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 169,
-                dropped_nodes: 3951,
+                processed_nodes: 192,
+                dropped_nodes: 4483,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1464188,
@@ -447,8 +447,8 @@ fn stuffed_peppers_2_heart_and_soul() {
                 pareto_values: 24789603,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1422363,
-                pareto_values: 27110130,
+                states: 1000524,
+                pareto_values: 19074563,
             },
         }
     "#]];
@@ -489,10 +489,10 @@ fn stuffed_peppers_2_quick_innovation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 113182,
+            finish_states: 114156,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 159,
-                dropped_nodes: 3375,
+                processed_nodes: 180,
+                dropped_nodes: 3810,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1405659,
@@ -500,8 +500,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_values: 21872304,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1472761,
-                pareto_values: 25449972,
+                states: 1021247,
+                pareto_values: 17473778,
             },
         }
     "#]];
@@ -538,10 +538,10 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1209636,
+            finish_states: 1224000,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 20526,
-                dropped_nodes: 329628,
+                processed_nodes: 21476,
+                dropped_nodes: 343304,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 709548,
@@ -549,8 +549,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
                 pareto_values: 11347845,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 932500,
-                pareto_values: 15248675,
+                states: 654691,
+                pareto_values: 10811806,
             },
         }
     "#]];
@@ -587,10 +587,10 @@ fn black_star_4048_3997() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 49527,
+            finish_states: 58979,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1728,
-                dropped_nodes: 26232,
+                processed_nodes: 2226,
+                dropped_nodes: 34466,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 414395,
@@ -598,8 +598,8 @@ fn black_star_4048_3997() {
                 pareto_values: 2776768,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 87418,
-                pareto_values: 751234,
+                states: 66942,
+                pareto_values: 556755,
             },
         }
     "#]];
@@ -636,10 +636,10 @@ fn claro_walnut_lumber_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 121980,
+            finish_states: 131269,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 7805,
-                dropped_nodes: 151490,
+                processed_nodes: 8697,
+                dropped_nodes: 169581,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 588992,
@@ -647,8 +647,8 @@ fn claro_walnut_lumber_4900_4800() {
                 pareto_values: 5111464,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 288310,
-                pareto_values: 2755925,
+                states: 208941,
+                pareto_values: 1955153,
             },
         }
     "#]];
@@ -685,10 +685,10 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 281651,
+            finish_states: 283542,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 75,
-                dropped_nodes: 1476,
+                processed_nodes: 109,
+                dropped_nodes: 2176,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 615546,
@@ -696,8 +696,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
                 pareto_values: 8053602,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 598082,
-                pareto_values: 8845466,
+                states: 414288,
+                pareto_values: 6060588,
             },
         }
     "#]];
@@ -734,10 +734,10 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 666973,
+            finish_states: 683323,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 6370,
-                dropped_nodes: 128337,
+                processed_nodes: 7939,
+                dropped_nodes: 160597,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 579131,
@@ -745,8 +745,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
                 pareto_values: 6864670,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 573278,
-                pareto_values: 7730423,
+                states: 410521,
+                pareto_values: 5457006,
             },
         }
     "#]];
@@ -783,10 +783,10 @@ fn archeo_kingdom_broadsword_4966_4914() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 865500,
+            finish_states: 926100,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 7628,
-                dropped_nodes: 151945,
+                processed_nodes: 9797,
+                dropped_nodes: 195521,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 812878,
@@ -794,8 +794,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
                 pareto_values: 15607520,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1033528,
-                pareto_values: 18709917,
+                states: 729095,
+                pareto_values: 13406303,
             },
         }
     "#]];
@@ -832,19 +832,19 @@ fn hardened_survey_plank_5558_5216() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 859926,
+            finish_states: 900043,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1821014,
-                dropped_nodes: 12419810,
+                processed_nodes: 2024194,
+                dropped_nodes: 13578238,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 969126,
-                sequential_states: 4016,
-                pareto_values: 16038900,
+                sequential_states: 4229,
+                pareto_values: 16039954,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 362275,
-                pareto_values: 5290898,
+                states: 263315,
+                pareto_values: 4081029,
             },
         }
     "#]];
@@ -892,8 +892,8 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
                 pareto_values: 38833493,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 962734,
-                pareto_values: 15708738,
+                states: 693981,
+                pareto_values: 11811912,
             },
         }
     "#]];
@@ -942,8 +942,8 @@ fn ceviche_4900_4800_no_quality() {
                 pareto_values: 428868,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 79680,
-                pareto_values: 79680,
+                states: 60307,
+                pareto_values: 60307,
             },
         }
     "#]];
@@ -993,8 +993,8 @@ fn ce_high_progress_zero_achieved_quality() {
                 pareto_values: 2232866,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 617004,
-                pareto_values: 1396057,
+                states: 450021,
+                pareto_values: 1030226,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -100,10 +100,10 @@ fn stuffed_peppers() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 863226,
+            finish_states: 879227,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 81430,
-                dropped_nodes: 1583303,
+                processed_nodes: 85547,
+                dropped_nodes: 1666327,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2271577,
@@ -111,8 +111,8 @@ fn stuffed_peppers() {
                 pareto_values: 39200086,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 948064,
-                pareto_values: 17159772,
+                states: 671639,
+                pareto_values: 12131887,
             },
         }
     "#]];
@@ -151,10 +151,10 @@ fn test_rare_tacos_2() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 1472394,
+            finish_states: 1472389,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 3804661,
-                dropped_nodes: 1384,
+                processed_nodes: 3803810,
+                dropped_nodes: 1304,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2490500,
@@ -162,8 +162,8 @@ fn test_rare_tacos_2() {
                 pareto_values: 70123242,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1677388,
-                pareto_values: 38199618,
+                states: 1159754,
+                pareto_values: 27872224,
             },
         }
     "#]];
@@ -206,19 +206,19 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 74980,
+            finish_states: 81293,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 28457,
-                dropped_nodes: 367648,
+                processed_nodes: 33222,
+                dropped_nodes: 427671,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1800421,
-                sequential_states: 39249,
-                pareto_values: 16731261,
+                sequential_states: 42370,
+                pareto_values: 16756707,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 56056,
-                pareto_values: 501137,
+                states: 38983,
+                pareto_values: 345963,
             },
         }
     "#]];
@@ -266,8 +266,8 @@ fn test_indagator_3858_4057() {
                 pareto_values: 64645870,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 728532,
-                pareto_values: 14472388,
+                states: 505459,
+                pareto_values: 10416852,
             },
         }
     "#]];
@@ -308,10 +308,10 @@ fn test_rare_tacos_4628_4410() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 559037,
+            finish_states: 559040,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1056172,
-                dropped_nodes: 2660725,
+                processed_nodes: 1056176,
+                dropped_nodes: 2661324,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 2623346,
@@ -319,8 +319,8 @@ fn test_rare_tacos_4628_4410() {
                 pareto_values: 78045031,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 381872,
-                pareto_values: 8421898,
+                states: 249850,
+                pareto_values: 5821862,
             },
         }
     "#]];
@@ -371,8 +371,8 @@ fn issue_113() {
                 pareto_values: 120610497,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 2202570,
-                pareto_values: 65341634,
+                states: 1525536,
+                pareto_values: 49094405,
             },
         }
     "#]];
@@ -410,19 +410,19 @@ fn issue_118() {
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
-            finish_states: 574583,
+            finish_states: 580302,
             search_queue_stats: SearchQueueStats {
-                processed_nodes: 1334213,
-                dropped_nodes: 15780284,
+                processed_nodes: 1375109,
+                dropped_nodes: 16253115,
             },
             quality_ub_stats: QualityUbSolverStats {
                 parallel_states: 1930860,
-                sequential_states: 61610,
-                pareto_values: 25587983,
+                sequential_states: 61633,
+                pareto_values: 25588399,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 222393,
-                pareto_values: 2491592,
+                states: 162597,
+                pareto_values: 1867959,
             },
         }
     "#]];


### PR DESCRIPTION
In `StepLbSolver`, if a state has both Innovation and Veneration active, set both effects to the maximum of the two.

This reduces the possible number of combinations of Innovation and Veneration from 20 down to 13.

Of course, it also improves the evaluation for affected states, which means `StepLbSolver` will produce a worse lower-bound, which in turn means the main search loop potentially has to process more nodes. However, as seen in the snapshot tests, the additional nodes processed in the main search loop is small in most cases. Together with the main search loop parallelization in #253, this should be a worthy trade-off.

The same pruning strategy was also tried on `QualityUbSolver` states, but doing so resulted in significantly worse bounds.