### PR TITLE
Use `thread_local` to avoid excessive solver sharding

### DIFF
--- a/raphael-solver/Cargo.toml
+++ b/raphael-solver/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true, optional = true }
 web-time = { workspace = true }
 wide = "0.7.33"
 nunny = "0.2.2"
+thread_local = "1.1.9"
 
 [features]
 serde = ["dep:serde", "raphael-sim/serde"]


### PR DESCRIPTION
Rayon's `try_fold` (or any other operation with an init value) creates a new init value per work segment. Rayon's implementation of work stealing results in a lot of work segments being created (up to a few thousand segments per batch).

Because each init value is a solver shard, this means that there is not a lot of data re-use even within the same thread.

Using `thread_local` ensures that each thread reuses the same shard for different segments instead of creating new shards.