### PR TITLE
Parallelize Pareto-dominance checking

### DIFF
--- a/raphael-solver/Cargo.toml
+++ b/raphael-solver/Cargo.toml
@@ -19,7 +19,7 @@ web-time = { workspace = true }
 wide = "0.8.2"
 nunny = "0.2.2"
 strum = "0.27"
-dashmap = "6.1.0"
+dashmap = { version = "6.1.0", features = ["raw-api"] }
 
 [features]
 serde = ["dep:serde", "raphael-sim/serde"]

--- a/raphael-solver/Cargo.toml
+++ b/raphael-solver/Cargo.toml
@@ -19,7 +19,6 @@ web-time = { workspace = true }
 wide = "0.8.2"
 nunny = "0.2.2"
 strum = "0.27"
-dashmap = { version = "6.1.0", features = ["raw-api"] }
 
 [features]
 serde = ["dep:serde", "raphael-sim/serde"]

--- a/raphael-solver/Cargo.toml
+++ b/raphael-solver/Cargo.toml
@@ -19,6 +19,7 @@ web-time = { workspace = true }
 wide = "0.8.2"
 nunny = "0.2.2"
 strum = "0.27"
+dashmap = "6.1.0"
 
 [features]
 serde = ["dep:serde", "raphael-sim/serde"]

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -104,10 +104,33 @@ pub struct ParetoFront {
 }
 
 impl ParetoFront {
-    pub fn insert(&mut self, state: SimulationState) -> bool {
+    /// Inserts all non-dominated elements into the pareto front while also removing dominated values
+    /// from the pareto front. Returns an iterator over elements that were inserted.
+    pub fn insert_batch<T>(
+        &mut self,
+        mut elements: Vec<T>,
+        to_state: impl Fn(&T) -> &SimulationState,
+    ) -> impl Iterator<Item = T> {
+        // Sort elements in a way that ensures an element cannot be dominated
+        // by another element that comes later in the list.
+        elements.sort_unstable_by_key(|element| {
+            let state = to_state(element);
+            let weight = u64::from(state.cp)
+                + u64::from(state.durability)
+                + u64::from(state.quality)
+                + u64::from(state.unreliable_quality)
+                + state.effects.into_bits();
+            std::cmp::Reverse(weight)
+        });
+        elements
+            .into_iter()
+            .filter(move |element| self.insert(to_state(element)))
+    }
+
+    fn insert(&mut self, state: &SimulationState) -> bool {
         const MAX_LEAF_SIZE: usize = 200;
-        let new_value = Value::from(&state);
-        let mut node = self.buckets.entry(Key::from(&state)).or_default();
+        let new_value = Value::from(state);
+        let mut node = self.buckets.entry(Key::from(state)).or_default();
         while let TreeNode::Intermediate(intermediate) = node {
             if new_value.cp() < intermediate.partition_point {
                 node = intermediate.lhs.as_mut();

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -166,7 +166,6 @@ impl ParetoFront {
     fn insert(state: &SimulationState, mut node: &mut TreeNode) -> bool {
         const MAX_LEAF_SIZE: usize = 200;
         let new_value = Value::from(state);
-        // let mut node = self.buckets.entry(Key::from(state)).or_default();
         while let TreeNode::Intermediate(intermediate) = node {
             if new_value.cp() < intermediate.partition_point {
                 node = intermediate.lhs.as_mut();

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -111,20 +111,9 @@ impl ParetoFront {
     /// from the pareto front. Returns an iterator over elements that were inserted.
     pub fn insert_batch<T: Send>(
         &mut self,
-        mut elements: Vec<T>,
+        elements: Vec<T>,
         to_state: impl Fn(&T) -> &SimulationState + Sync,
     ) -> impl Iterator<Item = T> {
-        // Sort elements in a way that ensures an element cannot be dominated
-        // by another element that comes later in the list.
-        elements.sort_unstable_by_key(|element| {
-            let state = to_state(element);
-            let weight = u64::from(state.cp)
-                + u64::from(state.durability)
-                + u64::from(state.quality)
-                + u64::from(state.unreliable_quality)
-                + state.effects.into_bits();
-            std::cmp::Reverse(weight)
-        });
         // Make sure all keys exist in the parallel hashmap.
         for element in &elements {
             self.buckets
@@ -143,6 +132,17 @@ impl ParetoFront {
             .into_par_iter()
             .with_max_len(1)
             .map(|(key, mut elements)| {
+                // Sort elements in a way that ensures an element cannot be dominated
+                // by another element that comes later in the list.
+                elements.sort_unstable_by_key(|element| {
+                    let state = to_state(element);
+                    let weight = u64::from(state.cp)
+                        + u64::from(state.durability)
+                        + u64::from(state.quality)
+                        + u64::from(state.unreliable_quality)
+                        + state.effects.into_bits();
+                    std::cmp::Reverse(weight)
+                });
                 let mut root_node = self.buckets.get(&key).unwrap().lock().unwrap();
                 elements.retain(|element| Self::insert(to_state(element), &mut root_node));
                 elements

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -124,18 +124,29 @@ impl ParetoFront {
                 + state.effects.into_bits();
             std::cmp::Reverse(weight)
         });
-        // Group elements by their key to reduce contention in the parallel hashmap.
-        let mut elements_by_key: FxHashMap<Key, Vec<T>> = FxHashMap::default();
+        // Make sure all keys exist in the parallel hashmap.
+        for element in &elements {
+            self.buckets
+                .entry(Key::from(to_state(element)))
+                .or_default();
+        }
+        // Group elements by their shard to reduce contention in the parallel hashmap.
+        let mut elements_by_shard: FxHashMap<usize, Vec<T>> = FxHashMap::default();
         for element in elements {
             let key = Key::from(to_state(&element));
-            elements_by_key.entry(key).or_default().push(element);
+            let hash = self.buckets.hash_usize(&key);
+            let shard = self.buckets.determine_shard(hash);
+            elements_by_shard.entry(shard).or_default().push(element);
         }
         // Update pareto front and return non-dominated elements.
-        let non_dominated_elements = elements_by_key
+        let non_dominated_elements = elements_by_shard
             .into_par_iter()
-            .map(|(key, mut elements)| {
-                let mut root_node = self.buckets.entry(key).or_default();
-                elements.retain(|element| Self::insert(to_state(element), root_node.value_mut()));
+            .map(|(_shard, mut elements)| {
+                elements.retain(|element| {
+                    let key = Key::from(to_state(element));
+                    let mut root_node = self.buckets.entry(key).or_default();
+                    Self::insert(to_state(element), root_node.value_mut())
+                });
                 elements
             })
             .collect_vec_list();

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -114,12 +114,6 @@ impl ParetoFront {
         elements: Vec<T>,
         to_state: impl Fn(&T) -> &SimulationState + Sync,
     ) -> impl Iterator<Item = T> {
-        // Make sure all keys exist in the parallel hashmap.
-        for element in &elements {
-            self.buckets
-                .entry(Key::from(to_state(element)))
-                .or_default();
-        }
         // Group elements by their key to reduce contention in the hashmap.
         let mut elements_by_key: FxHashMap<Key, Vec<T>> = FxHashMap::default();
         for element in elements {
@@ -127,6 +121,10 @@ impl ParetoFront {
             elements_by_key.entry(key).or_default().push(element);
         }
         let elements_by_key = Vec::from_iter(elements_by_key.into_iter());
+        // Make sure all keys exist in the hashmap.
+        for (key, _elements) in &elements_by_key {
+            self.buckets.entry(*key).or_default();
+        }
         // Update pareto front and return non-dominated elements.
         let non_dominated_elements = elements_by_key
             .into_par_iter()

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -17,7 +17,7 @@ const EFFECTS_VALUE_MASK: u64 = Effects::new()
 
 const EFFECTS_KEY_MASK: u64 = !EFFECTS_VALUE_MASK;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct Key {
     progress: u16,
     effects: u64,
@@ -109,18 +109,30 @@ pub struct ParetoFront {
 impl ParetoFront {
     /// Inserts all non-dominated elements into the pareto front while also removing dominated values
     /// from the pareto front. Returns an iterator over elements that were inserted.
-    pub fn insert_batch<T: Send>(
+    pub fn insert_batch<T: Clone + Send + Sync>(
         &mut self,
-        elements: Vec<T>,
+        mut elements: Vec<T>,
         to_state: impl Fn(&T) -> &SimulationState + Sync,
     ) -> impl Iterator<Item = T> {
-        // Group elements by their key to reduce contention in the hashmap.
-        let mut elements_by_key: FxHashMap<Key, Vec<T>> = FxHashMap::default();
-        for element in elements {
-            let key = Key::from(to_state(&element));
-            elements_by_key.entry(key).or_default().push(element);
-        }
-        let elements_by_key = Vec::from_iter(elements_by_key);
+        // Group elements by their key to avoid contention in the hashmap.
+        let elements_by_key: Vec<(Key, &[T])> = {
+            let mut result = Vec::new();
+            elements.par_sort_unstable_by_key(|element| Key::from(to_state(element)));
+            let mut elements_slice = elements.as_slice();
+            for idx in (1..elements_slice.len()).rev() {
+                let lhs_key = Key::from(to_state(&elements_slice[idx - 1]));
+                let rhs_key = Key::from(to_state(&elements_slice[idx]));
+                if lhs_key != rhs_key {
+                    let rhs_slice = elements_slice.split_off(idx..).unwrap();
+                    result.push((rhs_key, rhs_slice));
+                }
+            }
+            if !elements_slice.is_empty() {
+                let key = Key::from(to_state(elements_slice.first().unwrap()));
+                result.push((key, elements_slice));
+            }
+            result
+        };
         // Make sure all keys exist in the hashmap.
         for (key, _elements) in &elements_by_key {
             self.buckets.entry(*key).or_default();
@@ -129,7 +141,9 @@ impl ParetoFront {
         let non_dominated_elements = elements_by_key
             .into_par_iter()
             .with_max_len(1)
-            .map(|(key, mut elements)| {
+            .map(|(key, elements)| {
+                // Copy elements into own Vec to prevent false sharing.
+                let mut elements = elements.to_vec();
                 // Sort elements in a way that ensures an element cannot be dominated
                 // by another element that comes later in the list.
                 elements.sort_unstable_by_key(|element| {

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -120,7 +120,7 @@ impl ParetoFront {
             let key = Key::from(to_state(&element));
             elements_by_key.entry(key).or_default().push(element);
         }
-        let elements_by_key = Vec::from_iter(elements_by_key.into_iter());
+        let elements_by_key = Vec::from_iter(elements_by_key);
         // Make sure all keys exist in the hashmap.
         for (key, _elements) in &elements_by_key {
             self.buckets.entry(*key).or_default();

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -1,7 +1,8 @@
-use dashmap::DashMap;
+use std::sync::Mutex;
+
 use raphael_sim::{Effects, SimulationState};
 use rayon::prelude::*;
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::FxHashMap;
 
 // It is important that this mask doesn't use any effect to its full bit range.
 // Otherwise, `Value::effect_dominates` will break.
@@ -102,7 +103,7 @@ impl Default for TreeNode {
 
 #[derive(Default)]
 pub struct ParetoFront {
-    buckets: DashMap<Key, TreeNode, FxBuildHasher>,
+    buckets: FxHashMap<Key, Mutex<TreeNode>>,
 }
 
 impl ParetoFront {
@@ -130,23 +131,20 @@ impl ParetoFront {
                 .entry(Key::from(to_state(element)))
                 .or_default();
         }
-        // Group elements by their shard to reduce contention in the parallel hashmap.
-        let mut elements_by_shard: FxHashMap<usize, Vec<T>> = FxHashMap::default();
+        // Group elements by their key to reduce contention in the hashmap.
+        let mut elements_by_key: FxHashMap<Key, Vec<T>> = FxHashMap::default();
         for element in elements {
             let key = Key::from(to_state(&element));
-            let hash = self.buckets.hash_usize(&key);
-            let shard = self.buckets.determine_shard(hash);
-            elements_by_shard.entry(shard).or_default().push(element);
+            elements_by_key.entry(key).or_default().push(element);
         }
+        let elements_by_key = Vec::from_iter(elements_by_key.into_iter());
         // Update pareto front and return non-dominated elements.
-        let non_dominated_elements = elements_by_shard
+        let non_dominated_elements = elements_by_key
             .into_par_iter()
-            .map(|(_shard, mut elements)| {
-                elements.retain(|element| {
-                    let key = Key::from(to_state(element));
-                    let mut root_node = self.buckets.entry(key).or_default();
-                    Self::insert(to_state(element), root_node.value_mut())
-                });
+            .with_max_len(1)
+            .map(|(key, mut elements)| {
+                let mut root_node = self.buckets.get(&key).unwrap().lock().unwrap();
+                elements.retain(|element| Self::insert(to_state(element), &mut root_node));
                 elements
             })
             .collect_vec_list();

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -159,8 +159,8 @@ impl ParetoFront {
                 elements.retain(|element| Self::insert(to_state(element), &mut root_node));
                 elements
             })
-            .collect_vec_list();
-        non_dominated_elements.into_iter().flatten().flatten()
+            .collect::<Vec<_>>();
+        non_dominated_elements.into_iter().flatten()
     }
 
     fn insert(state: &SimulationState, mut node: &mut TreeNode) -> bool {

--- a/raphael-solver/src/macro_solver/pareto_front.rs
+++ b/raphael-solver/src/macro_solver/pareto_front.rs
@@ -1,5 +1,7 @@
+use dashmap::DashMap;
 use raphael_sim::{Effects, SimulationState};
-use rustc_hash::FxHashMap;
+use rayon::prelude::*;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 // It is important that this mask doesn't use any effect to its full bit range.
 // Otherwise, `Value::effect_dominates` will break.
@@ -100,16 +102,16 @@ impl Default for TreeNode {
 
 #[derive(Default)]
 pub struct ParetoFront {
-    buckets: FxHashMap<Key, TreeNode>,
+    buckets: DashMap<Key, TreeNode, FxBuildHasher>,
 }
 
 impl ParetoFront {
     /// Inserts all non-dominated elements into the pareto front while also removing dominated values
     /// from the pareto front. Returns an iterator over elements that were inserted.
-    pub fn insert_batch<T>(
+    pub fn insert_batch<T: Send>(
         &mut self,
         mut elements: Vec<T>,
-        to_state: impl Fn(&T) -> &SimulationState,
+        to_state: impl Fn(&T) -> &SimulationState + Sync,
     ) -> impl Iterator<Item = T> {
         // Sort elements in a way that ensures an element cannot be dominated
         // by another element that comes later in the list.
@@ -122,15 +124,28 @@ impl ParetoFront {
                 + state.effects.into_bits();
             std::cmp::Reverse(weight)
         });
-        elements
-            .into_iter()
-            .filter(move |element| self.insert(to_state(element)))
+        // Group elements by their key to reduce contention in the parallel hashmap.
+        let mut elements_by_key: FxHashMap<Key, Vec<T>> = FxHashMap::default();
+        for element in elements {
+            let key = Key::from(to_state(&element));
+            elements_by_key.entry(key).or_default().push(element);
+        }
+        // Update pareto front and return non-dominated elements.
+        let non_dominated_elements = elements_by_key
+            .into_par_iter()
+            .map(|(key, mut elements)| {
+                let mut root_node = self.buckets.entry(key).or_default();
+                elements.retain(|element| Self::insert(to_state(element), root_node.value_mut()));
+                elements
+            })
+            .collect_vec_list();
+        non_dominated_elements.into_iter().flatten().flatten()
     }
 
-    fn insert(&mut self, state: &SimulationState) -> bool {
+    fn insert(state: &SimulationState, mut node: &mut TreeNode) -> bool {
         const MAX_LEAF_SIZE: usize = 200;
         let new_value = Value::from(state);
-        let mut node = self.buckets.entry(Key::from(state)).or_default();
+        // let mut node = self.buckets.entry(Key::from(state)).or_default();
         while let TreeNode::Intermediate(intermediate) = node {
             if new_value.cp() < intermediate.partition_point {
                 node = intermediate.lhs.as_mut();

--- a/raphael-solver/src/macro_solver/search_queue.rs
+++ b/raphael-solver/src/macro_solver/search_queue.rs
@@ -176,7 +176,7 @@ impl SearchQueue {
         if let Some(score) = self.batch_ordering.pop_last()
             && let Some(batch) = self.batches.remove(&score)
         {
-            let mut batch = batch
+            let batch = batch
                 .into_iter()
                 .map(|candidate_node| {
                     let parent_node_state =
@@ -192,21 +192,20 @@ impl SearchQueue {
                         state: candidate_node_state.unwrap(),
                     }
                 })
-                .collect::<Vec<_>>();
+                .collect();
             // Filter out Pareto-dominated nodes.
-            batch.sort_unstable_by(|lhs, rhs| {
-                pareto_weight(rhs.state()).cmp(&pareto_weight(lhs.state()))
-            });
-            batch.retain(|node| self.pareto_front.insert(*node.state()));
-            // Construct the returned batch.
+            let old_len = self.visited_nodes.len();
+            self.visited_nodes
+                .extend(self.pareto_front.insert_batch(batch, VisitedNode::state));
             // Each node in the returned batch tracks its own idx, not the idx of its parent.
-            let ret = batch
+            let nodes = self
+                .visited_nodes
                 .iter()
                 .enumerate()
-                .map(|(idx, node)| (*node.state(), self.visited_nodes.len() + idx))
+                .skip(old_len)
+                .map(|(idx, node)| (*node.state(), idx))
                 .collect::<Vec<_>>();
-            self.visited_nodes.extend(batch);
-            Some(Batch { score, nodes: ret })
+            Some(Batch { score, nodes })
         } else {
             None
         }
@@ -230,12 +229,4 @@ impl SearchQueue {
             processed_nodes: self.visited_nodes.len(),
         }
     }
-}
-
-fn pareto_weight(state: &SimulationState) -> u64 {
-    u64::from(state.cp)
-        + u64::from(state.durability)
-        + u64::from(state.quality)
-        + u64::from(state.unreliable_quality)
-        + state.effects.into_bits()
 }

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -354,8 +354,8 @@ fn issue_216_steplbsolver_crash() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 436353,
-                processed_nodes: 21746,
+                inserted_nodes: 436375,
+                processed_nodes: 21747,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 9851,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -359,8 +359,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 431853,
-                processed_nodes: 70823,
+                inserted_nodes: 431803,
+                processed_nodes: 70815,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -373,8 +373,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 943777,
-                states_on_shards: 274380,
-                values: 14294761,
+                states_on_shards: 274390,
+                values: 14294760,
             },
         }
     "#]];
@@ -639,8 +639,8 @@ fn black_star_4048_3997() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 146206,
-                processed_nodes: 10246,
+                inserted_nodes: 146191,
+                processed_nodes: 10245,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3248,
@@ -693,8 +693,8 @@ fn claro_walnut_lumber_4900_4800() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 503314,
-                processed_nodes: 28602,
+                inserted_nodes: 503224,
+                processed_nodes: 28597,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 8079,
@@ -909,8 +909,8 @@ fn hardened_survey_plank_5558_5216() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1228731,
-                processed_nodes: 172652,
+                inserted_nodes: 1228859,
+                processed_nodes: 172661,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3619,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -359,8 +359,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 431840,
-                processed_nodes: 70818,
+                inserted_nodes: 431853,
+                processed_nodes: 70823,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -639,8 +639,8 @@ fn black_star_4048_3997() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 146191,
-                processed_nodes: 10245,
+                inserted_nodes: 146206,
+                processed_nodes: 10246,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3248,
@@ -693,8 +693,8 @@ fn claro_walnut_lumber_4900_4800() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 503332,
-                processed_nodes: 28603,
+                inserted_nodes: 503314,
+                processed_nodes: 28602,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 8079,
@@ -909,8 +909,8 @@ fn hardened_survey_plank_5558_5216() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1228817,
-                processed_nodes: 172660,
+                inserted_nodes: 1228731,
+                processed_nodes: 172652,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3619,

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -359,8 +359,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 431803,
-                processed_nodes: 70815,
+                inserted_nodes: 431806,
+                processed_nodes: 70816,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -693,8 +693,8 @@ fn claro_walnut_lumber_4900_4800() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 503224,
-                processed_nodes: 28597,
+                inserted_nodes: 503314,
+                processed_nodes: 28602,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 8079,
@@ -909,8 +909,8 @@ fn hardened_survey_plank_5558_5216() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1228859,
-                processed_nodes: 172661,
+                inserted_nodes: 1228940,
+                processed_nodes: 172691,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3619,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -359,8 +359,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 13407853,
-                processed_nodes: 1597664,
+                inserted_nodes: 13408035,
+                processed_nodes: 1597684,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -909,8 +909,8 @@ fn hardened_survey_plank_5558_5216() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 18326404,
-                processed_nodes: 2024178,
+                inserted_nodes: 18326527,
+                processed_nodes: 2024196,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3619,
@@ -1129,8 +1129,8 @@ fn ce_stellar_steady_hand() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1586490,
-                processed_nodes: 366681,
+                inserted_nodes: 1586537,
+                processed_nodes: 366678,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 10207,
@@ -1184,8 +1184,8 @@ fn ce_stellar_steady_hand_2() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1459060,
-                processed_nodes: 151392,
+                inserted_nodes: 1458986,
+                processed_nodes: 151383,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 16581,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -359,8 +359,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 13408325,
-                processed_nodes: 1597721,
+                inserted_nodes: 13407853,
+                processed_nodes: 1597664,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -909,8 +909,8 @@ fn hardened_survey_plank_5558_5216() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 18326528,
-                processed_nodes: 2024199,
+                inserted_nodes: 18326404,
+                processed_nodes: 2024178,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3619,
@@ -1129,8 +1129,8 @@ fn ce_stellar_steady_hand() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1586569,
-                processed_nodes: 366686,
+                inserted_nodes: 1586490,
+                processed_nodes: 366681,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 10207,
@@ -1184,8 +1184,8 @@ fn ce_stellar_steady_hand_2() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1459036,
-                processed_nodes: 151387,
+                inserted_nodes: 1459060,
+                processed_nodes: 151392,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 16581,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -359,8 +359,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 13407968,
-                processed_nodes: 1597673,
+                inserted_nodes: 13408325,
+                processed_nodes: 1597721,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -909,8 +909,8 @@ fn hardened_survey_plank_5558_5216() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 18326484,
-                processed_nodes: 2024194,
+                inserted_nodes: 18326528,
+                processed_nodes: 2024199,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3619,
@@ -1129,8 +1129,8 @@ fn ce_stellar_steady_hand() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1586508,
-                processed_nodes: 366678,
+                inserted_nodes: 1586569,
+                processed_nodes: 366686,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 10207,
@@ -1184,8 +1184,8 @@ fn ce_stellar_steady_hand_2() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1459023,
-                processed_nodes: 151388,
+                inserted_nodes: 1459036,
+                processed_nodes: 151387,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 16581,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -102,8 +102,8 @@ fn stuffed_peppers() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1805931,
-                processed_nodes: 85851,
+                inserted_nodes: 1810685,
+                processed_nodes: 86079,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -116,8 +116,8 @@ fn stuffed_peppers() {
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 366835,
-                states_on_shards: 304745,
-                values: 12130837,
+                states_on_shards: 304684,
+                values: 12130167,
             },
         }
     "#]];
@@ -158,8 +158,8 @@ fn test_rare_tacos_2() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 9017765,
-                processed_nodes: 3802137,
+                inserted_nodes: 9011521,
+                processed_nodes: 3800093,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -172,8 +172,8 @@ fn test_rare_tacos_2() {
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 878246,
-                states_on_shards: 281501,
-                values: 27872037,
+                states_on_shards: 281376,
+                values: 27870537,
             },
         }
     "#]];
@@ -218,8 +218,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 485650,
-                processed_nodes: 33232,
+                inserted_nodes: 485937,
+                processed_nodes: 33248,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 798,
@@ -227,8 +227,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1800421,
-                states_on_shards: 42365,
-                values: 16756707,
+                states_on_shards: 42372,
+                values: 16756728,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 28922,
@@ -330,8 +330,8 @@ fn test_rare_tacos_4628_4410() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 4883348,
-                processed_nodes: 1056010,
+                inserted_nodes: 4868783,
+                processed_nodes: 1055110,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 2966,
@@ -344,8 +344,8 @@ fn test_rare_tacos_4628_4410() {
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 213458,
-                states_on_shards: 36392,
-                values: 5821862,
+                states_on_shards: 36388,
+                values: 5821779,
             },
         }
     "#]];
@@ -387,8 +387,8 @@ fn issue_113() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 22700860,
-                processed_nodes: 1410202,
+                inserted_nodes: 22699558,
+                processed_nodes: 1410125,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 13977,
@@ -442,8 +442,8 @@ fn issue_118() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 19000122,
-                processed_nodes: 1375899,
+                inserted_nodes: 19011500,
+                processed_nodes: 1376562,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3619,
@@ -451,13 +451,13 @@ fn issue_118() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1930860,
-                states_on_shards: 61635,
-                values: 25588434,
+                states_on_shards: 61634,
+                values: 25588419,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 100860,
-                states_on_shards: 61743,
-                values: 1868004,
+                states_on_shards: 61737,
+                values: 1867959,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -102,8 +102,8 @@ fn stuffed_peppers() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1799797,
-                processed_nodes: 85547,
+                inserted_nodes: 1805931,
+                processed_nodes: 85851,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -116,8 +116,8 @@ fn stuffed_peppers() {
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 366835,
-                states_on_shards: 304804,
-                values: 12131887,
+                states_on_shards: 304745,
+                values: 12130837,
             },
         }
     "#]];
@@ -158,8 +158,8 @@ fn test_rare_tacos_2() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 9023119,
-                processed_nodes: 3803810,
+                inserted_nodes: 9017765,
+                processed_nodes: 3802137,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -172,8 +172,8 @@ fn test_rare_tacos_2() {
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 878246,
-                states_on_shards: 281508,
-                values: 27872224,
+                states_on_shards: 281501,
+                values: 27872037,
             },
         }
     "#]];
@@ -218,8 +218,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 485744,
-                processed_nodes: 33222,
+                inserted_nodes: 485650,
+                processed_nodes: 33232,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 798,
@@ -227,7 +227,7 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1800421,
-                states_on_shards: 42370,
+                states_on_shards: 42365,
                 values: 16756707,
             },
             step_lb_stats: StepLbSolverStats {
@@ -330,8 +330,8 @@ fn test_rare_tacos_4628_4410() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 4886370,
-                processed_nodes: 1056176,
+                inserted_nodes: 4883348,
+                processed_nodes: 1056010,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 2966,
@@ -387,8 +387,8 @@ fn issue_113() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 22700001,
-                processed_nodes: 1410146,
+                inserted_nodes: 22700860,
+                processed_nodes: 1410202,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 13977,
@@ -442,8 +442,8 @@ fn issue_118() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 18988662,
-                processed_nodes: 1375109,
+                inserted_nodes: 19000122,
+                processed_nodes: 1375899,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3619,
@@ -451,13 +451,13 @@ fn issue_118() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1930860,
-                states_on_shards: 61633,
-                values: 25588399,
+                states_on_shards: 61635,
+                values: 25588434,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 100860,
-                states_on_shards: 61737,
-                values: 1867959,
+                states_on_shards: 61743,
+                values: 1868004,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -102,8 +102,8 @@ fn stuffed_peppers() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1810685,
-                processed_nodes: 86079,
+                inserted_nodes: 1806300,
+                processed_nodes: 85863,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -116,8 +116,8 @@ fn stuffed_peppers() {
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 366835,
-                states_on_shards: 304684,
-                values: 12130167,
+                states_on_shards: 304801,
+                values: 12131882,
             },
         }
     "#]];
@@ -158,8 +158,8 @@ fn test_rare_tacos_2() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 9011521,
-                processed_nodes: 3800093,
+                inserted_nodes: 9016822,
+                processed_nodes: 3801980,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 15891,
@@ -172,8 +172,8 @@ fn test_rare_tacos_2() {
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 878246,
-                states_on_shards: 281376,
-                values: 27870537,
+                states_on_shards: 281647,
+                values: 27873987,
             },
         }
     "#]];
@@ -218,8 +218,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 485937,
-                processed_nodes: 33248,
+                inserted_nodes: 484906,
+                processed_nodes: 33166,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 798,
@@ -227,8 +227,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1800421,
-                states_on_shards: 42372,
-                values: 16756728,
+                states_on_shards: 42373,
+                values: 16756719,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 28922,
@@ -330,8 +330,8 @@ fn test_rare_tacos_4628_4410() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 4868783,
-                processed_nodes: 1055110,
+                inserted_nodes: 4881826,
+                processed_nodes: 1055885,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 2966,
@@ -344,8 +344,8 @@ fn test_rare_tacos_4628_4410() {
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 213458,
-                states_on_shards: 36388,
-                values: 5821779,
+                states_on_shards: 36392,
+                values: 5821840,
             },
         }
     "#]];
@@ -387,8 +387,8 @@ fn issue_113() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 22699558,
-                processed_nodes: 1410125,
+                inserted_nodes: 22701824,
+                processed_nodes: 1410264,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 13977,
@@ -442,8 +442,8 @@ fn issue_118() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 19011500,
-                processed_nodes: 1376562,
+                inserted_nodes: 18992408,
+                processed_nodes: 1375324,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 3619,
@@ -451,8 +451,8 @@ fn issue_118() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1930860,
-                states_on_shards: 61634,
-                values: 25588419,
+                states_on_shards: 61637,
+                values: 25588473,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 100860,


### PR DESCRIPTION
Candidate nodes are sorted into groups of nodes with the same bucket key, then groups are checked for Pareto-dominance parallel to each other.

The change in node count in the tests is due to slight change in node visit order.