### PR TITLE
Fix font size used in text width calculations not reflecting the UI's style

### DIFF
--- a/src/widgets/drop_down.rs
+++ b/src/widgets/drop_down.rs
@@ -33,9 +33,11 @@ where
 
         // Calculate the maximum width beforehand to make sure the drop down does not resize
         // when selecting a new value.
-        let max_label_width = max_text_width(ui, value_labels);
-        let combo_box_width =
-            max_label_width + ui.spacing().icon_width + 2.0 * ui.spacing().button_padding.x;
+        let max_label_width = max_text_width(ui, value_labels, egui::TextStyle::Button);
+        let combo_box_width = max_label_width
+            + ui.spacing().icon_spacing
+            + ui.spacing().icon_width
+            + 2.0 * ui.spacing().button_padding.x;
 
         egui::ComboBox::from_id_salt(self.id)
             .width(combo_box_width)

--- a/src/widgets/saved_rotations.rs
+++ b/src/widgets/saved_rotations.rs
@@ -494,6 +494,7 @@ impl<'a> RotationWidget<'a> {
                 t!(locale, "Potion"),
                 t!(locale, "Solver"),
             ],
+            egui::TextStyle::Body,
         );
 
         if let Some(recipe) = recipe {

--- a/src/widgets/simulator.rs
+++ b/src/widgets/simulator.rs
@@ -99,6 +99,7 @@ impl Simulator<'_> {
                         t!(locale, "Durability"),
                         t!(locale, "CP"),
                     ],
+                    egui::TextStyle::Body,
                 );
 
                 let text_size = egui::vec2(max_text_width, ui.spacing().interact_size.y);

--- a/src/widgets/stats_edit.rs
+++ b/src/widgets/stats_edit.rs
@@ -109,7 +109,7 @@ impl Widget for StatsEdit<'_> {
                             input_enabled,
                             egui::TextEdit::singleline(input_string)
                                 .hint_text(hint_text)
-                                .desired_width(text_width(ui, hint_text)),
+                                .desired_width(text_width(ui, hint_text, egui::TextStyle::Body)),
                         );
                         if input_response.changed()
                             && let Ok(crafter_config) = ron::from_str(input_string)

--- a/src/widgets/util.rs
+++ b/src/widgets/util.rs
@@ -1,3 +1,4 @@
+use egui::TextStyle;
 use raphael_data::{
     Consumable, CrafterStats, Locale, control_bonus, cp_bonus, craftsmanship_bonus,
 };
@@ -62,25 +63,27 @@ pub fn effect_string(
     effect
 }
 
-pub fn text_width(ui: &egui::Ui, text: impl Into<String>) -> f32 {
+pub fn text_width(ui: &egui::Ui, text: impl Into<String>, text_style: TextStyle) -> f32 {
+    let font_id = text_style.resolve(ui.style());
     ui.fonts_mut(|fonts| {
-        let galley = fonts.layout_no_wrap(
-            text.into(),
-            egui::FontId::default(),
-            egui::Color32::default(),
-        );
+        let galley = fonts.layout_no_wrap(text.into(), font_id, egui::Color32::default());
         galley.rect.width()
     })
 }
 
-pub fn max_text_width(ui: &egui::Ui, texts: impl IntoIterator<Item = impl ToString>) -> f32 {
+pub fn max_text_width(
+    ui: &egui::Ui,
+    texts: impl IntoIterator<Item = impl ToString>,
+    text_style: TextStyle,
+) -> f32 {
+    let font_id = text_style.resolve(ui.style());
     ui.fonts_mut(|fonts| {
         texts
             .into_iter()
             .map(|text| {
                 let galley = fonts.layout_no_wrap(
                     text.to_string(),
-                    egui::FontId::default(),
+                    font_id.clone(),
                     egui::Color32::default(),
                 );
                 galley.rect.width()
@@ -106,7 +109,8 @@ pub fn calculate_column_widths<const N: usize>(
     desired_widths.map(|desired_width| {
         let exact_width = match desired_width {
             TableColumnWidth::SelectButton => {
-                text_width(ui, t!(locale, "Select")) + 2.0 * ui.spacing().button_padding.x
+                text_width(ui, t!(locale, "Select"), TextStyle::Button)
+                    + 2.0 * ui.spacing().button_padding.x
             }
             TableColumnWidth::JobName => max_text_width(
                 ui,
@@ -119,6 +123,7 @@ pub fn calculate_column_widths<const N: usize>(
                     Locale::KR => &raphael_data::JOB_NAMES_KR,
                     Locale::TW => &raphael_data::JOB_NAMES_TW,
                 },
+                TextStyle::Body,
             ),
             TableColumnWidth::RelativeToRemainingClamped { scale, min, max } => {
                 (remaining_width * scale).clamp(min, max)


### PR DESCRIPTION
The helper functions that calculate text widths were using `egui::FontId::default()` before, which does not reflect the font size of the actual UI’s style, which seems to be `13.0` while it defaulted to `14.0`. 

I also reverted the width calculation from #284 to what it was originally, since my suggested change to it was not working for all languages because it was only (unintentionally) compensating for the discrepancy, and the original formula was correct (see https://github.com/emilk/egui/blob/f1e0b2e56597e185d18e53fe7f906e5a4455e243/crates/egui/src/containers/combo_box.rs#L364).

While the other uses of the helper functions are also affected, the differences are not as apparent.  The only thing really noticeable to me was that the text in the simulator widget is now shifted further to the left
<img width="87" height="122" alt="image" src="https://github.com/user-attachments/assets/4d1334e1-dec5-4fd0-a4ca-0c732ec4a8fa" />
<img width="87" height="122" alt="image" src="https://github.com/user-attachments/assets/aaf04463-bf4c-4b81-b9b1-7c87e0c84b9a" />

