### PR TITLE
Use thread-local `ParetoFrontBuilder` during inner solver precompute

### DIFF
--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use crate::{
     SolverException, SolverSettings,
     actions::FULL_SEARCH_ACTIONS,
@@ -10,6 +12,10 @@ use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use rustc_hash::FxHashMap;
 
 use super::state::ReducedState;
+
+thread_local! {
+    static THREAD_LOCAL_PF_BUILDER: RefCell<ParetoFrontBuilder> = const { RefCell::new(ParetoFrontBuilder::new()) };
+}
 
 #[derive(Debug, Clone)]
 struct QualityUbSolverContext {
@@ -170,9 +176,8 @@ impl QualityUbSolver {
                         .filter_map(|template| {
                             template.instantiate(cp).map(|state| (template, state))
                         })
-                        .map_init(
-                            ParetoFrontBuilder::new,
-                            |pf_builder, (template, state)| -> Result<_, SolverException> {
+                        .map(|(template, state)| -> Result<_, SolverException> {
+                            THREAD_LOCAL_PF_BUILDER.with_borrow_mut(|pf_builder| {
                                 let pareto_front =
                                     self.solve_precompute_state(pf_builder, state)?;
                                 let template_is_maximal = {
@@ -190,8 +195,8 @@ impl QualityUbSolver {
                                     template.required_cp_for_max_progress_and_quality = Some(cp);
                                 }
                                 Ok((state, pareto_front))
-                            },
-                        )
+                            })
+                        })
                         .collect::<Result<Vec<_>, SolverException>>()?;
                     self.solved_states.extend(solved_states);
                 }
@@ -276,7 +281,8 @@ impl<'a> QualityUbSolverShard<'a> {
     ) -> Result<u16, SolverException> {
         let mut required_progress = self.context.settings.max_progress() - state.progress;
         if state.effects.muscle_memory() != 0 {
-            // Assume MuscleMemory can be used to its max potential and remove the effect to reduce the number of states that need to be solved.
+            // Assume MuscleMemory can be used to its max potential and remove the effect to reduce
+            // the number of states that need to be solved.
             required_progress =
                 required_progress.saturating_sub(self.context.largest_progress_increase);
             state.effects.set_muscle_memory(0);

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     num::{NonZero, NonZeroU8},
     ops::Deref,
 };
@@ -18,6 +19,10 @@ use super::state::ReducedState;
 
 type NonEmptyParetoFront = nunny::Slice<ParetoValue>;
 type SolvedStates = FxHashMap<ReducedState, Box<NonEmptyParetoFront>>;
+
+thread_local! {
+    static THREAD_LOCAL_PF_BUILDER: RefCell<ParetoFrontBuilder> = const { RefCell::new(ParetoFrontBuilder::new()) };
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct StepLbSolverStats {
@@ -348,14 +353,13 @@ fn solve_state_parallel<'a>(
             let get_solution = |state| solved_states.get(&state);
             current_batch
                 .par_iter()
-                .map_init(
-                    ParetoFrontBuilder::new,
-                    |pf_builder, state| -> Result<_, SolverException> {
+                .map(|state| -> Result<_, SolverException> {
+                    THREAD_LOCAL_PF_BUILDER.with_borrow_mut(|pf_builder| {
                         let solution =
                             construct_solution(*state, context, pf_builder, get_solution)?;
                         Ok((*state, solution))
-                    },
-                )
+                    })
+                })
                 .collect::<Result<Vec<_>, SolverException>>()?
         };
         solved_states.extend(current_batch_solutions);

--- a/raphael-solver/src/utils/pareto_front_builder.rs
+++ b/raphael-solver/src/utils/pareto_front_builder.rs
@@ -24,7 +24,7 @@ pub struct ParetoFrontBuilder {
 }
 
 impl ParetoFrontBuilder {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             cutoff: ParetoValue::new(u16::MAX, u16::MAX),
             result: Vec::new(),


### PR DESCRIPTION
The goal is to reuse the same `ParetoFrontBuilder` instance as much as possible to reuse already allocated memory during merge operations. The reuse was previously implemented using rayon's `map_init`, but it had a limitation of only sharing the same `ParetoFrontBuilder` instance within a batch, not across batches.

This change should speed up the precompute stage for `QualityUbSolver` and `StepLbSolver`.