### PR TITLE
Use bump allocator for `QualityUbSolver` and `StepLbSolver`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "allocator-api2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
+
+[[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +559,17 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bump-scope"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cc7ed7bc865061d84b6c54280822da1e07ce6bb614cf9af9f38b64f8cedee52"
+dependencies = [
+ "allocator-api2 0.2.21",
+ "allocator-api2 0.3.1",
+ "allocator-api2 0.4.0",
 ]
 
 [[package]]
@@ -1807,7 +1830,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.2.0",
 ]
@@ -3483,6 +3506,7 @@ name = "raphael-solver"
 version = "0.0.0"
 dependencies = [
  "bitfield-struct",
+ "bump-scope",
  "env_logger",
  "expect-test",
  "log",

--- a/raphael-solver/Cargo.toml
+++ b/raphael-solver/Cargo.toml
@@ -20,6 +20,7 @@ wide = "0.8.2"
 nunny = "0.2.2"
 strum = "0.27"
 smallvec = { version = "1.15.1", features = ["const_generics", "union"] }
+bump-scope = "2.2.0"
 
 [features]
 serde = ["dep:serde", "raphael-sim/serde"]

--- a/raphael-solver/src/finish_solver.rs
+++ b/raphael-solver/src/finish_solver.rs
@@ -51,7 +51,7 @@ impl CpProgressBreakpoints {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct FinishSolverStats {
     pub states: usize,
     pub values: usize,

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -46,7 +46,6 @@ pub struct MacroSolver<'a> {
     solution_callback: Box<SolutionCallback<'a>>,
     progress_callback: Box<ProgressCallback<'a>>,
     finish_solver: FinishSolver,
-    quality_ub_solver: QualityUbSolver,
     interrupt_signal: AtomicFlag,
     last_solve_runtime_stats: MacroSolverStats,
 }
@@ -63,20 +62,23 @@ impl<'a> MacroSolver<'a> {
             solution_callback,
             progress_callback,
             finish_solver: FinishSolver::new(settings),
-            quality_ub_solver: QualityUbSolver::new(settings, interrupt_signal.clone()),
             interrupt_signal,
             last_solve_runtime_stats: MacroSolverStats::default(),
         }
     }
 
     pub fn solve(&mut self) -> Result<Vec<Action>, SolverException> {
-        self.last_solve_runtime_stats = MacroSolverStats::default();
-        let allocator = BumpPool::default();
-
         log::debug!(
             "rayon::current_num_threads() = {}",
             rayon::current_num_threads()
         );
+
+        self.last_solve_runtime_stats = MacroSolverStats::default();
+        let allocator = BumpPool::default();
+        let mut quality_ub_solver =
+            QualityUbSolver::new(self.settings, self.interrupt_signal.clone(), &allocator);
+        let mut step_lb_solver =
+            StepLbSolver::new(self.settings, self.interrupt_signal.clone(), &allocator);
 
         let _total_time = ScopedTimer::new("Total Time");
 
@@ -91,17 +93,17 @@ impl<'a> MacroSolver<'a> {
         drop(timer);
 
         let timer = ScopedTimer::new("Quality UB Solver");
-        self.quality_ub_solver.precompute()?;
+        quality_ub_solver.precompute()?;
         drop(timer);
 
-        let mut step_lb_solver =
-            StepLbSolver::new(self.settings, self.interrupt_signal.clone(), &allocator);
         let timer = ScopedTimer::new("Step LB Solver");
         step_lb_solver.precompute()?;
         drop(timer);
 
         let timer = ScopedTimer::new("Search");
-        let actions = self.do_solve(&mut step_lb_solver, initial_state)?.actions();
+        let actions = self
+            .do_solve(&mut quality_ub_solver, &mut step_lb_solver, initial_state)?
+            .actions();
         drop(timer);
 
         log::debug!("{:?}", self.runtime_stats());
@@ -109,9 +111,10 @@ impl<'a> MacroSolver<'a> {
         Ok(actions)
     }
 
-    fn do_solve(
+    fn do_solve<'alloc>(
         &mut self,
-        step_lb_solver: &mut StepLbSolver,
+        quality_ub_solver: &mut QualityUbSolver<'alloc>,
+        step_lb_solver: &mut StepLbSolver<'alloc>,
         state: SimulationState,
     ) -> Result<Solution, SolverException> {
         let mut search_queue = SearchQueue::new(self.settings, state);
@@ -131,7 +134,7 @@ impl<'a> MacroSolver<'a> {
             let create_worker_data = || WorkerData {
                 settings: &self.settings,
                 finish_solver: &self.finish_solver,
-                quality_ub_solver_shard: self.quality_ub_solver.create_shard(),
+                quality_ub_solver_shard: quality_ub_solver.create_shard(),
                 step_lb_solver_shard: step_lb_solver.create_shard(),
                 min_accepted_score,
                 candidate_states: Vec::new(),
@@ -188,7 +191,7 @@ impl<'a> MacroSolver<'a> {
                 })
                 .collect::<Vec<_>>();
             for solved_states in solved_states_per_worker {
-                self.quality_ub_solver.extend_solved_states(solved_states.0);
+                quality_ub_solver.extend_solved_states(solved_states.0);
                 step_lb_solver.extend_solved_states(solved_states.1);
             }
 
@@ -198,7 +201,7 @@ impl<'a> MacroSolver<'a> {
         self.last_solve_runtime_stats = MacroSolverStats {
             search_queue_stats: search_queue.runtime_stats(),
             finish_solver_stats: self.finish_solver.runtime_stats(),
-            quality_ub_stats: self.quality_ub_solver.runtime_stats(),
+            quality_ub_stats: quality_ub_solver.runtime_stats(),
             step_lb_stats: step_lb_solver.runtime_stats(),
         };
 
@@ -213,7 +216,7 @@ impl<'a> MacroSolver<'a> {
 struct WorkerData<'main, 'alloc> {
     settings: &'main SolverSettings,
     finish_solver: &'main FinishSolver,
-    quality_ub_solver_shard: QualityUbSolverShard<'main>,
+    quality_ub_solver_shard: QualityUbSolverShard<'main, 'alloc>,
     step_lb_solver_shard: StepLbSolverShard<'main, 'alloc>,
     min_accepted_score: SearchScore,
     candidate_states: Vec<(SimulationState, SearchScore, ActionCombo, usize)>,

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -1,3 +1,4 @@
+use bump_scope::BumpPool;
 use raphael_sim::*;
 use rayon::prelude::*;
 
@@ -32,7 +33,7 @@ impl Solution {
 type SolutionCallback<'a> = dyn Fn(&[Action]) + 'a;
 type ProgressCallback<'a> = dyn Fn(usize) + 'a;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct MacroSolverStats {
     pub search_queue_stats: SearchQueueStats,
     pub finish_solver_stats: FinishSolverStats,
@@ -46,9 +47,8 @@ pub struct MacroSolver<'a> {
     progress_callback: Box<ProgressCallback<'a>>,
     finish_solver: FinishSolver,
     quality_ub_solver: QualityUbSolver,
-    step_lb_solver: StepLbSolver,
-    search_queue_stats: SearchQueueStats, // stats of last solve
     interrupt_signal: AtomicFlag,
+    last_solve_runtime_stats: MacroSolverStats,
 }
 
 impl<'a> MacroSolver<'a> {
@@ -64,13 +64,15 @@ impl<'a> MacroSolver<'a> {
             progress_callback,
             finish_solver: FinishSolver::new(settings),
             quality_ub_solver: QualityUbSolver::new(settings, interrupt_signal.clone()),
-            step_lb_solver: StepLbSolver::new(settings, interrupt_signal.clone()),
-            search_queue_stats: SearchQueueStats::default(),
             interrupt_signal,
+            last_solve_runtime_stats: MacroSolverStats::default(),
         }
     }
 
     pub fn solve(&mut self) -> Result<Vec<Action>, SolverException> {
+        self.last_solve_runtime_stats = MacroSolverStats::default();
+        let allocator = BumpPool::default();
+
         log::debug!(
             "rayon::current_num_threads() = {}",
             rayon::current_num_threads()
@@ -83,6 +85,7 @@ impl<'a> MacroSolver<'a> {
         let timer = ScopedTimer::new("Finish Solver");
         self.finish_solver.precompute()?;
         if !self.finish_solver.can_finish(&initial_state)? {
+            self.last_solve_runtime_stats.finish_solver_stats = self.finish_solver.runtime_stats();
             return Err(SolverException::NoSolution);
         }
         drop(timer);
@@ -91,12 +94,14 @@ impl<'a> MacroSolver<'a> {
         self.quality_ub_solver.precompute()?;
         drop(timer);
 
+        let mut step_lb_solver =
+            StepLbSolver::new(self.settings, self.interrupt_signal.clone(), &allocator);
         let timer = ScopedTimer::new("Step LB Solver");
-        self.step_lb_solver.precompute()?;
+        step_lb_solver.precompute()?;
         drop(timer);
 
         let timer = ScopedTimer::new("Search");
-        let actions = self.do_solve(initial_state)?.actions();
+        let actions = self.do_solve(&mut step_lb_solver, initial_state)?.actions();
         drop(timer);
 
         log::debug!("{:?}", self.runtime_stats());
@@ -104,7 +109,11 @@ impl<'a> MacroSolver<'a> {
         Ok(actions)
     }
 
-    fn do_solve(&mut self, state: SimulationState) -> Result<Solution, SolverException> {
+    fn do_solve(
+        &mut self,
+        step_lb_solver: &mut StepLbSolver,
+        state: SimulationState,
+    ) -> Result<Solution, SolverException> {
         let mut search_queue = SearchQueue::new(self.settings, state);
         let mut solution: Option<Solution> = None;
         let mut min_accepted_score = SearchScore::MIN;
@@ -123,7 +132,7 @@ impl<'a> MacroSolver<'a> {
                 settings: &self.settings,
                 finish_solver: &self.finish_solver,
                 quality_ub_solver_shard: self.quality_ub_solver.create_shard(),
-                step_lb_solver_shard: self.step_lb_solver.create_shard(),
+                step_lb_solver_shard: step_lb_solver.create_shard(),
                 min_accepted_score,
                 candidate_states: Vec::new(),
             };
@@ -180,36 +189,37 @@ impl<'a> MacroSolver<'a> {
                 .collect::<Vec<_>>();
             for solved_states in solved_states_per_worker {
                 self.quality_ub_solver.extend_solved_states(solved_states.0);
-                self.step_lb_solver.extend_solved_states(solved_states.1);
+                step_lb_solver.extend_solved_states(solved_states.1);
             }
 
             (self.progress_callback)(search_queue.runtime_stats().processed_nodes);
         }
 
-        self.search_queue_stats = search_queue.runtime_stats();
+        self.last_solve_runtime_stats = MacroSolverStats {
+            search_queue_stats: search_queue.runtime_stats(),
+            finish_solver_stats: self.finish_solver.runtime_stats(),
+            quality_ub_stats: self.quality_ub_solver.runtime_stats(),
+            step_lb_stats: step_lb_solver.runtime_stats(),
+        };
+
         solution.ok_or(SolverException::NoSolution)
     }
 
     pub fn runtime_stats(&self) -> MacroSolverStats {
-        MacroSolverStats {
-            search_queue_stats: self.search_queue_stats,
-            finish_solver_stats: self.finish_solver.runtime_stats(),
-            quality_ub_stats: self.quality_ub_solver.runtime_stats(),
-            step_lb_stats: self.step_lb_solver.runtime_stats(),
-        }
+        self.last_solve_runtime_stats
     }
 }
 
-struct WorkerData<'a> {
-    settings: &'a SolverSettings,
-    finish_solver: &'a FinishSolver,
-    quality_ub_solver_shard: QualityUbSolverShard<'a>,
-    step_lb_solver_shard: StepLbSolverShard<'a>,
+struct WorkerData<'main, 'alloc> {
+    settings: &'main SolverSettings,
+    finish_solver: &'main FinishSolver,
+    quality_ub_solver_shard: QualityUbSolverShard<'main>,
+    step_lb_solver_shard: StepLbSolverShard<'main, 'alloc>,
     min_accepted_score: SearchScore,
     candidate_states: Vec<(SimulationState, SearchScore, ActionCombo, usize)>,
 }
 
-impl<'a> WorkerData<'a> {
+impl<'main, 'alloc> WorkerData<'main, 'alloc> {
     fn update_min_score(&mut self, score: SearchScore) {
         self.min_accepted_score = std::cmp::max(self.min_accepted_score, score);
     }

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -12,15 +12,8 @@ use rustc_hash::FxHashMap;
 
 use super::state::ReducedState;
 
-#[derive(Clone)]
-struct QualityUbSolverContext<'alloc> {
-    settings: SolverSettings,
-    interrupt_signal: utils::AtomicFlag,
-    iq_quality_lut: [u16; 11],
-    durability_cost: u16,
-    largest_progress_increase: u16,
-    allocator: &'alloc BumpPool,
-}
+type ParetoFront = nunny::Slice<ParetoValue>;
+type SolvedStates<'alloc> = FxHashMap<ReducedState, &'alloc ParetoFront>;
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct QualityUbSolverStats {
@@ -29,8 +22,15 @@ pub struct QualityUbSolverStats {
     pub values: usize,
 }
 
-type ParetoFront = nunny::Slice<ParetoValue>;
-type SolvedStates<'alloc> = FxHashMap<ReducedState, &'alloc ParetoFront>;
+#[derive(Clone)]
+struct QualityUbSolverContext<'alloc> {
+    allocator: &'alloc BumpPool,
+    settings: SolverSettings,
+    interrupt_signal: utils::AtomicFlag,
+    iq_quality_lut: [u16; 11],
+    durability_cost: u16,
+    largest_progress_increase: u16,
+}
 
 pub struct QualityUbSolver<'alloc> {
     context: QualityUbSolverContext<'alloc>,
@@ -59,6 +59,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
         };
         Self {
             context: QualityUbSolverContext {
+                allocator,
                 settings,
                 interrupt_signal,
                 iq_quality_lut: utils::compute_iq_quality_lut(&settings),
@@ -66,7 +67,6 @@ impl<'alloc> QualityUbSolver<'alloc> {
                 largest_progress_increase: utils::maximum_muscle_memory_utilization(
                     &settings.simulator_settings,
                 ),
-                allocator,
             },
             solved_states: FxHashMap::default(),
             maximal_templates: FxHashMap::default(),
@@ -86,7 +86,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
             context: &self.context,
             maximal_templates: &self.maximal_templates,
             shared_states: &self.solved_states,
-            local_states: FxHashMap::default(),
+            local_states: SolvedStates::default(),
         }
     }
 
@@ -325,23 +325,24 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
             }
         }
 
-        let pareto_front = if let Some(pareto_front) = self.shared_states.get(&reduced_state).copied() {
-            pareto_front
-        } else if let Some(pareto_front) = self.local_states.get(&reduced_state).copied() {
-            pareto_front
-        } else {
-            let allocator = self.context.allocator.get();
-            self.solve_state(reduced_state, &allocator)?;
-            if let Some(pareto_front) = self.local_states.get(&reduced_state).copied() {
+        let pareto_front =
+            if let Some(pareto_front) = self.shared_states.get(&reduced_state).copied() {
+                pareto_front
+            } else if let Some(pareto_front) = self.local_states.get(&reduced_state).copied() {
                 pareto_front
             } else {
-                return Err(internal_error!(
-                    "State not found in memoization table after solve.",
-                    self.context.settings,
-                    reduced_state
-                ));
-            }
-        };
+                let allocator = self.context.allocator.get();
+                self.solve_state(reduced_state, &allocator)?;
+                if let Some(pareto_front) = self.local_states.get(&reduced_state).copied() {
+                    pareto_front
+                } else {
+                    return Err(internal_error!(
+                        "State not found in memoization table after solve.",
+                        self.context.settings,
+                        reduced_state
+                    ));
+                }
+            };
         let i = pareto_front.partition_point(|value| value.progress < required_progress);
         let quality = pareto_front
             .get(i)
@@ -383,9 +384,16 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
                         child_pareto_front
                     } else {
                         self.solve_state(child_state, allocator)?;
-                        self.local_states.get(&child_state).copied().ok_or(internal_error!(
-                            "State not found in memoization table after solving.",
-                        ))?
+                        self.local_states
+                            .get(&child_state)
+                            .copied()
+                            .ok_or_else(|| {
+                                internal_error!(
+                                    "State not found in memoization table after solving.",
+                                    self.context.settings,
+                                    child_state
+                                )
+                            })?
                     };
                     pareto_front_builder.push_slice(
                         child_pareto_front

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -5,19 +5,21 @@ use crate::{
     utils::{self, ParetoFrontBuilder, ParetoValue},
 };
 
+use bump_scope::{BumpPool, BumpPoolGuard};
 use raphael_sim::*;
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use rustc_hash::FxHashMap;
 
 use super::state::ReducedState;
 
-#[derive(Debug, Clone)]
-struct QualityUbSolverContext {
+#[derive(Clone)]
+struct QualityUbSolverContext<'alloc> {
     settings: SolverSettings,
     interrupt_signal: utils::AtomicFlag,
     iq_quality_lut: [u16; 11],
     durability_cost: u16,
     largest_progress_increase: u16,
+    allocator: &'alloc BumpPool,
 }
 
 #[derive(Default, Debug, Clone, Copy)]
@@ -27,24 +29,29 @@ pub struct QualityUbSolverStats {
     pub values: usize,
 }
 
-type SolvedStates = FxHashMap<ReducedState, Box<nunny::Slice<ParetoValue>>>;
+type ParetoFront<'alloc> = &'alloc nunny::Slice<ParetoValue>;
+type SolvedStates<'alloc> = FxHashMap<ReducedState, ParetoFront<'alloc>>;
 
-pub struct QualityUbSolver {
-    context: QualityUbSolverContext,
+pub struct QualityUbSolver<'alloc> {
+    context: QualityUbSolverContext<'alloc>,
     maximal_templates: FxHashMap<TemplateData, u16>,
-    solved_states: SolvedStates,
+    solved_states: SolvedStates<'alloc>,
     num_states_solved_on_shards: usize,
 }
 
-pub struct QualityUbSolverShard<'a> {
-    context: &'a QualityUbSolverContext,
-    maximal_templates: &'a FxHashMap<TemplateData, u16>,
-    shared_states: &'a SolvedStates,
-    local_states: SolvedStates,
+pub struct QualityUbSolverShard<'main, 'alloc> {
+    context: &'main QualityUbSolverContext<'alloc>,
+    maximal_templates: &'main FxHashMap<TemplateData, u16>,
+    shared_states: &'main SolvedStates<'alloc>,
+    local_states: SolvedStates<'alloc>,
 }
 
-impl QualityUbSolver {
-    pub fn new(mut settings: SolverSettings, interrupt_signal: utils::AtomicFlag) -> Self {
+impl<'alloc> QualityUbSolver<'alloc> {
+    pub fn new(
+        mut settings: SolverSettings,
+        interrupt_signal: utils::AtomicFlag,
+        allocator: &'alloc BumpPool,
+    ) -> Self {
         let durability_cost = durability_cost(&settings.simulator_settings);
         settings.simulator_settings.max_cp = {
             let initial_state = SimulationState::new(&settings.simulator_settings);
@@ -59,6 +66,7 @@ impl QualityUbSolver {
                 largest_progress_increase: utils::maximum_muscle_memory_utilization(
                     &settings.simulator_settings,
                 ),
+                allocator,
             },
             solved_states: FxHashMap::default(),
             maximal_templates: FxHashMap::default(),
@@ -66,14 +74,14 @@ impl QualityUbSolver {
         }
     }
 
-    pub fn extend_solved_states(&mut self, new_solved_states: SolvedStates) {
+    pub fn extend_solved_states(&mut self, new_solved_states: SolvedStates<'alloc>) {
         let len_before = self.solved_states.len();
         self.solved_states.extend(new_solved_states);
         let len_after = self.solved_states.len();
         self.num_states_solved_on_shards += len_after - len_before;
     }
 
-    pub fn create_shard(&self) -> QualityUbSolverShard<'_> {
+    pub fn create_shard<'main>(&'main self) -> QualityUbSolverShard<'main, 'alloc> {
         QualityUbSolverShard {
             context: &self.context,
             maximal_templates: &self.maximal_templates,
@@ -171,10 +179,12 @@ impl QualityUbSolver {
                             template.instantiate(cp).map(|state| (template, state))
                         })
                         .map_init(
-                            ParetoFrontBuilder::new,
-                            |pf_builder, (template, state)| -> Result<_, SolverException> {
+                            || (ParetoFrontBuilder::new(), self.context.allocator.get()),
+                            |(pf_builder, allocator),
+                             (template, state)|
+                             -> Result<_, SolverException> {
                                 let pareto_front =
-                                    self.solve_precompute_state(pf_builder, state)?;
+                                    self.solve_precompute_state(pf_builder, state, allocator)?;
                                 let template_is_maximal = {
                                     // A template is "maximal" if there is no benefit of solving it with higher CP
                                     let required_progress = self.context.settings.max_progress();
@@ -210,7 +220,8 @@ impl QualityUbSolver {
         &self,
         pf_builder: &mut ParetoFrontBuilder,
         state: ReducedState,
-    ) -> Result<Box<nunny::Slice<ParetoValue>>, SolverException> {
+        allocator: &BumpPoolGuard<'alloc>,
+    ) -> Result<ParetoFront<'alloc>, SolverException> {
         let cutoff = ParetoValue::new(
             self.context.settings.max_progress(),
             self.context.settings.max_quality().saturating_sub(
@@ -247,7 +258,10 @@ impl QualityUbSolver {
                 }
             }
         }
-        pf_builder.result().try_into().map_err(|_| {
+        let pareto_front = allocator
+            .alloc_slice_copy(pf_builder.result_as_slice())
+            .into_ref();
+        pareto_front.try_into().map_err(|_| {
             internal_error!(
                 "Empty precompute Pareto front.",
                 self.context.settings,
@@ -265,8 +279,8 @@ impl QualityUbSolver {
     }
 }
 
-impl<'a> QualityUbSolverShard<'a> {
-    pub fn solved_states(self) -> SolvedStates {
+impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
+    pub fn solved_states(self) -> SolvedStates<'alloc> {
         self.local_states
     }
 
@@ -316,7 +330,8 @@ impl<'a> QualityUbSolverShard<'a> {
         } else if let Some(pareto_front) = self.local_states.get(&reduced_state) {
             pareto_front
         } else {
-            self.solve_state(reduced_state)?;
+            let allocator = self.context.allocator.get();
+            self.solve_state(reduced_state, &allocator)?;
             if let Some(pareto_front) = self.local_states.get(&reduced_state) {
                 pareto_front
             } else {
@@ -334,7 +349,11 @@ impl<'a> QualityUbSolverShard<'a> {
         Ok(std::cmp::min(self.context.settings.max_quality(), quality))
     }
 
-    fn solve_state(&mut self, state: ReducedState) -> Result<(), SolverException> {
+    fn solve_state(
+        &mut self,
+        state: ReducedState,
+        allocator: &BumpPoolGuard<'alloc>,
+    ) -> Result<(), SolverException> {
         if self.context.interrupt_signal.is_set() {
             return Err(SolverException::Interrupted);
         }
@@ -361,7 +380,7 @@ impl<'a> QualityUbSolverShard<'a> {
                     } else if let Some(child_pareto_front) = self.local_states.get(&child_state) {
                         child_pareto_front
                     } else {
-                        self.solve_state(child_state)?;
+                        self.solve_state(child_state, allocator)?;
                         self.local_states.get(&child_state).ok_or(internal_error!(
                             "State not found in memoization table after solving.",
                         ))?
@@ -379,15 +398,17 @@ impl<'a> QualityUbSolverShard<'a> {
                 }
             }
         }
-
-        let pareto_front = pareto_front_builder.result().try_into().map_err(|_| {
+        let pareto_front = allocator
+            .alloc_slice_copy(pareto_front_builder.result_as_slice())
+            .into_ref();
+        let pareto_front = pareto_front.try_into().map_err(|_| {
             internal_error!(
                 "Solver produced empty Pareto front.",
                 self.context.settings,
                 state
             )
-        });
-        self.local_states.insert(state, pareto_front?);
+        })?;
+        self.local_states.insert(state, pareto_front);
         Ok(())
     }
 }

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -235,7 +235,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
             {
                 let action_value = ParetoValue::new(progress, quality);
                 if !new_state.is_final(self.context.durability_cost) {
-                    if let Some(pareto_front) = self.solved_states.get(&new_state) {
+                    if let Some(pareto_front) = self.solved_states.get(&new_state).copied() {
                         pf_builder.push_slice(
                             pareto_front
                                 .iter()
@@ -310,7 +310,7 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
                 cp: required_cp,
                 ..reduced_state
             };
-            if let Some(pareto_front) = self.shared_states.get(&reduced_state)
+            if let Some(pareto_front) = self.shared_states.get(&reduced_state).copied()
                 && pareto_front.first().progress >= required_progress
                 && pareto_front.first().quality.saturating_add(state.quality)
                     >= self.context.settings.max_quality()
@@ -325,14 +325,14 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
             }
         }
 
-        let pareto_front = if let Some(pareto_front) = self.shared_states.get(&reduced_state) {
+        let pareto_front = if let Some(pareto_front) = self.shared_states.get(&reduced_state).copied() {
             pareto_front
-        } else if let Some(pareto_front) = self.local_states.get(&reduced_state) {
+        } else if let Some(pareto_front) = self.local_states.get(&reduced_state).copied() {
             pareto_front
         } else {
             let allocator = self.context.allocator.get();
             self.solve_state(reduced_state, &allocator)?;
-            if let Some(pareto_front) = self.local_states.get(&reduced_state) {
+            if let Some(pareto_front) = self.local_states.get(&reduced_state).copied() {
                 pareto_front
             } else {
                 return Err(internal_error!(
@@ -374,14 +374,16 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
                 let action_value = ParetoValue::new(progress, quality);
                 if !child_state.is_final(self.context.durability_cost) {
                     let child_pareto_front = if let Some(child_pareto_front) =
-                        self.shared_states.get(&child_state)
+                        self.shared_states.get(&child_state).copied()
                     {
                         child_pareto_front
-                    } else if let Some(child_pareto_front) = self.local_states.get(&child_state) {
+                    } else if let Some(child_pareto_front) =
+                        self.local_states.get(&child_state).copied()
+                    {
                         child_pareto_front
                     } else {
                         self.solve_state(child_state, allocator)?;
-                        self.local_states.get(&child_state).ok_or(internal_error!(
+                        self.local_states.get(&child_state).copied().ok_or(internal_error!(
                             "State not found in memoization table after solving.",
                         ))?
                     };

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -20,7 +20,7 @@ struct QualityUbSolverContext {
     largest_progress_increase: u16,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct QualityUbSolverStats {
     pub states_on_main: usize,
     pub states_on_shards: usize,

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -29,8 +29,8 @@ pub struct QualityUbSolverStats {
     pub values: usize,
 }
 
-type ParetoFront<'alloc> = &'alloc nunny::Slice<ParetoValue>;
-type SolvedStates<'alloc> = FxHashMap<ReducedState, ParetoFront<'alloc>>;
+type ParetoFront = nunny::Slice<ParetoValue>;
+type SolvedStates<'alloc> = FxHashMap<ReducedState, &'alloc ParetoFront>;
 
 pub struct QualityUbSolver<'alloc> {
     context: QualityUbSolverContext<'alloc>,
@@ -221,7 +221,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
         pf_builder: &mut ParetoFrontBuilder,
         state: ReducedState,
         allocator: &BumpPoolGuard<'alloc>,
-    ) -> Result<ParetoFront<'alloc>, SolverException> {
+    ) -> Result<&'alloc ParetoFront, SolverException> {
         let cutoff = ParetoValue::new(
             self.context.settings.max_progress(),
             self.context.settings.max_quality().saturating_sub(

--- a/raphael-solver/src/quality_upper_bound_solver/tests.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/tests.rs
@@ -1,3 +1,4 @@
+use bump_scope::BumpPool;
 use raphael_sim::*;
 
 use crate::{
@@ -12,7 +13,8 @@ use super::QualityUbSolver;
 /// It is consistent if the step-lb of a parent state is never greater than the step-lb of a child state.
 /// It is admissible if the quality-ub of a state is never less than the quality of a reachable final state.
 fn check_consistency(solver_settings: SolverSettings) {
-    let mut solver = QualityUbSolver::new(solver_settings, Default::default());
+    let allocator = BumpPool::default();
+    let mut solver = QualityUbSolver::new(solver_settings, Default::default(), &allocator);
     solver.precompute().unwrap();
     let mut solver_shard = solver.create_shard();
     for state in generate_random_states(solver_settings, 1_000_000)

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -1,7 +1,4 @@
-use std::{
-    num::{NonZero, NonZeroU8},
-    ops::Deref,
-};
+use std::num::{NonZero, NonZeroU8};
 
 use crate::{
     SolverException, SolverSettings,
@@ -10,50 +7,57 @@ use crate::{
     utils::{self, ParetoFrontBuilder, ParetoValue, compute_iq_quality_lut},
 };
 
+use bump_scope::{BumpPool, BumpPoolGuard};
 use raphael_sim::*;
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::state::ReducedState;
 
-type NonEmptyParetoFront = nunny::Slice<ParetoValue>;
-type SolvedStates = FxHashMap<ReducedState, Box<NonEmptyParetoFront>>;
+type ParetoFront<'alloc> = &'alloc [ParetoValue];
+type SolvedStates<'alloc> = FxHashMap<ReducedState, ParetoFront<'alloc>>;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct StepLbSolverStats {
     pub states_on_main: usize,
     pub states_on_shards: usize,
     pub values: usize,
 }
 
-#[derive(Debug, Clone)]
-struct StepLbSolverContext {
+#[derive(Clone)]
+struct StepLbSolverContext<'alloc> {
+    allocator: &'alloc BumpPool,
     settings: SolverSettings,
     interrupt_signal: utils::AtomicFlag,
     iq_quality_lut: [u16; 11],
     largest_progress_increase: u16,
 }
 
-pub struct StepLbSolver {
-    context: StepLbSolverContext,
-    solved_states: SolvedStates,
+pub struct StepLbSolver<'alloc> {
+    context: StepLbSolverContext<'alloc>,
+    solved_states: SolvedStates<'alloc>,
     num_states_solved_on_shards: usize,
 }
 
-pub struct StepLbSolverShard<'a> {
-    context: &'a StepLbSolverContext,
-    shared_states: &'a SolvedStates,
-    local_states: SolvedStates,
+pub struct StepLbSolverShard<'main, 'alloc> {
+    context: &'main StepLbSolverContext<'alloc>,
+    shared_states: &'main SolvedStates<'alloc>,
+    local_states: SolvedStates<'alloc>,
     pf_builder: ParetoFrontBuilder,
 }
 
-impl StepLbSolver {
-    pub fn new(mut settings: SolverSettings, interrupt_signal: utils::AtomicFlag) -> Self {
+impl<'alloc> StepLbSolver<'alloc> {
+    pub fn new(
+        mut settings: SolverSettings,
+        interrupt_signal: utils::AtomicFlag,
+        allocator: &'alloc BumpPool,
+    ) -> Self {
         let iq_quality_lut = compute_iq_quality_lut(&settings);
         settings.simulator_settings.adversarial = false;
         ReducedState::optimize_action_mask(&mut settings.simulator_settings);
         Self {
             context: StepLbSolverContext {
+                allocator,
                 settings,
                 interrupt_signal,
                 iq_quality_lut,
@@ -66,7 +70,7 @@ impl StepLbSolver {
         }
     }
 
-    pub fn create_shard(&self) -> StepLbSolverShard<'_> {
+    pub fn create_shard<'main>(&'main self) -> StepLbSolverShard<'main, 'alloc> {
         StepLbSolverShard {
             context: &self.context,
             shared_states: &self.solved_states,
@@ -75,7 +79,7 @@ impl StepLbSolver {
         }
     }
 
-    pub fn extend_solved_states(&mut self, new_solved_states: SolvedStates) {
+    pub fn extend_solved_states(&mut self, new_solved_states: SolvedStates<'alloc>) {
         let len_before = self.solved_states.len();
         self.solved_states.extend(new_solved_states);
         let len_after = self.solved_states.len();
@@ -125,7 +129,7 @@ impl StepLbSolver {
             state.effects.set_muscle_memory(0);
         }
         let reduced_state = ReducedState::from_state(state, step_budget);
-        let pareto_front = if let Some(solution) = self.solved_states.get(&reduced_state) {
+        let pareto_front = if let Some(solution) = self.solved_states.get(&reduced_state).copied() {
             solution
         } else {
             solve_state_parallel(reduced_state, &self.context, &mut self.solved_states)?
@@ -144,8 +148,8 @@ impl StepLbSolver {
     }
 }
 
-impl<'a> StepLbSolverShard<'a> {
-    pub fn solved_states(self) -> SolvedStates {
+impl<'main, 'alloc> StepLbSolverShard<'main, 'alloc> {
+    pub fn solved_states(self) -> SolvedStates<'alloc> {
         self.local_states
     }
 
@@ -186,9 +190,9 @@ impl<'a> StepLbSolverShard<'a> {
             state.effects.set_muscle_memory(0);
         }
         let reduced_state = ReducedState::from_state(state, step_budget);
-        let pareto_front = if let Some(solution) = self.shared_states.get(&reduced_state) {
+        let pareto_front = if let Some(solution) = self.shared_states.get(&reduced_state).copied() {
             solution
-        } else if let Some(solution) = self.local_states.get(&reduced_state) {
+        } else if let Some(solution) = self.local_states.get(&reduced_state).copied() {
             solution
         } else {
             solve_state_sequential(
@@ -236,12 +240,13 @@ fn discover_unsolved_states(
     unsolved_states
 }
 
-fn construct_solution<'a>(
+fn construct_solution<'alloc>(
     state: ReducedState,
-    context: &StepLbSolverContext,
+    context: &StepLbSolverContext<'alloc>,
     pf_builder: &mut ParetoFrontBuilder,
-    get_solution: impl Fn(ReducedState) -> Option<&'a Box<NonEmptyParetoFront>>,
-) -> Result<Box<nunny::Slice<ParetoValue>>, SolverException> {
+    get_solution: impl Fn(ReducedState) -> Option<&'alloc [ParetoValue]>,
+    allocator: &BumpPoolGuard<'alloc>,
+) -> Result<ParetoFront<'alloc>, SolverException> {
     let min_quality = context.iq_quality_lut[usize::from(state.effects.inner_quiet())];
     let cutoff = ParetoValue::new(
         context.settings.max_progress(),
@@ -279,56 +284,59 @@ fn construct_solution<'a>(
             }
         }
     }
-    pf_builder.result().try_into().map_err(|_| {
-        internal_error!(
+    let solution = allocator
+        .alloc_slice_copy(pf_builder.result_as_slice())
+        .into_ref();
+    if solution.is_empty() {
+        return Err(internal_error!(
             "Solver produced empty Pareto front.",
             context.settings,
             state
-        )
-    })
+        ));
+    }
+    Ok(solution)
 }
 
-fn solve_state_sequential<'a>(
+fn solve_state_sequential<'alloc>(
     seed_state: ReducedState,
-    context: &StepLbSolverContext,
-    shared_states: &'a SolvedStates,
-    local_states: &'a mut SolvedStates,
+    context: &StepLbSolverContext<'alloc>,
+    shared_states: &SolvedStates<'alloc>,
+    local_states: &mut SolvedStates<'alloc>,
     pf_builder: &mut ParetoFrontBuilder,
-) -> Result<&'a nunny::Slice<ParetoValue>, SolverException> {
+) -> Result<ParetoFront<'alloc>, SolverException> {
     let mut unsolved_states = {
         let has_solution =
             |state| shared_states.contains_key(&state) || local_states.contains_key(&state);
         discover_unsolved_states(seed_state, &context.settings, has_solution)
     };
     unsolved_states.sort_unstable_by_key(|state| state.steps_budget);
+    let allocator = context.allocator.get();
     for state in unsolved_states {
         let solution = {
             let get_solution = |state| {
                 shared_states
                     .get(&state)
                     .or_else(|| local_states.get(&state))
+                    .copied()
             };
-            construct_solution(state, context, pf_builder, get_solution)?
+            construct_solution(state, context, pf_builder, get_solution, &allocator)?
         };
         local_states.insert(state, solution);
     }
-    local_states
-        .get(&seed_state)
-        .map(Box::deref)
-        .ok_or_else(|| {
-            internal_error!(
-                "State not found in memoization after solving",
-                context.settings,
-                seed_state
-            )
-        })
+    local_states.get(&seed_state).copied().ok_or_else(|| {
+        internal_error!(
+            "State not found in memoization after solving",
+            context.settings,
+            seed_state
+        )
+    })
 }
 
-fn solve_state_parallel<'a>(
+fn solve_state_parallel<'alloc>(
     seed_state: ReducedState,
-    context: &StepLbSolverContext,
-    solved_states: &'a mut SolvedStates,
-) -> Result<&'a nunny::Slice<ParetoValue>, SolverException> {
+    context: &StepLbSolverContext<'alloc>,
+    solved_states: &mut SolvedStates<'alloc>,
+) -> Result<ParetoFront<'alloc>, SolverException> {
     let mut unsolved_states = {
         let has_solution = |state| solved_states.contains_key(&state);
         discover_unsolved_states(seed_state, &context.settings, has_solution)
@@ -345,14 +353,19 @@ fn solve_state_parallel<'a>(
         }
         let current_batch = &unsolved_states[idx_begin..idx_end];
         let current_batch_solutions = {
-            let get_solution = |state| solved_states.get(&state);
+            let get_solution = |state| solved_states.get(&state).copied();
             current_batch
                 .par_iter()
                 .map_init(
-                    ParetoFrontBuilder::new,
-                    |pf_builder, state| -> Result<_, SolverException> {
-                        let solution =
-                            construct_solution(*state, context, pf_builder, get_solution)?;
+                    || (ParetoFrontBuilder::new(), context.allocator.get()),
+                    |(pf_builder, allocator), state| -> Result<_, SolverException> {
+                        let solution = construct_solution(
+                            *state,
+                            context,
+                            pf_builder,
+                            get_solution,
+                            allocator,
+                        )?;
                         Ok((*state, solution))
                     },
                 )
@@ -361,14 +374,11 @@ fn solve_state_parallel<'a>(
         solved_states.extend(current_batch_solutions);
         idx_begin = idx_end;
     }
-    solved_states
-        .get(&seed_state)
-        .map(Box::deref)
-        .ok_or_else(|| {
-            internal_error!(
-                "State not found in memoization after solving",
-                context.settings,
-                seed_state
-            )
-        })
+    solved_states.get(&seed_state).copied().ok_or_else(|| {
+        internal_error!(
+            "State not found in memoization after solving",
+            context.settings,
+            seed_state
+        )
+    })
 }

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -325,7 +325,7 @@ fn solve_state_sequential<'alloc>(
     }
     local_states.get(&seed_state).copied().ok_or_else(|| {
         internal_error!(
-            "State not found in memoization after solving",
+            "State not found in memoization table after solving.",
             context.settings,
             seed_state
         )
@@ -376,7 +376,7 @@ fn solve_state_parallel<'alloc>(
     }
     solved_states.get(&seed_state).copied().ok_or_else(|| {
         internal_error!(
-            "State not found in memoization after solving",
+            "State not found in memoization table after solving.",
             context.settings,
             seed_state
         )

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -14,8 +14,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::state::ReducedState;
 
-type ParetoFront<'alloc> = &'alloc nunny::Slice<ParetoValue>;
-type SolvedStates<'alloc> = FxHashMap<ReducedState, ParetoFront<'alloc>>;
+type ParetoFront = nunny::Slice<ParetoValue>;
+type SolvedStates<'alloc> = FxHashMap<ReducedState, &'alloc ParetoFront>;
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct StepLbSolverStats {
@@ -244,9 +244,9 @@ fn construct_solution<'alloc>(
     state: ReducedState,
     context: &StepLbSolverContext<'alloc>,
     pf_builder: &mut ParetoFrontBuilder,
-    get_solution: impl Fn(ReducedState) -> Option<ParetoFront<'alloc>>,
+    get_solution: impl Fn(ReducedState) -> Option<&'alloc ParetoFront>,
     allocator: &BumpPoolGuard<'alloc>,
-) -> Result<ParetoFront<'alloc>, SolverException> {
+) -> Result<&'alloc ParetoFront, SolverException> {
     let min_quality = context.iq_quality_lut[usize::from(state.effects.inner_quiet())];
     let cutoff = ParetoValue::new(
         context.settings.max_progress(),
@@ -303,7 +303,7 @@ fn solve_state_sequential<'alloc>(
     shared_states: &SolvedStates<'alloc>,
     local_states: &mut SolvedStates<'alloc>,
     pf_builder: &mut ParetoFrontBuilder,
-) -> Result<ParetoFront<'alloc>, SolverException> {
+) -> Result<&'alloc ParetoFront, SolverException> {
     let mut unsolved_states = {
         let has_solution =
             |state| shared_states.contains_key(&state) || local_states.contains_key(&state);
@@ -336,7 +336,7 @@ fn solve_state_parallel<'alloc>(
     seed_state: ReducedState,
     context: &StepLbSolverContext<'alloc>,
     solved_states: &mut SolvedStates<'alloc>,
-) -> Result<ParetoFront<'alloc>, SolverException> {
+) -> Result<&'alloc ParetoFront, SolverException> {
     let mut unsolved_states = {
         let has_solution = |state| solved_states.contains_key(&state);
         discover_unsolved_states(seed_state, &context.settings, has_solution)

--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -14,7 +14,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::state::ReducedState;
 
-type ParetoFront<'alloc> = &'alloc [ParetoValue];
+type ParetoFront<'alloc> = &'alloc nunny::Slice<ParetoValue>;
 type SolvedStates<'alloc> = FxHashMap<ReducedState, ParetoFront<'alloc>>;
 
 #[derive(Default, Debug, Clone, Copy)]
@@ -244,7 +244,7 @@ fn construct_solution<'alloc>(
     state: ReducedState,
     context: &StepLbSolverContext<'alloc>,
     pf_builder: &mut ParetoFrontBuilder,
-    get_solution: impl Fn(ReducedState) -> Option<&'alloc [ParetoValue]>,
+    get_solution: impl Fn(ReducedState) -> Option<ParetoFront<'alloc>>,
     allocator: &BumpPoolGuard<'alloc>,
 ) -> Result<ParetoFront<'alloc>, SolverException> {
     let min_quality = context.iq_quality_lut[usize::from(state.effects.inner_quiet())];
@@ -284,17 +284,17 @@ fn construct_solution<'alloc>(
             }
         }
     }
-    let solution = allocator
+    allocator
         .alloc_slice_copy(pf_builder.result_as_slice())
-        .into_ref();
-    if solution.is_empty() {
-        return Err(internal_error!(
-            "Solver produced empty Pareto front.",
-            context.settings,
-            state
-        ));
-    }
-    Ok(solution)
+        .into_ref()
+        .try_into()
+        .map_err(|_| {
+            internal_error!(
+                "Solver produced empty Pareto front.",
+                context.settings,
+                state
+            )
+        })
 }
 
 fn solve_state_sequential<'alloc>(

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -1,3 +1,4 @@
+use bump_scope::BumpPool;
 use raphael_sim::*;
 
 use crate::{
@@ -12,7 +13,8 @@ use super::*;
 /// It is consistent if the step-lb of a parent state is never greater than the step-lb of a child state.
 /// It is admissible if the step-lb of a state is never greater than the step count of a reachable final state.
 fn check_consistency(solver_settings: SolverSettings) {
-    let mut solver = StepLbSolver::new(solver_settings, AtomicFlag::default());
+    let allocator = BumpPool::default();
+    let mut solver = StepLbSolver::new(solver_settings, AtomicFlag::default(), &allocator);
     for state in generate_random_states(solver_settings, 1_000_000)
         .filter(|state| state.effects.combo() == Combo::None)
     {

--- a/raphael-solver/src/utils/pareto_front_builder.rs
+++ b/raphael-solver/src/utils/pareto_front_builder.rs
@@ -73,10 +73,6 @@ impl ParetoFrontBuilder {
         })
     }
 
-    pub fn result(&mut self) -> Box<[ParetoValue]> {
-        self.result.as_slice().into()
-    }
-
     pub fn result_as_slice(&mut self) -> &[ParetoValue] {
         self.result.as_slice()
     }

--- a/raphael-solver/src/utils/pareto_front_builder.rs
+++ b/raphael-solver/src/utils/pareto_front_builder.rs
@@ -76,6 +76,10 @@ impl ParetoFrontBuilder {
     pub fn result(&mut self) -> Box<[ParetoValue]> {
         self.result.as_slice().into()
     }
+
+    pub fn result_as_slice(&mut self) -> &[ParetoValue] {
+        self.result.as_slice()
+    }
 }
 
 fn trim(mut slice: &mut [ParetoValue], cutoff: ParetoValue) -> &mut [ParetoValue] {


### PR DESCRIPTION
In a typical scenario, the two solvers are currently making hundreds of thousands of small heap allocations to store the Pareto fronts for each state. Using a bump allocator as the backing storage significantly reduces the amount of heap allocations.

Before:

```
Name                                            Time        Memory       Quality
--------------------------------------------------------------------------------
pactmaker_3240_3130_600                       2.44 s    230.92 MiB    8912/12800
pactmaker_3240_3130_600_no_manipulation       1.37 s    148.46 MiB    8482/12800
rare_tacos_4900_4800_620                      5.93 s    425.61 MiB   12022/12000
rare_tacos_4900_4800_620_backload_progress    4.26 s    328.66 MiB   12181/12000
rare_tacos_4900_4800_620_adversarial         10.33 s    761.00 MiB   11827/12000
courtly_lover_5811_5461_649                   7.01 s    590.11 MiB   12890/21200
courtly_lover_5811_5461_649_specialist       25.16 s   1754.07 MiB   14078/21200
high_memory_default_settings_1               12.52 s   1780.04 MiB   21261/21200
high_memory_default_settings_2               22.74 s   2592.41 MiB   17705/17300
```

After:

```
Name                                            Time        Memory       Quality
--------------------------------------------------------------------------------
pactmaker_3240_3130_600                       2.31 s    209.21 MiB    8912/12800
pactmaker_3240_3130_600_no_manipulation       1.34 s    136.98 MiB    8482/12800
rare_tacos_4900_4800_620                      5.45 s    408.55 MiB   12022/12000
rare_tacos_4900_4800_620_backload_progress    4.18 s    318.00 MiB   12181/12000
rare_tacos_4900_4800_620_adversarial          8.81 s    720.57 MiB   11827/12000
courtly_lover_5811_5461_649                   6.67 s    547.97 MiB   12890/21200
courtly_lover_5811_5461_649_specialist       21.98 s   1639.89 MiB   14078/21200
high_memory_default_settings_1               11.26 s   1741.36 MiB   21261/21200
high_memory_default_settings_2               22.26 s   2574.95 MiB   17705/17300
```

The result is shorter solve time and lower memory usage for every single benchmark case.
