### PR TITLE
Use updated field name of current schema in `raphael-data-updater`

### DIFF
--- a/raphael-data-updater/src/consumable.rs
+++ b/raphael-data-updater/src/consumable.rs
@@ -11,7 +11,7 @@ pub struct ItemAction {
 
 impl SheetData for ItemAction {
     const SHEET: &'static str = "ItemAction";
-    const REQUIRED_FIELDS: &[&str] = &["Type", "Data"];
+    const REQUIRED_FIELDS: &[&str] = &["Action@as(raw)", "Data"];
 
     fn row_id(&self) -> u32 {
         self.id
@@ -21,7 +21,7 @@ impl SheetData for ItemAction {
         let fields = &value["fields"];
         Some(Self {
             id: value["row_id"].as_u32().unwrap(),
-            type_id: fields["Type"].as_u32().unwrap(),
+            type_id: fields["Action@as(raw)"].as_u32().unwrap(),
             item_food_id: fields["Data"].members().nth(1).unwrap().as_u32().unwrap(),
         })
     }


### PR DESCRIPTION
Closes #281

The newly released global version's patch brought with it an update to the EXDSchema definitions used by boilmaster. For Raphael, only a single change, https://github.com/xivdev/EXDSchema/commit/c5448061f016838e2e26a708f3d4a2ad103af1e3, affects the updater.

The other problem mentioned in the issue is due to more general changes to the game data itself in patch 7.4 and is resolved after https://github.com/xivdev/EXDSchema/commit/e9c9700fa3a5e20839ac963781dbed1d5eb57131 (which boilmaster seems to fetch / update to reflect hourly, https://github.com/ackwell/boilmaster/blob/main/boilmaster.toml#L73).