### PR TITLE
Skip precompute for `StepLbSolver` if it will never be queried

### DIFF
--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -96,9 +96,16 @@ impl<'a> MacroSolver<'a> {
         quality_ub_solver.precompute()?;
         drop(timer);
 
-        let timer = ScopedTimer::new("Step LB Solver");
-        step_lb_solver.precompute()?;
-        drop(timer);
+        // The StepLbSolver is only queried when a state has the potential to reach max_quality.
+        // If the quality upper-bound of the initial state is less than max_quality, then no
+        // subsequent state can reach max_quality, which in turn means the StepLbSolver is not needed.
+        let initial_state_quality_ub = quality_ub_solver
+            .create_shard()
+            .quality_upper_bound(initial_state)?;
+        if initial_state_quality_ub >= self.settings.max_quality() {
+            let _timer = ScopedTimer::new("Step LB Solver");
+            step_lb_solver.precompute()?;
+        }
 
         let timer = ScopedTimer::new("Search");
         let actions = self

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -99,9 +99,10 @@ impl<'a> MacroSolver<'a> {
         // The StepLbSolver is only queried when a state has the potential to reach max_quality.
         // If the quality upper-bound of the initial state is less than max_quality, then no
         // subsequent state can reach max_quality, which in turn means the StepLbSolver is not needed.
-        let initial_state_quality_ub = quality_ub_solver
-            .create_shard()
-            .quality_upper_bound(initial_state)?;
+        let mut quality_ub_solver_shard = quality_ub_solver.create_shard();
+        let initial_state_quality_ub =
+            quality_ub_solver_shard.quality_upper_bound(initial_state)?;
+        quality_ub_solver.extend_solved_states(quality_ub_solver_shard.solved_states());
         if initial_state_quality_ub >= self.settings.max_quality() {
             let _timer = ScopedTimer::new("Step LB Solver");
             step_lb_solver.precompute()?;

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -146,8 +146,8 @@ fn zero_quality() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 31147,
-                states_on_shards: 0,
-                values: 109398,
+                states_on_shards: 7301,
+                values: 128831,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -200,8 +200,8 @@ fn max_quality() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 389796,
-                states_on_shards: 514,
-                values: 2236380,
+                states_on_shards: 517,
+                values: 2236383,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 26538,
@@ -254,8 +254,8 @@ fn large_progress_quality_increase() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 2208900,
-                states_on_shards: 22,
-                values: 8280016,
+                states_on_shards: 26,
+                values: 8280020,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 320,
@@ -308,8 +308,8 @@ fn backload_progress_single_delicate_synthesis() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 3243,
-                states_on_shards: 0,
-                values: 3243,
+                states_on_shards: 3,
+                values: 3246,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 1,
@@ -363,8 +363,8 @@ fn issue_216_steplbsolver_crash() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 318520,
-                states_on_shards: 0,
-                values: 1267763,
+                states_on_shards: 6,
+                values: 1267769,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 36739,
@@ -418,8 +418,8 @@ fn issue_312_quick_innovation_reflect() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 28849,
-                states_on_shards: 1,
-                values: 33547,
+                states_on_shards: 2,
+                values: 33548,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 46,
@@ -486,8 +486,8 @@ fn daring_touch_interrupted_combo() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 22280,
-                states_on_shards: 43,
-                values: 26453,
+                states_on_shards: 44,
+                values: 26454,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 403,

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -150,9 +150,9 @@ fn zero_quality() {
                 values: 109398,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 26538,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 194222,
+                values: 0,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -100,9 +100,9 @@ fn rinascita_3700_3280() {
                 values: 16783500,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 579412,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 6563554,
+                values: 0,
             },
         }
     "#]];
@@ -154,9 +154,9 @@ fn pactmaker_3240_3130() {
                 values: 13132176,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 579412,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 6355536,
+                values: 0,
             },
         }
     "#]];
@@ -210,9 +210,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 values: 27637851,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 1089001,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 13225920,
+                values: 0,
             },
         }
     "#]];
@@ -264,9 +264,9 @@ fn diadochos_4021_3660() {
                 values: 17344815,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 638953,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 8453810,
+                values: 0,
             },
         }
     "#]];
@@ -318,9 +318,9 @@ fn indagator_3858_4057() {
                 values: 16209295,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 460345,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 5446159,
+                values: 0,
             },
         }
     "#]];

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -96,8 +96,8 @@ fn rinascita_3700_3280() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 957930,
-                states_on_shards: 42813,
-                values: 16783500,
+                states_on_shards: 42909,
+                values: 16783607,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -150,8 +150,8 @@ fn pactmaker_3240_3130() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 818130,
-                states_on_shards: 44933,
-                values: 13132176,
+                states_on_shards: 45029,
+                values: 13132295,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -206,8 +206,8 @@ fn pactmaker_3240_3130_heart_and_soul() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1690660,
-                states_on_shards: 84617,
-                values: 27637851,
+                states_on_shards: 84804,
+                values: 27638058,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -260,8 +260,8 @@ fn diadochos_4021_3660() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 888030,
-                states_on_shards: 44397,
-                values: 17344815,
+                states_on_shards: 44493,
+                values: 17344936,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -314,8 +314,8 @@ fn indagator_3858_4057() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 971910,
-                states_on_shards: 45972,
-                values: 16209295,
+                states_on_shards: 46068,
+                values: 16209392,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -368,8 +368,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 945752,
-                states_on_shards: 12609,
-                values: 16494731,
+                states_on_shards: 12611,
+                values: 16494733,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 943777,
@@ -424,8 +424,8 @@ fn stuffed_peppers_2() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 727703,
-                states_on_shards: 0,
-                values: 8685113,
+                states_on_shards: 5,
+                values: 8685118,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 429544,
@@ -482,8 +482,8 @@ fn stuffed_peppers_2_heart_and_soul() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1547790,
-                states_on_shards: 0,
-                values: 20676360,
+                states_on_shards: 4,
+                values: 20676364,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 723616,
@@ -540,8 +540,8 @@ fn stuffed_peppers_2_quick_innovation() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1477069,
-                states_on_shards: 5,
-                values: 17827203,
+                states_on_shards: 10,
+                values: 17827208,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 432530,
@@ -594,8 +594,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 750109,
-                states_on_shards: 1,
-                values: 9640072,
+                states_on_shards: 5,
+                values: 9640076,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 429544,
@@ -648,8 +648,8 @@ fn black_star_4048_3997() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 448545,
-                states_on_shards: 20,
-                values: 2531249,
+                states_on_shards: 24,
+                values: 2531253,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 28376,
@@ -702,8 +702,8 @@ fn claro_walnut_lumber_4900_4800() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 632525,
-                states_on_shards: 39,
-                values: 4421953,
+                states_on_shards: 43,
+                values: 4421957,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 115313,
@@ -756,8 +756,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 654113,
-                states_on_shards: 0,
-                values: 7088630,
+                states_on_shards: 5,
+                values: 7088635,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 321119,
@@ -810,8 +810,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 620174,
-                states_on_shards: 0,
-                values: 6152904,
+                states_on_shards: 5,
+                values: 6152909,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 229899,
@@ -864,8 +864,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 871349,
-                states_on_shards: 0,
-                values: 12661815,
+                states_on_shards: 5,
+                values: 12661820,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 513399,
@@ -918,8 +918,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 994029,
-                states_on_shards: 9788,
-                values: 11580610,
+                states_on_shards: 9790,
+                values: 11580612,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 169611,

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -100,9 +100,9 @@ fn rinascita_3700_3280() {
                 values: 22751757,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 631128,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 11674974,
+                values: 0,
             },
         }
     "#]];
@@ -154,9 +154,9 @@ fn pactmaker_3240_3130() {
                 values: 17736621,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 631128,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 11652491,
+                values: 0,
             },
         }
     "#]];
@@ -210,9 +210,9 @@ fn pactmaker_3240_3130_heart_and_soul() {
                 values: 37644777,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 1178831,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 23063578,
+                values: 0,
             },
         }
     "#]];
@@ -264,9 +264,9 @@ fn diadochos_4021_3660() {
                 values: 23497998,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 693970,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 14559312,
+                values: 0,
             },
         }
     "#]];
@@ -318,9 +318,9 @@ fn indagator_3858_4057() {
                 values: 21397668,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 505459,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 9590744,
+                values: 0,
             },
         }
     "#]];
@@ -976,9 +976,9 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
                 values: 39004486,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 370097,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 6336270,
+                values: 0,
             },
         }
     "#]];
@@ -1087,9 +1087,9 @@ fn ce_high_progress_zero_achieved_quality() {
                 values: 2232866,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 450021,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 1030226,
+                values: 0,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -96,8 +96,8 @@ fn rinascita_3700_3280() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 946344,
-                states_on_shards: 45503,
-                values: 22751757,
+                states_on_shards: 51868,
+                values: 22969485,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -150,8 +150,8 @@ fn pactmaker_3240_3130() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 808184,
-                states_on_shards: 46099,
-                values: 17736621,
+                states_on_shards: 52464,
+                values: 17941182,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -206,8 +206,8 @@ fn pactmaker_3240_3130_heart_and_soul() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1668344,
-                states_on_shards: 87012,
-                values: 37644777,
+                states_on_shards: 96743,
+                values: 37955492,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -260,8 +260,8 @@ fn diadochos_4021_3660() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 877264,
-                states_on_shards: 46836,
-                values: 23497998,
+                states_on_shards: 53201,
+                values: 23763580,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -314,8 +314,8 @@ fn indagator_3858_4057() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 960160,
-                states_on_shards: 45425,
-                values: 21397668,
+                states_on_shards: 51790,
+                values: 21551198,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -368,8 +368,8 @@ fn rarefied_tacos_de_carne_asada_4785_4758() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 932788,
-                states_on_shards: 6315,
-                values: 22061921,
+                states_on_shards: 6317,
+                values: 22061923,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 878246,
@@ -424,8 +424,8 @@ fn stuffed_peppers_2() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 685374,
-                states_on_shards: 0,
-                values: 10568081,
+                states_on_shards: 5,
+                values: 10568086,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 366835,
@@ -482,8 +482,8 @@ fn stuffed_peppers_2_heart_and_soul() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1464188,
-                states_on_shards: 0,
-                values: 24789603,
+                states_on_shards: 4,
+                values: 24789607,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 606763,
@@ -540,8 +540,8 @@ fn stuffed_peppers_2_quick_innovation() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1405659,
-                states_on_shards: 5,
-                values: 21872309,
+                states_on_shards: 10,
+                values: 21872314,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 378448,
@@ -594,8 +594,8 @@ fn rakaznar_lapidary_hammer_4462_4391() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 709548,
-                states_on_shards: 0,
-                values: 11347845,
+                states_on_shards: 4,
+                values: 11347849,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 482739,
@@ -648,8 +648,8 @@ fn black_star_4048_3997() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 414395,
-                states_on_shards: 0,
-                values: 2776768,
+                states_on_shards: 4,
+                values: 2776772,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 36767,
@@ -702,8 +702,8 @@ fn claro_walnut_lumber_4900_4800() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 588992,
-                states_on_shards: 0,
-                values: 5111464,
+                states_on_shards: 4,
+                values: 5111468,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 136211,
@@ -756,8 +756,8 @@ fn rakaznar_lapidary_hammer_4900_4800() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 615546,
-                states_on_shards: 0,
-                values: 8053602,
+                states_on_shards: 5,
+                values: 8053607,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 266926,
@@ -810,8 +810,8 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 579131,
-                states_on_shards: 0,
-                values: 6864670,
+                states_on_shards: 5,
+                values: 6864675,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 266926,
@@ -864,8 +864,8 @@ fn archeo_kingdom_broadsword_4966_4914() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 812878,
-                states_on_shards: 0,
-                values: 15607520,
+                states_on_shards: 5,
+                values: 15607525,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 569044,
@@ -918,8 +918,8 @@ fn hardened_survey_plank_5558_5216() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 969126,
-                states_on_shards: 4229,
-                values: 16039954,
+                states_on_shards: 4231,
+                values: 16039956,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 196205,
@@ -972,8 +972,8 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 2397570,
-                states_on_shards: 114989,
-                values: 39004486,
+                states_on_shards: 130579,
+                values: 39323690,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -1027,8 +1027,8 @@ fn ceviche_4900_4800_no_quality() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 428868,
-                states_on_shards: 0,
-                values: 428868,
+                states_on_shards: 6,
+                values: 428874,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 13059,
@@ -1083,8 +1083,8 @@ fn ce_high_progress_zero_achieved_quality() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 951755,
-                states_on_shards: 0,
-                values: 2232866,
+                states_on_shards: 26915,
+                values: 2288640,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -1138,8 +1138,8 @@ fn ce_stellar_steady_hand() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 2408386,
-                states_on_shards: 84286,
-                values: 50005756,
+                states_on_shards: 84287,
+                values: 50005757,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 673566,
@@ -1193,8 +1193,8 @@ fn ce_stellar_steady_hand_2() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 4310883,
-                states_on_shards: 39626,
-                values: 74576231,
+                states_on_shards: 39628,
+                values: 74576233,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 1079473,

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -285,9 +285,9 @@ fn test_indagator_3858_4057() {
                 values: 64645870,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 505459,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 10416852,
+                values: 0,
             },
         }
     "#]];
@@ -400,9 +400,9 @@ fn issue_113() {
                 values: 120610497,
             },
             step_lb_stats: StepLbSolverStats {
-                states_on_main: 1525536,
+                states_on_main: 0,
                 states_on_shards: 0,
-                values: 49094405,
+                values: 0,
             },
         }
     "#]];

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -111,8 +111,8 @@ fn stuffed_peppers() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 2271577,
-                states_on_shards: 16,
-                values: 39200086,
+                states_on_shards: 19,
+                values: 39200089,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 366835,
@@ -167,8 +167,8 @@ fn test_rare_tacos_2() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 2490500,
-                states_on_shards: 77965,
-                values: 70123242,
+                states_on_shards: 77975,
+                values: 70123379,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 878246,
@@ -227,8 +227,8 @@ fn test_mountain_chromite_ingot_no_manipulation() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1800421,
-                states_on_shards: 42373,
-                values: 16756719,
+                states_on_shards: 42375,
+                values: 16756721,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 28922,
@@ -281,8 +281,8 @@ fn test_indagator_3858_4057() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 2515254,
-                states_on_shards: 140896,
-                values: 64645870,
+                states_on_shards: 147927,
+                values: 64921336,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -339,8 +339,8 @@ fn test_rare_tacos_4628_4410() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 2623346,
-                states_on_shards: 69379,
-                values: 78045031,
+                states_on_shards: 75251,
+                values: 78241975,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 213458,
@@ -396,8 +396,8 @@ fn issue_113() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 3043236,
-                states_on_shards: 80504,
-                values: 120610497,
+                states_on_shards: 87698,
+                values: 121049151,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 0,
@@ -451,8 +451,8 @@ fn issue_118() {
             },
             quality_ub_stats: QualityUbSolverStats {
                 states_on_main: 1930860,
-                states_on_shards: 61637,
-                values: 25588473,
+                states_on_shards: 61638,
+                values: 25588474,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 100860,


### PR DESCRIPTION
As the title says. We can easily determine whether the `StepLbSolver` will ever be queried by looking at the quality upper-bound of the initial state. If it is less than `max_quality`, then we can skip the `StepLbSolver` entirely.

Easy runtime and memory usage improvement for configurations that are far from reaching max quality. I can't believe i missed this...