### PR TITLE
Fix some bugs surrounding Expedience

### DIFF
--- a/raphael-sim/src/actions.rs
+++ b/raphael-sim/src/actions.rs
@@ -1117,6 +1117,10 @@ impl ActionImpl for HastyTouch {
         if state.effects.stellar_steady_hand() == 0 {
             return Err(ActionError::UnreliableAction);
         }
+        if state.effects.expedience() {
+            // Hasty Touch gets upgraded to Daring Touch when expedience is active.
+            return Err(ActionError::SpecialConditionNotMet);
+        }
         Ok(())
     }
 

--- a/raphael-sim/src/actions.rs
+++ b/raphael-sim/src/actions.rs
@@ -1105,7 +1105,7 @@ impl ActionImpl for HastyTouch {
     const EFFECT_RESET_MASK: Effects = DEFAULT_EFFECT_RESET_MASK
         .with_great_strides(0)
         .with_trained_perfection_active(false);
-    const EFFECT_SET_MASK: Effects = Effects::new().with_expedience(true);
+    const EFFECT_SET_MASK: Effects = Effects::new();
 
     fn precondition(
         state: &SimulationState,
@@ -1130,6 +1130,12 @@ impl ActionImpl for HastyTouch {
 
     fn base_durability_cost(_state: &SimulationState, _settings: &Settings) -> u16 {
         10
+    }
+
+    fn transform(state: &mut SimulationState, settings: &Settings, _condition: Condition) {
+        if settings.job_level >= DaringTouch::LEVEL_REQUIREMENT {
+            state.effects.set_expedience(true);
+        }
     }
 }
 

--- a/raphael-sim/src/state.rs
+++ b/raphael-sim/src/state.rs
@@ -140,14 +140,14 @@ impl SimulationState {
             state.effects.set_combo(Combo::SynthesisBegin);
         }
 
-        A::transform(&mut state, settings, condition);
-
         if A::INCREASES_STEP_COUNT {
             if state.effects.manipulation() != 0 {
                 state.durability = std::cmp::min(settings.max_durability, state.durability + 5);
             }
             state.effects = state.effects.tick_down();
         }
+
+        A::transform(&mut state, settings, condition);
 
         state.effects =
             Effects::from_bits(state.effects.into_bits() | A::EFFECT_SET_MASK.into_bits());

--- a/raphael-sim/tests/action_tests.rs
+++ b/raphael-sim/tests/action_tests.rs
@@ -719,6 +719,16 @@ fn test_hasty_touch() {
     // Test that Hasty Touch cannot be used if Stellar Steady Hand is not active.
     let state = SimulationState::from_macro(&settings, &[Action::HastyTouch]);
     assert_eq!(Err(ActionError::UnreliableAction), state);
+    // Test that Hasty Touch cannot be used if expedience is active.
+    let state = SimulationState::from_macro(
+        &settings,
+        &[
+            Action::StellarSteadyHand,
+            Action::HastyTouch,
+            Action::HastyTouch,
+        ],
+    );
+    assert_eq!(Err(ActionError::SpecialConditionNotMet), state);
 }
 
 #[test]

--- a/raphael-sim/tests/action_tests.rs
+++ b/raphael-sim/tests/action_tests.rs
@@ -729,6 +729,22 @@ fn test_hasty_touch() {
         ],
     );
     assert_eq!(Err(ActionError::SpecialConditionNotMet), state);
+    // Test that Hasty Touch doesn't apply Expedience when level requirement is not met.
+    let settings = Settings {
+        stellar_steady_hand_charges: 1,
+        job_level: 90,
+        ..SETTINGS
+    };
+    let state = SimulationState::from_macro(
+        &settings,
+        &[
+            Action::StellarSteadyHand,
+            Action::HastyTouch,
+            Action::HastyTouch,
+        ],
+    )
+    .unwrap();
+    assert_eq!(state.effects.expedience(), false);
 }
 
 #[test]

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -477,7 +477,7 @@ fn daring_touch_interrupted_combo() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 29,
+                inserted_nodes: 27,
                 processed_nodes: 10,
             },
             finish_solver_stats: FinishSolverStats {
@@ -485,14 +485,14 @@ fn daring_touch_interrupted_combo() {
                 values: 24476,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states_on_main: 22280,
+                states_on_main: 22201,
                 states_on_shards: 44,
-                values: 26454,
+                values: 26324,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 403,
-                states_on_shards: 1482,
-                values: 4815,
+                states_on_shards: 1433,
+                values: 4718,
             },
         }
     "#]];
@@ -650,22 +650,22 @@ fn high_max_stellar_steady_hand_charges() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 45477821,
-                processed_nodes: 13954584,
+                inserted_nodes: 43468032,
+                processed_nodes: 13519786,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 89742,
                 values: 330130,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states_on_main: 10285984,
-                states_on_shards: 4621938,
-                values: 219692514,
+                states_on_main: 10283259,
+                states_on_shards: 4622137,
+                values: 222461865,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 11719233,
-                states_on_shards: 3006471,
-                values: 308917227,
+                states_on_shards: 2970491,
+                values: 308218111,
             },
         }
     "#]];

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -1137,14 +1137,14 @@ fn ce_stellar_steady_hand() {
                 values: 107674,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states_on_main: 2408386,
-                states_on_shards: 84287,
-                values: 50005757,
+                states_on_main: 2407520,
+                states_on_shards: 84378,
+                values: 49937176,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 673566,
-                states_on_shards: 203080,
-                values: 17231284,
+                states_on_shards: 203064,
+                values: 17231130,
             },
         }
     "#]];
@@ -1184,22 +1184,22 @@ fn ce_stellar_steady_hand_2() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1458986,
-                processed_nodes: 151383,
+                inserted_nodes: 1446535,
+                processed_nodes: 150173,
             },
             finish_solver_stats: FinishSolverStats {
                 states: 16581,
                 values: 113302,
             },
             quality_ub_stats: QualityUbSolverStats {
-                states_on_main: 4310883,
-                states_on_shards: 39628,
-                values: 74576233,
+                states_on_main: 4309420,
+                states_on_shards: 39876,
+                values: 74698419,
             },
             step_lb_stats: StepLbSolverStats {
                 states_on_main: 1079473,
-                states_on_shards: 451445,
-                values: 29106449,
+                states_on_shards: 451339,
+                values: 29105727,
             },
         }
     "#]];


### PR DESCRIPTION
- Fix the simulator allowing the use of Hasty Touch while the Expedience effect is active. (Hasty Touch gets upgraded to Daring Touch under Expedience)
- Fix Expedience effect being applied even when the level requirement for Expedience isn't met.

Closes https://github.com/KonaeAkira/raphael-rs/issues/357