### PR TITLE
Fix `StepLbSolver` overflow panic

### DIFF
--- a/raphael-solver/src/step_lower_bound_solver/solver.rs
+++ b/raphael-solver/src/step_lower_bound_solver/solver.rs
@@ -110,7 +110,10 @@ impl<'alloc> StepLbSolver<'alloc> {
             .quality_upper_bound(state, hint)?
             .is_none_or(|quality_ub| quality_ub < self.context.settings.max_quality())
         {
-            hint = hint.checked_add(1).unwrap();
+            match hint.checked_add(1) {
+                Some(new_hint) => hint = new_hint,
+                None => return Ok(u8::MAX),
+            }
         }
         Ok(hint.get())
     }
@@ -171,7 +174,10 @@ impl<'main, 'alloc> StepLbSolverShard<'main, 'alloc> {
             .quality_upper_bound(state, hint)?
             .is_none_or(|quality_ub| quality_ub < self.context.settings.max_quality())
         {
-            hint = hint.checked_add(1).unwrap();
+            match hint.checked_add(1) {
+                Some(new_hint) => hint = new_hint,
+                None => return Ok(u8::MAX),
+            }
         }
         Ok(hint.get())
     }

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -50,24 +50,6 @@ fn check_consistency(solver_settings: SolverSettings) {
 /// 3 quality actions that can generate at most 124 quality — never reaching max_quality=130.
 #[test]
 fn step_lower_bound_unreachable_quality_no_panic() {
-    // Recipe: Fingerless Leather Gloves (recipe_id=309, item_id=3530)
-    // Crafter: level 5 Leatherworker, craftsmanship=39, control=9, cp=180
-    //
-    // max_progress, max_quality, max_durability:
-    //   rlvls.rs index 4: { max_progress: 21, max_quality: 130, max_durability: 60, ... }
-    //   multiplied by recipe progress_factor/quality_factor/durability_factor (all 100)
-    //
-    // base_progress = craftsmanship*10 / progress_div + 2 = 39*10/50 + 2 = 9.8 → 9
-    //   (progress_div=50 from rlvls.rs; crafter level 5 > recipe job_level 4, no modifier penalty)
-    //
-    // base_quality = control*10 / quality_div + 35 = 9*10/30 + 35 = 38.0 → 38
-    //   (quality_div=30 from rlvls.rs; same level rule as above)
-    //
-    // allowed_actions: ActionMask::all() minus the four actions get_game_settings removes:
-    //   Manipulation  — crafter_stats.manipulation = false (level 65 skill, not unlocked)
-    //   TrainedEye    — crafter level (5) < recipe job_level (4) + 10 = 14
-    //   HeartAndSoul  — crafter_stats.heart_and_soul = false
-    //   QuickInnovation — crafter_stats.quick_innovation = false
     let simulator_settings = Settings {
         max_progress: 21,
         max_quality: 130,

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -41,6 +41,61 @@ fn check_consistency(solver_settings: SolverSettings) {
     }
 }
 
+/// Regression test: step_lower_bound must return u8::MAX (not panic) when max_quality is
+/// unreachable. Example is a Level 5 Leatherworker trying to craft Fingerless Leather Gloves
+///
+/// At job level 5, only BasicSynthesis (lvl 1) and BasicTouch (lvl 5) are available.
+/// With 60 max durability and 10 durability per action, the crafter can take 6 actions
+/// total. Reaching max_progress=21 requires 3 BasicSynthesis (27 progress), leaving only
+/// 3 quality actions that can generate at most 124 quality — never reaching max_quality=130.
+#[test]
+fn step_lower_bound_unreachable_quality_no_panic() {
+    // Recipe: Fingerless Leather Gloves (recipe_id=309, item_id=3530)
+    // Crafter: level 5 Leatherworker, craftsmanship=39, control=9, cp=180
+    //
+    // max_progress, max_quality, max_durability:
+    //   rlvls.rs index 4: { max_progress: 21, max_quality: 130, max_durability: 60, ... }
+    //   multiplied by recipe progress_factor/quality_factor/durability_factor (all 100)
+    //
+    // base_progress = craftsmanship*10 / progress_div + 2 = 39*10/50 + 2 = 9.8 → 9
+    //   (progress_div=50 from rlvls.rs; crafter level 5 > recipe job_level 4, no modifier penalty)
+    //
+    // base_quality = control*10 / quality_div + 35 = 9*10/30 + 35 = 38.0 → 38
+    //   (quality_div=30 from rlvls.rs; same level rule as above)
+    //
+    // allowed_actions: ActionMask::all() minus the four actions get_game_settings removes:
+    //   Manipulation  — crafter_stats.manipulation = false (level 65 skill, not unlocked)
+    //   TrainedEye    — crafter level (5) < recipe job_level (4) + 10 = 14
+    //   HeartAndSoul  — crafter_stats.heart_and_soul = false
+    //   QuickInnovation — crafter_stats.quick_innovation = false
+    let simulator_settings = Settings {
+        max_progress: 21,
+        max_quality: 130,
+        max_durability: 60,
+        max_cp: 180,
+        base_progress: 9,
+        base_quality: 38,
+        job_level: 5,
+        allowed_actions: ActionMask::all()
+            .remove(Action::Manipulation)
+            .remove(Action::TrainedEye)
+            .remove(Action::HeartAndSoul)
+            .remove(Action::QuickInnovation),
+        adversarial: false,
+        backload_progress: false,
+        stellar_steady_hand_charges: 0,
+    };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: false,
+    };
+    let allocator = BumpPool::default();
+    let mut solver = StepLbSolver::new(solver_settings, AtomicFlag::default(), &allocator);
+    let initial_state = SimulationState::new(&simulator_settings);
+    let result = solver.step_lower_bound(initial_state, 0).unwrap();
+    assert_eq!(result, u8::MAX);
+}
+
 #[test_case::test_matrix(
     [20, 35, 60, 80],
     [REGULAR_ACTIONS, NO_MANIPULATION, WITH_SPECIALIST_ACTIONS]

--- a/raphael-solver/src/step_lower_bound_solver/tests.rs
+++ b/raphael-solver/src/step_lower_bound_solver/tests.rs
@@ -58,11 +58,7 @@ fn step_lower_bound_unreachable_quality_no_panic() {
         base_progress: 9,
         base_quality: 38,
         job_level: 5,
-        allowed_actions: ActionMask::all()
-            .remove(Action::Manipulation)
-            .remove(Action::TrainedEye)
-            .remove(Action::HeartAndSoul)
-            .remove(Action::QuickInnovation),
+        allowed_actions: ActionMask::regular(),
         adversarial: false,
         backload_progress: false,
         stellar_steady_hand_charges: 0,


### PR DESCRIPTION
Hello, thanks for this project - it is very effective and I recommend it to everyone I can.

Today I ran into an edge case where the solver can panic on an impossible craft rather than throwing the usual error. 



## Reproduction

On the main site, set up a Level 5 Leatherworker with the Fingerless Leather Gloves recipe and the following stats:

- **Craftsmanship**: 39
- **Control**: 9
- **CP**: 180
- **Target quality**: >=95%
- **HQ Materials**: None

Then click Solve. The UI will seize and in the console a stack trace like this can be found:

```
raphael-xiv-fbd57d83f831cae4.js:783 panicked at raphael-solver/src/step_lower_bound_solver/solver.rs:113:40:
called `Option::unwrap()` on a `None` value

Stack:

Error
    at __wbg_new_65733360f6737f38 (raphael-xiv-fbd57d83f831cae4.js:1530:25)
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x583461
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x6906cd
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x6bba80
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x6c0aec
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x6d1598
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x23324a
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x43e23b
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x5755d9
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x346d61
__wbg_error_bbcc95426a3167ad @ raphael-xiv-fbd57d83f831cae4.js:783
raphael-xiv-fbd57d83f831cae4_bg.wasm:0x69070c Uncaught (in promise) RuntimeError: unreachable
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x69070c
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x6bba80
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x6c0aec
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x6d1598
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x23324a
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x43e23b
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x5755d9
    at raphael-xiv-fbd57d83f831cae4_bg.wasm:0x346d61
    at Module.wbg_rayon_start_worker (raphael-xiv-fbd57d83f831cae4.js:61:10)
    at 7fe409f5-b7ba-42a6-a8d2-d7ca8f21b46d:34:7
```

## Fix

Ultimately this comes from an integer overflow, so if that happens we return `Ok(u8::MAX)` for a failure case.

```rust
match hint.checked_add(1) {
  Some(new_hint) => hint = new_hint,
  None => return Ok(u8::MAX),
}
```