### PR TITLE
Reduce impact of Quick Innovation on number of `StepLbSolver` states

### DIFF
--- a/raphael-solver/src/step_lower_bound_solver/state.rs
+++ b/raphael-solver/src/step_lower_bound_solver/state.rs
@@ -41,6 +41,8 @@ impl ReducedState {
         // This decreases the number of possible states, as now there are only Active/Inactive states for TrainedPerfection instead of the usual Available/Active/Unavailable.
         // This also technically loosens the step-lb, but testing shows that rarely has any impact on the number of pruned nodes.
         effects.set_trained_perfection_available(true);
+        // Same thing for QuickInnovation. Just set it to always available.
+        effects.set_quick_innovation_available(true);
 
         // Make the effects of GreatStrides and WasteNot last forever.
         // This decreases the number of unique states as now each effect only has 2 possible states

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -238,8 +238,8 @@ fn large_progress_quality_increase() {
                 pareto_values: 178982,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 14,
-                pareto_values: 14,
+                states: 13,
+                pareto_values: 13,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -500,8 +500,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_values: 17827198,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1094482,
-                pareto_values: 10934179,
+                states: 602715,
+                pareto_values: 5794281,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -500,8 +500,8 @@ fn stuffed_peppers_2_quick_innovation() {
                 pareto_values: 21872304,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 1021247,
-                pareto_values: 17473778,
+                states: 537763,
+                pareto_values: 9141198,
             },
         }
     "#]];
@@ -892,8 +892,8 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
                 pareto_values: 38833493,
             },
             step_lb_stats: StepLbSolverStats {
-                states: 693981,
-                pareto_values: 11811912,
+                states: 370080,
+                pareto_values: 6335993,
             },
         }
     "#]];


### PR DESCRIPTION
Set `quick_innovation_available=true` for all `StepLbSolver` states to reduce number of unique states. This can be done with minimal negative impact because in the context of `StepLbSolver`, where there is no CP cost, Quick Innovation is unlikely to be a good action, so being able to use it repeatedly should have a minimal impact on a state's evaluation, if at all.

Out of the four snapshot tests that include Quick Innvation, none had any increase in number of visited states in the main loop.