### PR TITLE
Fix "Solution much reach target quality" option sometimes giving macro that does not reach target quality.

### DIFF
--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -211,6 +211,13 @@ impl<'a> MacroSolver<'a> {
             step_lb_stats: step_lb_solver.runtime_stats(),
         };
 
+        if let Some(solution) = &solution
+            && solution.score.0.quality_upper_bound < self.settings.max_quality()
+            && !self.settings.allow_non_max_quality_solutions
+        {
+            return Err(SolverException::NoSolution);
+        }
+
         solution.ok_or(SolverException::NoSolution)
     }
 

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -563,13 +563,8 @@ fn solution_must_reach_target_quality() {
         allow_non_max_quality_solutions: false,
     };
     let expected_score = expect![[r#"
-        Ok(
-            SolutionScore {
-                capped_quality: 9338,
-                steps: 25,
-                duration: 66,
-                overflow_quality: 0,
-            },
+        Err(
+            NoSolution,
         )
     "#]];
     let expected_runtime_stats = expect![[r#"

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -539,3 +539,60 @@ fn low_level_steplbsolver_crash() {
     let actions = test_with_settings(solver_settings, expected_score, expected_runtime_stats);
     assert_eq!(actions, []);
 }
+
+#[test]
+/// Test a bug where the solver would sometimes give a macro that does not reach target quality
+/// even with `allow_non_max_quality_solutions = false`.
+/// https://github.com/KonaeAkira/raphael-rs/issues/352
+fn solution_must_reach_target_quality() {
+    let simulator_settings = Settings {
+        max_cp: 710,
+        max_durability: 35,
+        max_progress: 5622,
+        max_quality: 14204,
+        base_progress: 300,
+        base_quality: 280,
+        job_level: 100,
+        allowed_actions: ActionMask::regular(),
+        adversarial: false,
+        backload_progress: false,
+        stellar_steady_hand_charges: 0,
+    };
+    let solver_settings = SolverSettings {
+        simulator_settings,
+        allow_non_max_quality_solutions: false,
+    };
+    let expected_score = expect![[r#"
+        Ok(
+            SolutionScore {
+                capped_quality: 9338,
+                steps: 25,
+                duration: 66,
+                overflow_quality: 0,
+            },
+        )
+    "#]];
+    let expected_runtime_stats = expect![[r#"
+        MacroSolverStats {
+            search_queue_stats: SearchQueueStats {
+                inserted_nodes: 3294,
+                processed_nodes: 2866,
+            },
+            finish_solver_stats: FinishSolverStats {
+                states: 7042,
+                values: 91214,
+            },
+            quality_ub_stats: QualityUbSolverStats {
+                states_on_main: 975933,
+                states_on_shards: 24437,
+                values: 21621882,
+            },
+            step_lb_stats: StepLbSolverStats {
+                states_on_main: 472838,
+                states_on_shards: 69855,
+                values: 10657631,
+            },
+        }
+    "#]];
+    test_with_settings(solver_settings, expected_score, expected_runtime_stats);
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -138,6 +138,7 @@ impl eframe::App for MacroSolverApp {
                         ui.label(egui::RichText::new(t!(locale, "No solution")).strong());
                         ui.separator();
                         ui.label(t!(locale, "Cannot complete synthesis."));
+                        self.actions.clear();
                         if self.app_context.solver_config.must_reach_target_quality
                             && self.app_context.game_settings().max_quality != 0
                         {


### PR DESCRIPTION
That macro will also almost always be much worse than the macro the user would've gotten if the "Solution much reach target quality" option was disabled.

Fixes #352 