### PR TITLE
Use `u16` for progress and quality to reduce memory usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ web-time = "1.1.0"
 
 [package]
 name = "raphael-xiv"
-version = "0.26.3"
+version = "0.27.0"
 edition = "2024"
 default-run = "raphael-xiv"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ wgpu = "27"
 wasm-bindgen-rayon = { version = "1.3", features = ["no-bundler"] }
 wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1.7"
-web-sys = "0.3"
+web-sys = "=0.3.85"
 eframe = { version = "0.33.2", features = ["persistence"] }
 
 [dev-dependencies]

--- a/raphael-cli/src/commands/solve.rs
+++ b/raphael-cli/src/commands/solve.rs
@@ -358,7 +358,7 @@ pub fn execute(args: &SolveArgs) {
 
     let final_state = SimulationState::from_macro(&settings, &actions).unwrap();
     let state_quality = final_state.quality;
-    let final_quality = state_quality + u32::from(initial_quality);
+    let final_quality = state_quality.saturating_add(initial_quality);
     let steps = actions.len();
     let duration: u8 = actions.iter().map(|action| action.time_cost()).sum();
     let action_ids: Vec<u32> = actions.iter().map(|f| f.action_id()).collect();

--- a/raphael-sim/src/actions.rs
+++ b/raphael-sim/src/actions.rs
@@ -26,14 +26,15 @@ pub trait ActionImpl {
     }
 
     #[inline]
-    fn progress_increase(state: &SimulationState, settings: &Settings) -> u32 {
+    fn progress_increase(state: &SimulationState, settings: &Settings) -> u16 {
         let action_mod = Self::progress_modifier(state, settings);
         let effect_mod = state.effects.progress_modifier();
-        u32::from(settings.base_progress) * action_mod * effect_mod / 1000
+        let progress = u32::from(settings.base_progress) * action_mod * effect_mod / 1000;
+        progress.try_into().unwrap_or(u16::MAX)
     }
 
     #[inline]
-    fn quality_increase(state: &SimulationState, settings: &Settings, condition: Condition) -> u32 {
+    fn quality_increase(state: &SimulationState, settings: &Settings, condition: Condition) -> u16 {
         let action_mod = Self::quality_modifier(state, settings);
         let effect_mod = state.effects.quality_modifier();
         let condition_mod = match condition {
@@ -42,7 +43,9 @@ pub trait ActionImpl {
             Condition::Excellent => 8,
             Condition::Poor => 1,
         };
-        u32::from(settings.base_quality) * action_mod * effect_mod * condition_mod / 20000
+        let quality =
+            u32::from(settings.base_quality) * action_mod * effect_mod * condition_mod / 20000;
+        quality.try_into().unwrap_or(u16::MAX)
     }
 
     fn durability_cost(state: &SimulationState, settings: &Settings, _condition: Condition) -> u16 {
@@ -810,11 +813,11 @@ impl ActionImpl for TrainedEye {
     }
 
     fn quality_increase(
-        _state: &SimulationState,
+        state: &SimulationState,
         settings: &Settings,
         _condition: Condition,
-    ) -> u32 {
-        u32::from(settings.max_quality)
+    ) -> u16 {
+        state.quality.saturating_sub(settings.max_quality)
     }
 
     fn quality_modifier(_state: &SimulationState, settings: &Settings) -> u32 {

--- a/raphael-sim/src/actions.rs
+++ b/raphael-sim/src/actions.rs
@@ -817,7 +817,7 @@ impl ActionImpl for TrainedEye {
         settings: &Settings,
         _condition: Condition,
     ) -> u16 {
-        state.quality.saturating_sub(settings.max_quality)
+        settings.max_quality.saturating_sub(state.quality)
     }
 
     fn quality_modifier(_state: &SimulationState, settings: &Settings) -> u32 {

--- a/raphael-sim/src/state.rs
+++ b/raphael-sim/src/state.rs
@@ -6,9 +6,9 @@ use crate::{Condition, Settings};
 pub struct SimulationState {
     pub cp: u16,
     pub durability: u16,
-    pub progress: u32,
-    pub quality: u32,            // previous unguarded action = Poor
-    pub unreliable_quality: u32, // previous unguarded action = Normal, diff with quality
+    pub progress: u16,
+    pub quality: u16,            // previous unguarded action = Poor
+    pub unreliable_quality: u16, // previous unguarded action = Normal, diff with quality
     pub effects: Effects,
 }
 
@@ -54,7 +54,7 @@ impl SimulationState {
     }
 
     pub fn is_final(&self, settings: &Settings) -> bool {
-        self.durability == 0 || self.progress >= u32::from(settings.max_progress)
+        self.durability == 0 || self.progress >= settings.max_progress
     }
 
     fn check_common_preconditions<A: ActionImpl>(

--- a/raphael-sim/src/state.rs
+++ b/raphael-sim/src/state.rs
@@ -98,14 +98,16 @@ impl SimulationState {
             let guard_active = state.effects.adversarial_guard_active();
             if quality_increase != 0 {
                 if guard_active {
-                    state.quality += quality_increase;
+                    state.quality = state.quality.saturating_add(quality_increase);
                     state.unreliable_quality = 0;
                 } else {
                     let adversarial_quality_increase =
                         A::quality_increase(self, settings, Condition::Poor);
                     let quality_diff = quality_increase - adversarial_quality_increase;
-                    state.quality += adversarial_quality_increase
-                        + std::cmp::min(state.unreliable_quality, quality_diff);
+                    state.quality = state
+                        .quality
+                        .saturating_add(adversarial_quality_increase)
+                        .saturating_add(std::cmp::min(state.unreliable_quality, quality_diff));
                     state.unreliable_quality =
                         quality_diff.saturating_sub(state.unreliable_quality);
                 }
@@ -113,7 +115,7 @@ impl SimulationState {
                 state.unreliable_quality = 0;
             }
         } else {
-            state.quality += quality_increase;
+            state.quality = state.quality.saturating_add(quality_increase);
         }
         if quality_increase != 0 && settings.job_level >= 11 {
             state
@@ -122,7 +124,7 @@ impl SimulationState {
         }
 
         let progress_increase = A::progress_increase(self, settings);
-        state.progress += progress_increase;
+        state.progress = state.progress.saturating_add(progress_increase);
 
         if state.is_final(settings) {
             return Ok(state);

--- a/raphael-sim/tests/action_tests.rs
+++ b/raphael-sim/tests/action_tests.rs
@@ -19,7 +19,7 @@ const SETTINGS: Settings = Settings {
 /// - Quality
 /// - Durability (used)
 /// - CP (used)
-fn primary_stats(state: &SimulationState, settings: &Settings) -> (u32, u32, u16, u16) {
+fn primary_stats(state: &SimulationState, settings: &Settings) -> (u16, u16, u16, u16) {
     (
         state.progress,
         state.quality,
@@ -500,7 +500,7 @@ fn test_trained_eye() {
         .unwrap();
     assert_eq!(
         primary_stats(&state, &SETTINGS),
-        (0, u32::from(SETTINGS.max_quality), 10, 250)
+        (0, SETTINGS.max_quality, 10, 250)
     );
     assert_eq!(state.effects.inner_quiet(), 1);
 }

--- a/raphael-sim/tests/adversarial_tests.rs
+++ b/raphael-sim/tests/adversarial_tests.rs
@@ -14,7 +14,7 @@ const SETTINGS: Settings = Settings {
 };
 
 /// Calculate the minimum achievable Quality across all possible Condition rolls
-fn guaranteed_quality(mut settings: Settings, actions: &[Action]) -> Result<u32, ActionError> {
+fn guaranteed_quality(mut settings: Settings, actions: &[Action]) -> Result<u16, ActionError> {
     let is_valid_mask = |mut mask: i32| {
         // a 1-bit denotes an Excellent proc
         if (mask & 1) != 0 {
@@ -35,7 +35,7 @@ fn guaranteed_quality(mut settings: Settings, actions: &[Action]) -> Result<u32,
         |action: &Action| *action != Action::QuickInnovation && *action != Action::HeartAndSoul;
 
     settings.adversarial = false;
-    let mut min_quality = u32::MAX;
+    let mut min_quality = u16::MAX;
 
     let condition_mask_len = actions
         .iter()

--- a/raphael-sim/tests/effect_tests.rs
+++ b/raphael-sim/tests/effect_tests.rs
@@ -19,7 +19,7 @@ const SETTINGS: Settings = Settings {
 /// - Quality
 /// - Durability (used)
 /// - CP (used)
-fn primary_stats(state: &SimulationState, settings: &Settings) -> (u32, u32, u16, u16) {
+fn primary_stats(state: &SimulationState, settings: &Settings) -> (u16, u16, u16, u16) {
     (
         state.progress,
         state.quality,

--- a/raphael-solver/src/finish_solver.rs
+++ b/raphael-solver/src/finish_solver.rs
@@ -12,14 +12,14 @@ use crate::{
 struct CpProgressBreakpoints {
     /// List of CP breakpoints and the associated achievable Progress.
     /// Sorted in order of ascending CP.
-    breakpoints: Vec<(u16, u32)>,
+    breakpoints: Vec<(u16, u16)>,
     /// The maximum CP at which the state was solved.
     /// Querying the solution at a CP higher than this may give incorrect results.
     max_solved_cp: Option<u16>,
 }
 
 impl CpProgressBreakpoints {
-    fn get_progress(&self, cp: u16) -> Option<u32> {
+    fn get_progress(&self, cp: u16) -> Option<u16> {
         if Some(cp) > self.max_solved_cp {
             return None;
         }
@@ -33,7 +33,7 @@ impl CpProgressBreakpoints {
     /// Add a new (CP, Durability) breakpoint.
     /// Breakpoints must be added with strictly increasing CP, otherwise `get_progress` may return wrong results.
     /// If the new breakpoint does not have strictly better Progress than the previous breakpoint, it is ignored.
-    fn add_breakpoint(&mut self, cp: u16, progress: u32) {
+    fn add_breakpoint(&mut self, cp: u16, progress: u16) {
         self.max_solved_cp = Some(cp);
         if self.breakpoints.last().is_none_or(|last| last.1 < progress) {
             self.breakpoints.push((cp, progress));
@@ -159,7 +159,7 @@ struct Template {
     durability: u16,
     effects: Effects,
     current_cp: u16,
-    current_max_progress: Option<u32>,
+    current_max_progress: Option<u16>,
 }
 
 fn generate_templates(settings: &SolverSettings) -> Vec<Template> {

--- a/raphael-solver/src/finish_solver.rs
+++ b/raphael-solver/src/finish_solver.rs
@@ -77,7 +77,7 @@ impl FinishSolver {
                 state
             )
         })?;
-        Ok(state.progress + max_additional_progress >= self.settings.max_progress())
+        Ok(state.progress.saturating_add(max_additional_progress) >= self.settings.max_progress())
     }
 
     pub fn precompute(&mut self) -> Result<(), SolverException> {
@@ -131,7 +131,7 @@ impl FinishSolver {
                 } else if let Some(child_breakpoints) = self.solved_states.get(&key)
                     && let Some(child_progress) = child_breakpoints.get_progress(child_state.cp)
                 {
-                    result = std::cmp::max(result, child_state.progress + child_progress);
+                    result = result.max(child_state.progress.saturating_add(child_progress));
                 } else {
                     // Required child state has not been solved yet.
                     // Abort and try again in the next iteration.

--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -74,23 +74,19 @@ impl SolverSettings {
         self.simulator_settings.max_cp
     }
 
-    pub fn max_progress(&self) -> u32 {
-        #[allow(clippy::useless_conversion)]
-        u32::from(self.simulator_settings.max_progress)
+    pub fn max_progress(&self) -> u16 {
+        self.simulator_settings.max_progress
     }
 
-    pub fn max_quality(&self) -> u32 {
-        #[allow(clippy::useless_conversion)]
-        u32::from(self.simulator_settings.max_quality)
+    pub fn max_quality(&self) -> u16 {
+        self.simulator_settings.max_quality
     }
 
-    pub fn base_progress(&self) -> u32 {
-        #[allow(clippy::useless_conversion)]
-        u32::from(self.simulator_settings.base_progress)
+    pub fn base_progress(&self) -> u16 {
+        self.simulator_settings.base_progress
     }
 
-    pub fn base_quality(&self) -> u32 {
-        #[allow(clippy::useless_conversion)]
-        u32::from(self.simulator_settings.base_quality)
+    pub fn base_quality(&self) -> u16 {
+        self.simulator_settings.base_quality
     }
 }

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -16,7 +16,7 @@ const EFFECTS_KEY_MASK: u64 = !EFFECTS_VALUE_MASK;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 struct Key {
-    progress: u32,
+    progress: u16,
     effects: u64,
 }
 
@@ -64,8 +64,8 @@ impl From<&SimulationState> for Value {
     fn from(state: &SimulationState) -> Self {
         Self(wide::u32x4::new([
             (u32::from(state.cp) << 16) + u32::from(state.durability),
-            state.quality,
-            state.quality + state.unreliable_quality,
+            u32::from(state.quality),
+            u32::from(state.quality) + u32::from(state.unreliable_quality),
             (state.effects.into_bits() & EFFECTS_VALUE_MASK) as u32,
         ]))
     }

--- a/raphael-solver/src/macro_solver/search_queue.rs
+++ b/raphael-solver/src/macro_solver/search_queue.rs
@@ -12,7 +12,7 @@ use super::pareto_front::ParetoFront;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SearchScore {
-    pub quality_upper_bound: u32,
+    pub quality_upper_bound: u16,
     pub steps_lower_bound: u8,
     pub duration_lower_bound: u8,
     pub current_steps: u8,
@@ -29,7 +29,7 @@ impl SearchScore {
     };
 
     pub const MAX: Self = Self {
-        quality_upper_bound: u32::MAX,
+        quality_upper_bound: u16::MAX,
         steps_lower_bound: 0,
         duration_lower_bound: 0,
         current_steps: 0,

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -16,7 +16,7 @@ use std::vec::Vec;
 
 #[derive(Clone)]
 struct Solution {
-    score: (SearchScore, u32),
+    score: (SearchScore, u16),
     solver_actions: Vec<ActionCombo>,
 }
 

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -15,9 +15,9 @@ use super::state::ReducedState;
 struct QualityUbSolverContext {
     settings: SolverSettings,
     interrupt_signal: utils::AtomicFlag,
-    iq_quality_lut: [u32; 11],
+    iq_quality_lut: [u16; 11],
     durability_cost: u16,
-    largest_progress_increase: u32,
+    largest_progress_increase: u16,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -270,7 +270,7 @@ impl<'a> QualityUbSolverShard<'a> {
     pub fn quality_upper_bound(
         &mut self,
         mut state: SimulationState,
-    ) -> Result<u32, SolverException> {
+    ) -> Result<u16, SolverException> {
         let mut required_progress = self.context.settings.max_progress() - state.progress;
         if state.effects.muscle_memory() != 0 {
             // Assume MuscleMemory can be used to its max potential and remove the effect to reduce the number of states that need to be solved.

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -222,11 +222,14 @@ impl QualityUbSolver {
             if let Some((new_state, progress, quality)) =
                 state.use_action(action, &self.context.settings, self.context.durability_cost)
             {
-                let action_offset = ParetoValue::new(progress, quality);
+                let action_value = ParetoValue::new(progress, quality);
                 if !new_state.is_final(self.context.durability_cost) {
                     if let Some(pareto_front) = self.solved_states.get(&new_state) {
-                        pf_builder
-                            .push_slice(pareto_front.iter().map(|value| *value + action_offset));
+                        pf_builder.push_slice(
+                            pareto_front
+                                .iter()
+                                .map(|value| value.saturating_add(action_value)),
+                        );
                     } else {
                         return Err(internal_error!(
                             "Required precompute state does not exist.",
@@ -237,7 +240,7 @@ impl QualityUbSolver {
                         ));
                     }
                 } else if progress != 0 {
-                    pf_builder.push(action_offset);
+                    pf_builder.push(action_value);
                 }
                 if pf_builder.is_maximal(cutoff) {
                     break;
@@ -295,7 +298,7 @@ impl<'a> QualityUbSolverShard<'a> {
             };
             if let Some(pareto_front) = self.shared_states.get(&reduced_state)
                 && pareto_front.first().progress >= required_progress
-                && pareto_front.first().quality + state.quality
+                && pareto_front.first().quality.saturating_add(state.quality)
                     >= self.context.settings.max_quality()
             {
                 return Ok(self.context.settings.max_quality());
@@ -325,7 +328,9 @@ impl<'a> QualityUbSolverShard<'a> {
             }
         };
         let i = pareto_front.partition_point(|value| value.progress < required_progress);
-        let quality = pareto_front.get(i).map_or(0, |v| state.quality + v.quality);
+        let quality = pareto_front
+            .get(i)
+            .map_or(0, |value| state.quality.saturating_add(value.quality));
         Ok(std::cmp::min(self.context.settings.max_quality(), quality))
     }
 
@@ -347,7 +352,7 @@ impl<'a> QualityUbSolverShard<'a> {
             if let Some((child_state, progress, quality)) =
                 state.use_action(action, &self.context.settings, self.context.durability_cost)
             {
-                let action_offset = ParetoValue::new(progress, quality);
+                let action_value = ParetoValue::new(progress, quality);
                 if !child_state.is_final(self.context.durability_cost) {
                     let child_pareto_front = if let Some(child_pareto_front) =
                         self.shared_states.get(&child_state)
@@ -364,13 +369,13 @@ impl<'a> QualityUbSolverShard<'a> {
                     pareto_front_builder.push_slice(
                         child_pareto_front
                             .iter()
-                            .map(|value| *value + action_offset),
+                            .map(|value| value.saturating_add(action_value)),
                     );
                     if pareto_front_builder.is_maximal(cutoff) {
                         break;
                     }
-                } else if action_offset.progress != 0 {
-                    pareto_front_builder.push(action_offset);
+                } else if action_value.progress != 0 {
+                    pareto_front_builder.push(action_value);
                 }
             }
         }

--- a/raphael-solver/src/quality_upper_bound_solver/state.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/state.rs
@@ -77,7 +77,7 @@ impl ReducedState {
             cp: self.cp,
             progress: 0,
             quality: 0,
-            unreliable_quality: u32::from(self.compressed_unreliable_quality)
+            unreliable_quality: u16::from(self.compressed_unreliable_quality)
                 * (2 * settings.base_quality()),
             effects: self.effects,
         }
@@ -97,7 +97,7 @@ impl ReducedState {
         action: ActionCombo,
         settings: &SolverSettings,
         durability_cost: u16,
-    ) -> Option<(Self, u32, u32)> {
+    ) -> Option<(Self, u16, u16)> {
         match action {
             ActionCombo::Single(
                 Action::MasterMend | Action::ImmaculateMend | Action::Manipulation,

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -23,8 +23,8 @@ fn check_consistency(solver_settings: SolverSettings) {
             let child_upper_bound = match use_action_combo(&solver_settings, state, action) {
                 Ok(child) => match child.is_final(&solver_settings.simulator_settings) {
                     false => solver_shard.quality_upper_bound(child).unwrap(),
-                    true if child.progress >= u32::from(solver_settings.max_progress()) => {
-                        std::cmp::min(u32::from(solver_settings.max_quality()), child.quality)
+                    true if child.progress >= solver_settings.max_progress() => {
+                        std::cmp::min(solver_settings.max_quality(), child.quality)
                     }
                     true => 0,
                 },

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -200,7 +200,9 @@ impl<'a> StepLbSolverShard<'a> {
             )?
         };
         let idx = pareto_front.partition_point(|value| value.progress < required_progress);
-        let quality_ub = pareto_front.get(idx).map(|v| state.quality + v.quality);
+        let quality_ub = pareto_front
+            .get(idx)
+            .map(|value| state.quality.saturating_add(value.quality));
         Ok(quality_ub)
     }
 }
@@ -252,16 +254,17 @@ fn construct_solution<'a>(
         }
         let new_step_budget = state.steps_budget.get() - action.steps();
         if let Ok(child_state) = use_action_combo(&context.settings, state.to_state(), action) {
-            let progress = child_state.progress;
-            let quality = child_state.quality;
+            let action_value = ParetoValue::new(child_state.progress, child_state.quality);
             if let Ok(new_step_budget) = NonZeroU8::try_from(new_step_budget)
                 && !child_state.is_final(&context.settings.simulator_settings)
             {
                 let child_state = ReducedState::from_state(child_state, new_step_budget);
                 if let Some(pareto_front) = get_solution(child_state) {
-                    pf_builder.push_slice(pareto_front.iter().map(|value| {
-                        ParetoValue::new(value.progress + progress, value.quality + quality)
-                    }));
+                    pf_builder.push_slice(
+                        pareto_front
+                            .iter()
+                            .map(|value| value.saturating_add(action_value)),
+                    );
                 } else {
                     return Err(internal_error!(
                         "Required child state does not exist.",
@@ -271,8 +274,8 @@ fn construct_solution<'a>(
                         child_state
                     ));
                 }
-            } else if progress != 0 {
-                pf_builder.push(ParetoValue::new(progress, quality));
+            } else if action_value.progress != 0 {
+                pf_builder.push(action_value);
             }
         }
     }

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -30,8 +30,8 @@ pub struct StepLbSolverStats {
 struct StepLbSolverContext {
     settings: SolverSettings,
     interrupt_signal: utils::AtomicFlag,
-    iq_quality_lut: [u32; 11],
-    largest_progress_increase: u32,
+    iq_quality_lut: [u16; 11],
+    largest_progress_increase: u16,
 }
 
 pub struct StepLbSolver {
@@ -115,7 +115,7 @@ impl StepLbSolver {
         &mut self,
         mut state: SimulationState,
         step_budget: NonZeroU8,
-    ) -> Result<Option<u32>, SolverException> {
+    ) -> Result<Option<u16>, SolverException> {
         let mut required_progress = self.context.settings.max_progress() - state.progress;
         if state.effects.muscle_memory() != 0 {
             // Assume MuscleMemory can be used to its max potential and remove the effect
@@ -176,7 +176,7 @@ impl<'a> StepLbSolverShard<'a> {
         &mut self,
         mut state: SimulationState,
         step_budget: NonZeroU8,
-    ) -> Result<Option<u32>, SolverException> {
+    ) -> Result<Option<u16>, SolverException> {
         let mut required_progress = self.context.settings.max_progress() - state.progress;
         if state.effects.muscle_memory() != 0 {
             // Assume MuscleMemory can be used to its max potential and remove the effect

--- a/raphael-solver/src/utils/mod.rs
+++ b/raphael-solver/src/utils/mod.rs
@@ -37,7 +37,7 @@ impl Drop for ScopedTimer {
 /// The only way to increase the InnerQuiet effect is to use Quality-increasing actions,
 /// which means that all states with InnerQuiet must have some amount of Quality.
 /// This function finds a lower-bound on the minimum amount of Quality a state with `n` InnerQuiet can have.
-pub fn compute_iq_quality_lut(settings: &SolverSettings) -> [u32; 11] {
+pub fn compute_iq_quality_lut(settings: &SolverSettings) -> [u16; 11] {
     if settings.simulator_settings.adversarial {
         // TODO: implement this for adversarial mode
         return [0; 11];
@@ -49,7 +49,7 @@ pub fn compute_iq_quality_lut(settings: &SolverSettings) -> [u32; 11] {
         // TODO: implement this for heart and soul
         return [0; 11];
     }
-    let mut result = [u32::MAX; 11];
+    let mut result = [u16::MAX; 11];
     result[0] = 0;
     for iq in 0..10 {
         let state = SimulationState {
@@ -79,7 +79,7 @@ pub fn compute_iq_quality_lut(settings: &SolverSettings) -> [u32; 11] {
 }
 
 /// Returns the maximum additional Progress gained by having the Muscle Memory effect.
-pub fn maximum_muscle_memory_utilization(settings: &Settings) -> u32 {
+pub fn maximum_muscle_memory_utilization(settings: &Settings) -> u16 {
     let mut state = SimulationState::new(settings);
     let mut result = 0;
     if settings.is_action_allowed::<BasicSynthesis>() {

--- a/raphael-solver/src/utils/pareto_front_builder.rs
+++ b/raphael-solver/src/utils/pareto_front_builder.rs
@@ -8,13 +8,12 @@ impl ParetoValue {
     pub const fn new(progress: u16, quality: u16) -> Self {
         Self { progress, quality }
     }
-}
 
-impl std::ops::Add for ParetoValue {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self::new(self.progress + rhs.progress, self.quality + rhs.quality)
+    pub const fn saturating_add(self, rhs: Self) -> Self {
+        Self {
+            progress: self.progress.saturating_add(rhs.progress),
+            quality: self.quality.saturating_add(rhs.quality),
+        }
     }
 }
 

--- a/raphael-solver/src/utils/pareto_front_builder.rs
+++ b/raphael-solver/src/utils/pareto_front_builder.rs
@@ -1,11 +1,11 @@
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ParetoValue {
-    pub progress: u32,
-    pub quality: u32,
+    pub progress: u16,
+    pub quality: u16,
 }
 
 impl ParetoValue {
-    pub const fn new(progress: u32, quality: u32) -> Self {
+    pub const fn new(progress: u16, quality: u16) -> Self {
         Self { progress, quality }
     }
 }
@@ -27,7 +27,7 @@ pub struct ParetoFrontBuilder {
 impl ParetoFrontBuilder {
     pub fn new() -> Self {
         Self {
-            cutoff: ParetoValue::new(u32::MAX, u32::MAX),
+            cutoff: ParetoValue::new(u16::MAX, u16::MAX),
             result: Vec::new(),
             merge_buffer: Vec::new(),
         }

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -218,13 +218,13 @@ fn large_progress_quality_increase() {
     let simulator_settings = Settings {
         max_cp: 300,
         max_durability: 40,
-        max_progress: 100,
-        max_quality: 100,
-        base_progress: 5000,
-        base_quality: 5000,
+        max_progress: u16::MAX,
+        max_quality: u16::MAX,
+        base_progress: 10000,
+        base_quality: 10000,
         job_level: 100,
         allowed_actions: ActionMask::all(),
-        adversarial: false,
+        adversarial: true,
         backload_progress: false,
         stellar_steady_hand_charges: 0,
     };
@@ -235,32 +235,32 @@ fn large_progress_quality_increase() {
     let expected_score = expect![[r#"
         Ok(
             SolutionScore {
-                capped_quality: 100,
-                steps: 1,
-                duration: 3,
-                overflow_quality: 4900,
+                capped_quality: 65535,
+                steps: 6,
+                duration: 16,
+                overflow_quality: 0,
             },
         )
     "#]];
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1,
-                processed_nodes: 1,
+                inserted_nodes: 17644,
+                processed_nodes: 907,
             },
             finish_solver_stats: FinishSolverStats {
-                states: 21848,
-                values: 21848,
+                states: 27451,
+                values: 37675,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states_on_main: 178982,
-                states_on_shards: 5,
-                values: 178987,
+                states_on_main: 2208900,
+                states_on_shards: 40,
+                values: 8280034,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 1,
-                states_on_shards: 13,
-                values: 14,
+                states_on_main: 1140,
+                states_on_shards: 10709,
+                values: 49859,
             },
         }
     "#]];

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -5,10 +5,10 @@ use raphael_solver::{AtomicFlag, MacroSolver, SolverSettings};
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 struct SolutionScore {
-    pub capped_quality: u32,
+    pub capped_quality: u16,
     pub steps: u8,
     pub duration: u8,
-    pub overflow_quality: u32,
+    pub overflow_quality: u16,
 }
 
 fn is_progress_backloaded(settings: &SolverSettings, actions: &[Action]) -> bool {

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -236,8 +236,8 @@ fn large_progress_quality_increase() {
         Ok(
             SolutionScore {
                 capped_quality: 65535,
-                steps: 6,
-                duration: 16,
+                steps: 4,
+                duration: 11,
                 overflow_quality: 0,
             },
         )
@@ -245,8 +245,8 @@ fn large_progress_quality_increase() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 17644,
-                processed_nodes: 907,
+                inserted_nodes: 76,
+                processed_nodes: 18,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 27451,
@@ -254,13 +254,13 @@ fn large_progress_quality_increase() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 2208900,
-                states_on_shards: 40,
-                values: 8280034,
+                states_on_shards: 22,
+                values: 8280016,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 1140,
-                states_on_shards: 10709,
-                values: 49859,
+                states_on_main: 320,
+                states_on_shards: 5236,
+                values: 22793,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -5,10 +5,10 @@ use raphael_solver::{AtomicFlag, MacroSolver, SolverSettings};
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 struct SolutionScore {
-    pub capped_quality: u32,
+    pub capped_quality: u16,
     pub steps: u8,
     pub duration: u8,
-    pub overflow_quality: u32,
+    pub overflow_quality: u16,
 }
 
 fn is_progress_backloaded(settings: &SolverSettings, actions: &[Action]) -> bool {

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -5,10 +5,10 @@ use raphael_solver::{AtomicFlag, MacroSolver, SolverSettings};
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 struct SolutionScore {
-    pub capped_quality: u32,
+    pub capped_quality: u16,
     pub steps: u8,
     pub duration: u8,
-    pub overflow_quality: u32,
+    pub overflow_quality: u16,
 }
 
 fn is_progress_backloaded(settings: &SolverSettings, actions: &[Action]) -> bool {

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -5,10 +5,10 @@ use raphael_solver::{AtomicFlag, MacroSolver, SolverSettings};
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)]
 struct SolutionScore {
-    pub capped_quality: u32,
+    pub capped_quality: u16,
     pub steps: u8,
     pub duration: u8,
-    pub overflow_quality: u32,
+    pub overflow_quality: u16,
 }
 
 fn is_progress_backloaded(settings: &SolverSettings, actions: &[Action]) -> bool {

--- a/src/widgets/simulator.rs
+++ b/src/widgets/simulator.rs
@@ -115,7 +115,7 @@ impl Simulator<'_> {
                         )
                         .text(progress_bar_text(
                             state.progress,
-                            u32::from(self.settings.max_progress),
+                            self.settings.max_progress,
                             locale,
                         ))
                         .corner_radius(0),
@@ -126,12 +126,12 @@ impl Simulator<'_> {
                     ui.allocate_ui_with_layout(text_size, text_layout, |ui| {
                         ui.label(t!(locale, "Quality"));
                     });
-                    let quality = u32::from(self.initial_quality) + state.quality;
+                    let quality = self.initial_quality.saturating_add(state.quality);
                     ui.add(
                         egui::ProgressBar::new(quality as f32 / self.settings.max_quality as f32)
                             .text(progress_bar_text(
                                 quality,
-                                u32::from(self.settings.max_quality),
+                                self.settings.max_quality,
                                 locale,
                             ))
                             .corner_radius(0),
@@ -180,7 +180,7 @@ impl Simulator<'_> {
                         }));
                         if !state.is_final(&self.settings) {
                             // do nothing
-                        } else if state.progress < u32::from(self.settings.max_progress) {
+                        } else if state.progress < self.settings.max_progress {
                             ui.label(t!(locale, "Synthesis failed"));
                         } else if self.item_always_collectable {
                             let (t1, t2, t3) = (
@@ -188,16 +188,16 @@ impl Simulator<'_> {
                                 QualityTarget::CollectableT2.get_target(self.settings.max_quality),
                                 QualityTarget::CollectableT3.get_target(self.settings.max_quality),
                             );
-                            let tier = match u32::from(self.initial_quality) + state.quality {
-                                quality if quality >= u32::from(t3) => 3,
-                                quality if quality >= u32::from(t2) => 2,
-                                quality if quality >= u32::from(t1) => 1,
+                            let tier = match self.initial_quality.saturating_add(state.quality) {
+                                quality if quality >= t3 => 3,
+                                quality if quality >= t2 => 2,
+                                quality if quality >= t1 => 1,
                                 _ => 0,
                             };
                             ui.label(t_format!(locale, "Tier {tier} collectable"));
                         } else {
                             let hq = raphael_data::hq_percentage(
-                                u32::from(self.initial_quality) + state.quality,
+                                self.initial_quality.saturating_add(state.quality),
                                 self.settings.max_quality,
                             )
                             .unwrap_or(0);


### PR DESCRIPTION
Normal additions had to be replaced with `saturating_add` due to the possibility of overflow. I was expecting a slight drop in runtime performance but that doesn't seem to be the case.

The size of `SimulationState` remains unchanged due to padding, but the size of `ParetoValue` is halved, which means the `QualityUbSolver` and `StepLbSolver` use less memory.