### PR TITLE
Reduce size of backtracking nodes in search queue

### DIFF
--- a/raphael-solver/src/macro_solver/search_queue.rs
+++ b/raphael-solver/src/macro_solver/search_queue.rs
@@ -75,8 +75,8 @@ enum VisitedNode {
 impl VisitedNode {
     fn state(&self) -> &SimulationState {
         match self {
-            VisitedNode::Root { state } => state,
-            VisitedNode::Intermediate { state, .. } => state,
+            Self::Root { state } => state,
+            Self::Intermediate { state, .. } => state,
         }
     }
 }


### PR DESCRIPTION
Related issue: #292 

Reduces the size of `VisitedNode`:
- On 32-bit architectures: 32 bytes -> 28 bytes.
- On 64-bit architectures: 40 bytes -> 32 bytes.