### PR TITLE
Add search node batch prefetching

### DIFF
--- a/raphael-solver/src/macro_solver/search_queue.rs
+++ b/raphael-solver/src/macro_solver/search_queue.rs
@@ -124,6 +124,10 @@ impl SearchQueue {
         }
     }
 
+    pub fn next_batch_score(&self) -> Option<&SearchScore> {
+        self.batch_ordering.last()
+    }
+
     pub fn pop_batch(&mut self) -> Option<(SearchScore, Vec<(SimulationState, usize)>)> {
         if self.processed_nodes == 0 {
             self.processed_nodes += 1;

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -188,7 +188,7 @@ fn max_quality() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 97351,
-                processed_nodes: 6915,
+                processed_nodes: 6916,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 4659,
@@ -348,7 +348,7 @@ fn issue_216_steplbsolver_crash() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 436353,
-                processed_nodes: 21746,
+                processed_nodes: 21924,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 9851,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -86,7 +86,7 @@ fn rinascita_3700_3280() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 5091,
+                inserted_nodes: 5092,
                 processed_nodes: 457,
             },
             finish_solver_stats: FinishSolverStats {
@@ -139,7 +139,7 @@ fn pactmaker_3240_3130() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 42206,
+                inserted_nodes: 42207,
                 processed_nodes: 4631,
             },
             finish_solver_stats: FinishSolverStats {
@@ -247,7 +247,7 @@ fn diadochos_4021_3660() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 7609,
+                inserted_nodes: 7612,
                 processed_nodes: 1627,
             },
             finish_solver_stats: FinishSolverStats {
@@ -354,7 +354,7 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 431840,
-                processed_nodes: 70818,
+                processed_nodes: 70825,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -409,7 +409,7 @@ fn stuffed_peppers_2() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 46128,
-                processed_nodes: 2788,
+                processed_nodes: 2790,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -523,7 +523,7 @@ fn stuffed_peppers_2_quick_innovation() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 47108,
-                processed_nodes: 2788,
+                processed_nodes: 2790,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -629,7 +629,7 @@ fn black_star_4048_3997() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 146191,
-                processed_nodes: 10245,
+                processed_nodes: 10401,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3248,
@@ -682,7 +682,7 @@ fn claro_walnut_lumber_4900_4800() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 503332,
-                processed_nodes: 28603,
+                processed_nodes: 28616,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 8079,
@@ -735,7 +735,7 @@ fn rakaznar_lapidary_hammer_4900_4800() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 5598,
-                processed_nodes: 362,
+                processed_nodes: 370,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -788,7 +788,7 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 15034,
-                processed_nodes: 930,
+                processed_nodes: 955,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -841,7 +841,7 @@ fn archeo_kingdom_broadsword_4966_4914() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 265762,
-                processed_nodes: 15512,
+                processed_nodes: 15517,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 13977,
@@ -894,7 +894,7 @@ fn hardened_survey_plank_5558_5216() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 1228817,
-                processed_nodes: 172660,
+                processed_nodes: 172676,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3619,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -139,7 +139,7 @@ fn pactmaker_3240_3130() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 72819,
+                inserted_nodes: 72820,
                 processed_nodes: 5240,
             },
             finish_solver_stats: FinishSolverStats {
@@ -354,7 +354,7 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 13407968,
-                processed_nodes: 1597673,
+                processed_nodes: 1597736,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -576,7 +576,7 @@ fn rakaznar_lapidary_hammer_4462_4391() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 376873,
-                processed_nodes: 21476,
+                processed_nodes: 21505,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -629,7 +629,7 @@ fn black_star_4048_3997() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 37315,
-                processed_nodes: 2226,
+                processed_nodes: 2351,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3248,
@@ -682,7 +682,7 @@ fn claro_walnut_lumber_4900_4800() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 183400,
-                processed_nodes: 8697,
+                processed_nodes: 8702,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 8079,
@@ -788,7 +788,7 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 171861,
-                processed_nodes: 7939,
+                processed_nodes: 8044,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -841,7 +841,7 @@ fn archeo_kingdom_broadsword_4966_4914() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 209791,
-                processed_nodes: 9797,
+                processed_nodes: 9803,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 13977,
@@ -894,7 +894,7 @@ fn hardened_survey_plank_5558_5216() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 18326484,
-                processed_nodes: 2024194,
+                processed_nodes: 2024197,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3619,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -102,7 +102,7 @@ fn stuffed_peppers() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 1799797,
-                processed_nodes: 85547,
+                processed_nodes: 85550,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -157,7 +157,7 @@ fn test_rare_tacos_2() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 9023119,
-                processed_nodes: 3803810,
+                processed_nodes: 3803811,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -216,7 +216,7 @@ fn test_mountain_chromite_ingot_no_manipulation() {
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
                 inserted_nodes: 485744,
-                processed_nodes: 33222,
+                processed_nodes: 33227,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 798,


### PR DESCRIPTION
Fetching the next batch from the search queue is an expensive operation because that's when the Pareto-dominance checking happens.

If possible, we want to prefetch the next batch in parallel as we are iterating over the current batch.