### PR TITLE
Add job filter for recipes

### DIFF
--- a/raphael-cli/src/commands/search_mission.rs
+++ b/raphael-cli/src/commands/search_mission.rs
@@ -49,12 +49,7 @@ pub fn execute(args: &SearchArgs) {
         );
     }
     if let Some(pattern_arg) = &args.pattern {
-        let job_id = args.job.as_ref().and_then(|job_name| get_job_id(job_name, locale));
-        if let Some(job_arg) = &args.job
-            && job_id.is_none()
-        {
-            log::warn!("Ignoring unknown job '{}'", job_arg);
-        }
+        let job_id = args.job.as_ref().and_then(|job_name| Some(get_job_id(job_name, locale).expect("Unknown job!")));
         matches.extend(raphael_data::find_stellar_missions(StellarSearchQuery {
             text: pattern_arg,
             locale,

--- a/raphael-cli/src/commands/search_mission.rs
+++ b/raphael-cli/src/commands/search_mission.rs
@@ -52,7 +52,7 @@ pub fn execute(args: &SearchArgs) {
         let job_id = args
             .job
             .as_ref()
-            .and_then(|job_name| Some(get_job_id(job_name, locale).expect("Unknown job!")));
+            .map(|job_name| get_job_id(job_name, locale).expect("Unknown job!"));
         matches.extend(raphael_data::find_stellar_missions(StellarSearchQuery {
             text: pattern_arg,
             locale,

--- a/raphael-cli/src/commands/search_mission.rs
+++ b/raphael-cli/src/commands/search_mission.rs
@@ -49,7 +49,10 @@ pub fn execute(args: &SearchArgs) {
         );
     }
     if let Some(pattern_arg) = &args.pattern {
-        let job_id = args.job.as_ref().and_then(|job_name| Some(get_job_id(job_name, locale).expect("Unknown job!")));
+        let job_id = args
+            .job
+            .as_ref()
+            .and_then(|job_name| Some(get_job_id(job_name, locale).expect("Unknown job!")));
         matches.extend(raphael_data::find_stellar_missions(StellarSearchQuery {
             text: pattern_arg,
             locale,

--- a/raphael-cli/src/commands/search_mission.rs
+++ b/raphael-cli/src/commands/search_mission.rs
@@ -1,6 +1,7 @@
 use clap::Args;
 use raphael_data::{
-    RECIPES, STELLAR_MISSIONS, StellarMission, get_job_name, get_stellar_mission_name,
+    RECIPES, STELLAR_MISSIONS, StellarMission, StellarSearchQuery, get_job_id, get_job_name,
+    get_stellar_mission_name,
 };
 
 use crate::commands::Language;
@@ -10,6 +11,10 @@ pub struct SearchArgs {
     /// Search string to use, can be partial name
     #[arg(short, long, required_unless_present_any(["recipe_id", "item_id", "mission_id"]), conflicts_with_all(["recipe_id", "item_id"]))]
     pub pattern: Option<String>,
+
+    /// Job name to limit searches to
+    #[arg(short, long, requires("pattern"), conflicts_with_all(["recipe_id", "item_id"]))]
+    pub job: Option<String>,
 
     /// Recipe ID to search for
     #[arg(short, long, required_unless_present_any(["pattern", "item_id", "mission_id"]), conflicts_with = "item_id")]
@@ -44,7 +49,17 @@ pub fn execute(args: &SearchArgs) {
         );
     }
     if let Some(pattern_arg) = &args.pattern {
-        matches.extend(raphael_data::find_stellar_missions(pattern_arg, locale));
+        let job_id = args.job.as_ref().and_then(|j| get_job_id(j, locale));
+        if let Some(job_arg) = &args.job
+            && job_id.is_none()
+        {
+            log::warn!("Ignoring unknown job '{}'", job_arg);
+        }
+        matches.extend(raphael_data::find_stellar_missions(StellarSearchQuery {
+            text: pattern_arg,
+            locale,
+            job_id,
+        }));
     }
     if let Some(recipe_id_arg) = args.recipe_id {
         matches.extend(

--- a/raphael-cli/src/commands/search_mission.rs
+++ b/raphael-cli/src/commands/search_mission.rs
@@ -49,7 +49,7 @@ pub fn execute(args: &SearchArgs) {
         );
     }
     if let Some(pattern_arg) = &args.pattern {
-        let job_id = args.job.as_ref().and_then(|j| get_job_id(j, locale));
+        let job_id = args.job.as_ref().and_then(|job_name| get_job_id(job_name, locale));
         if let Some(job_arg) = &args.job
             && job_id.is_none()
         {

--- a/raphael-cli/src/commands/search_recipe.rs
+++ b/raphael-cli/src/commands/search_recipe.rs
@@ -62,7 +62,7 @@ pub fn execute(args: &SearchArgs) {
         }
     }
     if let Some(pattern_arg) = &args.pattern {
-        let job_id = args.job.as_ref().and_then(|j| get_job_id(j, locale));
+        let job_id = args.job.as_ref().and_then(|job_name| get_job_id(job_name, locale));
         if let Some(job_arg) = &args.job
             && job_id.is_none()
         {

--- a/raphael-cli/src/commands/search_recipe.rs
+++ b/raphael-cli/src/commands/search_recipe.rs
@@ -62,12 +62,7 @@ pub fn execute(args: &SearchArgs) {
         }
     }
     if let Some(pattern_arg) = &args.pattern {
-        let job_id = args.job.as_ref().and_then(|job_name| get_job_id(job_name, locale));
-        if let Some(job_arg) = &args.job
-            && job_id.is_none()
-        {
-            log::warn!("Ignoring unknown job '{}'", job_arg);
-        }
+        let job_id = args.job.as_ref().and_then(|job_name| Some(get_job_id(job_name, locale).expect("Unknown job!")));
         matches.extend(raphael_data::find_recipes(RecipeSearchQuery {
             text: pattern_arg,
             locale,

--- a/raphael-cli/src/commands/search_recipe.rs
+++ b/raphael-cli/src/commands/search_recipe.rs
@@ -1,5 +1,8 @@
 use clap::Args;
-use raphael_data::{RECIPES, Recipe, STELLAR_MISSIONS, get_job_name, get_raw_item_name};
+use raphael_data::{
+    RECIPES, Recipe, RecipeSearchQuery, STELLAR_MISSIONS, get_job_id, get_job_name,
+    get_raw_item_name,
+};
 
 use crate::commands::Language;
 
@@ -8,6 +11,10 @@ pub struct SearchArgs {
     /// Search string to use, can be partial name
     #[arg(short, long, required_unless_present_any(["recipe_id", "item_id", "mission_id"]), conflicts_with_all(["recipe_id", "item_id"]))]
     pub pattern: Option<String>,
+
+    /// Job name to limit searches to
+    #[arg(short, long, requires("pattern"), conflicts_with_all(["recipe_id", "item_id"]))]
+    pub job: Option<String>,
 
     /// Recipe ID to search for
     #[arg(short, long, required_unless_present_any(["pattern", "item_id", "mission_id"]), conflicts_with = "item_id")]
@@ -55,7 +62,17 @@ pub fn execute(args: &SearchArgs) {
         }
     }
     if let Some(pattern_arg) = &args.pattern {
-        matches.extend(raphael_data::find_recipes(pattern_arg, locale));
+        let job_id = args.job.as_ref().and_then(|j| get_job_id(j, locale));
+        if let Some(job_arg) = &args.job
+            && job_id.is_none()
+        {
+            log::warn!("Ignoring unknown job '{}'", job_arg);
+        }
+        matches.extend(raphael_data::find_recipes(RecipeSearchQuery {
+            text: pattern_arg,
+            locale,
+            job_id,
+        }));
     }
     if let Some(recipe_id_arg) = args.recipe_id {
         matches.extend(

--- a/raphael-cli/src/commands/search_recipe.rs
+++ b/raphael-cli/src/commands/search_recipe.rs
@@ -62,7 +62,10 @@ pub fn execute(args: &SearchArgs) {
         }
     }
     if let Some(pattern_arg) = &args.pattern {
-        let job_id = args.job.as_ref().and_then(|job_name| Some(get_job_id(job_name, locale).expect("Unknown job!")));
+        let job_id = args
+            .job
+            .as_ref()
+            .and_then(|job_name| Some(get_job_id(job_name, locale).expect("Unknown job!")));
         matches.extend(raphael_data::find_recipes(RecipeSearchQuery {
             text: pattern_arg,
             locale,

--- a/raphael-cli/src/commands/search_recipe.rs
+++ b/raphael-cli/src/commands/search_recipe.rs
@@ -65,7 +65,7 @@ pub fn execute(args: &SearchArgs) {
         let job_id = args
             .job
             .as_ref()
-            .and_then(|job_name| Some(get_job_id(job_name, locale).expect("Unknown job!")));
+            .map(|job_name| get_job_id(job_name, locale).expect("Unknown job!"));
         matches.extend(raphael_data::find_recipes(RecipeSearchQuery {
             text: pattern_arg,
             locale,

--- a/raphael-data/benches/bench_game_data.rs
+++ b/raphael-data/benches/bench_game_data.rs
@@ -27,13 +27,25 @@ fn bench_random_access(c: &mut Criterion) {
 
 fn bench_find_recipes(c: &mut Criterion) {
     c.bench_function("find_recipes", |b| {
-        b.iter(|| find_recipes("", Locale::EN));
+        b.iter(|| {
+            find_recipes(RecipeSearchQuery {
+                text: "",
+                locale: Locale::EN,
+                job_id: None,
+            })
+        });
     });
 }
 
 fn bench_find_stellar_missions(c: &mut Criterion) {
     c.bench_function("find_stellar_missions", |b| {
-        b.iter(|| find_stellar_missions("", Locale::EN));
+        b.iter(|| {
+            find_stellar_missions(StellarSearchQuery {
+                text: "",
+                locale: Locale::EN,
+                job_id: None,
+            })
+        });
     });
 }
 

--- a/raphael-data/src/locales.rs
+++ b/raphael-data/src/locales.rs
@@ -74,7 +74,7 @@ pub fn get_job_id(job_name: &str, locale: Locale) -> Option<u8> {
     };
     job_names
         .iter()
-        .position(|&n| n == job_name)
+        .position(|&name| name == job_name)
         .map(|i| i as u8)
 }
 

--- a/raphael-data/src/locales.rs
+++ b/raphael-data/src/locales.rs
@@ -62,6 +62,22 @@ pub fn get_job_name(job_id: u8, locale: Locale) -> &'static str {
     }
 }
 
+pub fn get_job_id(job_name: &str, locale: Locale) -> Option<u8> {
+    let job_names = match locale {
+        Locale::EN => JOB_NAMES_EN,
+        Locale::DE => JOB_NAMES_DE,
+        Locale::FR => JOB_NAMES_FR,
+        Locale::JP => JOB_NAMES_JP,
+        Locale::CN => JOB_NAMES_CN,
+        Locale::KR => JOB_NAMES_KR,
+        Locale::TW => JOB_NAMES_TW,
+    };
+    job_names
+        .iter()
+        .position(|&n| n == job_name)
+        .map(|i| i as u8)
+}
+
 pub const ITEM_NAMES_EN: NciArray<u32, &str> = include!("../data/item_names_en.rs");
 pub const ITEM_NAMES_DE: NciArray<u32, &str> = include!("../data/item_names_de.rs");
 pub const ITEM_NAMES_FR: NciArray<u32, &str> = include!("../data/item_names_fr.rs");

--- a/raphael-data/src/search.rs
+++ b/raphael-data/src/search.rs
@@ -29,6 +29,13 @@ impl<T> AsRef<str> for MatcherCandidate<T> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Hash)]
+pub struct RecipeSearchQuery<'a> {
+    pub text: &'a str,
+    pub locale: crate::Locale,
+    pub job_id: Option<u8>,
+}
+
 fn preprocess_pattern(pattern: &str) -> String {
     pattern
         .chars()
@@ -37,17 +44,19 @@ fn preprocess_pattern(pattern: &str) -> String {
 }
 
 pub type RecipeSearchEntry = (u32, &'static crate::Recipe);
-pub fn find_recipes(
-    search_string: &str,
-    locale: crate::Locale,
-) -> impl Iterator<Item = RecipeSearchEntry> {
+pub fn find_recipes(query: RecipeSearchQuery) -> impl Iterator<Item = RecipeSearchEntry> {
     let pattern = Pattern::parse(
-        &preprocess_pattern(search_string),
+        &preprocess_pattern(query.text),
         CaseMatching::Ignore,
         Normalization::Smart,
     );
     let entries = RECIPES.entries().filter_map(|(recipe_id, recipe)| {
-        let item_name = get_raw_item_name(recipe.item_id, locale)?;
+        let item_name = get_raw_item_name(recipe.item_id, query.locale)?;
+        if let Some(job_id) = query.job_id
+            && job_id != recipe.job_id
+        {
+            return None;
+        }
         Some(MatcherCandidate {
             haystack: item_name,
             associated_data: (recipe_id, recipe),
@@ -59,20 +68,30 @@ pub fn find_recipes(
         .map(|(entry, _score)| entry.associated_data)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Hash)]
+pub struct StellarSearchQuery<'a> {
+    pub text: &'a str,
+    pub locale: crate::Locale,
+    pub job_id: Option<u8>,
+}
 pub type StellarMissionSearchEntry = (u32, &'static crate::StellarMission);
 pub fn find_stellar_missions(
-    search_string: &str,
-    locale: crate::Locale,
+    query: StellarSearchQuery,
 ) -> impl Iterator<Item = StellarMissionSearchEntry> {
     let pattern = Pattern::parse(
-        &preprocess_pattern(search_string),
+        &preprocess_pattern(query.text),
         CaseMatching::Ignore,
         Normalization::Smart,
     );
     let mission_entries = STELLAR_MISSIONS
         .entries()
         .filter_map(|(mission_id, mission)| {
-            let mission_name = get_stellar_mission_name(mission_id, locale)?;
+            let mission_name = get_stellar_mission_name(mission_id, query.locale)?;
+            if let Some(job_id) = query.job_id
+                && job_id != mission.job_id
+            {
+                return None;
+            }
             Some(MatcherCandidate {
                 haystack: mission_name,
                 associated_data: (mission_id, mission),
@@ -83,7 +102,12 @@ pub fn find_stellar_missions(
         .flat_map(|(mission_id, mission)| {
             mission.recipe_ids.iter().filter_map(move |&recipe_id| {
                 let recipe = RECIPES.get(recipe_id)?;
-                let item_name = get_raw_item_name(recipe.item_id, locale)?;
+                let item_name = get_raw_item_name(recipe.item_id, query.locale)?;
+                if let Some(job_id) = query.job_id
+                    && job_id != recipe.job_id
+                {
+                    return None;
+                }
                 Some(MatcherCandidate {
                     haystack: item_name,
                     associated_data: (mission_id, mission),

--- a/raphael-data/src/search.rs
+++ b/raphael-data/src/search.rs
@@ -52,9 +52,7 @@ pub fn find_recipes(query: RecipeSearchQuery) -> impl Iterator<Item = RecipeSear
     );
     let entries = RECIPES.entries().filter_map(|(recipe_id, recipe)| {
         let item_name = get_raw_item_name(recipe.item_id, query.locale)?;
-        if let Some(job_id) = query.job_id
-            && job_id != recipe.job_id
-        {
+        if query.job_id.is_some_and(|job_id| job_id != recipe.job_id) {
             return None;
         }
         Some(MatcherCandidate {
@@ -87,9 +85,7 @@ pub fn find_stellar_missions(
         .entries()
         .filter_map(|(mission_id, mission)| {
             let mission_name = get_stellar_mission_name(mission_id, query.locale)?;
-            if let Some(job_id) = query.job_id
-                && job_id != mission.job_id
-            {
+            if query.job_id.is_some_and(|job_id| job_id != mission.job_id) {
                 return None;
             }
             Some(MatcherCandidate {
@@ -103,9 +99,7 @@ pub fn find_stellar_missions(
             mission.recipe_ids.iter().filter_map(move |&recipe_id| {
                 let recipe = RECIPES.get(recipe_id)?;
                 let item_name = get_raw_item_name(recipe.item_id, query.locale)?;
-                if let Some(job_id) = query.job_id
-                    && job_id != recipe.job_id
-                {
+                if query.job_id.is_some_and(|job_id| job_id != recipe.job_id) {
                     return None;
                 }
                 Some(MatcherCandidate {

--- a/raphael-data/tests/test_recipes.rs
+++ b/raphael-data/tests/test_recipes.rs
@@ -557,9 +557,9 @@ fn habitat_chair() {
 
 #[test]
 fn habitat_chair_jobid() {
-    let nonmatching_recipes =
+    let results_with_wrong_job =
         find_recipes_exact("Habitat Chair", Locale::EN, Some(5)).collect::<Vec<_>>();
-    assert!(nonmatching_recipes.is_empty());
+    assert!(results_with_wrong_job.is_empty());
 
     let matching_recipes =
         find_recipes_exact("Habitat Chair", Locale::EN, Some(0)).collect::<Vec<_>>();

--- a/raphael-data/tests/test_recipes.rs
+++ b/raphael-data/tests/test_recipes.rs
@@ -27,8 +27,14 @@ fn all_recipe_items_exist() {
 fn find_recipes_exact(
     item_name: &str,
     locale: raphael_data::Locale,
+    job_id: Option<u8>,
 ) -> impl Iterator<Item = &'static raphael_data::Recipe> {
-    raphael_data::find_recipes(item_name, locale).filter_map(move |(_recipe_id, recipe)| {
+    raphael_data::find_recipes(RecipeSearchQuery {
+        text: item_name,
+        locale,
+        job_id,
+    })
+    .filter_map(move |(_recipe_id, recipe)| {
         let recipe_item_name = raphael_data::get_raw_item_name(recipe.item_id, locale).unwrap();
         if item_name == recipe_item_name {
             Some(recipe)
@@ -40,7 +46,8 @@ fn find_recipes_exact(
 
 #[test]
 fn medical_supplies() {
-    let matching_recipes = find_recipes_exact("Medical Supplies", Locale::EN).collect::<Vec<_>>();
+    let matching_recipes =
+        find_recipes_exact("Medical Supplies", Locale::EN, None).collect::<Vec<_>>();
     let expected = expect![[r#"
         [
             Recipe {
@@ -362,7 +369,7 @@ fn medical_supplies() {
 
 #[test]
 fn ipe_lumber() {
-    let matching_recipes = find_recipes_exact("Ipe Lumber", Locale::EN).collect::<Vec<_>>();
+    let matching_recipes = find_recipes_exact("Ipe Lumber", Locale::EN, None).collect::<Vec<_>>();
     let expected = expect![[r#"
         [
             Recipe {
@@ -412,7 +419,7 @@ fn ipe_lumber() {
 #[test]
 fn uncharted_course_resin() {
     let matching_recipes =
-        find_recipes_exact("Uncharted Course Resin", Locale::EN).collect::<Vec<_>>();
+        find_recipes_exact("Uncharted Course Resin", Locale::EN, None).collect::<Vec<_>>();
     let expected = expect![[r#"
         [
             Recipe {
@@ -500,7 +507,63 @@ fn uncharted_course_resin() {
 
 #[test]
 fn habitat_chair() {
-    let matching_recipes = find_recipes_exact("Habitat Chair", Locale::EN).collect::<Vec<_>>();
+    let matching_recipes =
+        find_recipes_exact("Habitat Chair", Locale::EN, None).collect::<Vec<_>>();
+    let expected = expect![[r#"
+        [
+            Recipe {
+                job_id: 0,
+                item_id: 48295,
+                max_level_scaling: 100,
+                recipe_level: 690,
+                progress_factor: 54,
+                quality_factor: 87,
+                durability_factor: 88,
+                material_factor: 0,
+                ingredients: [
+                    Ingredient {
+                        item_id: 0,
+                        amount: 0,
+                    },
+                    Ingredient {
+                        item_id: 0,
+                        amount: 0,
+                    },
+                    Ingredient {
+                        item_id: 0,
+                        amount: 0,
+                    },
+                    Ingredient {
+                        item_id: 0,
+                        amount: 0,
+                    },
+                    Ingredient {
+                        item_id: 0,
+                        amount: 0,
+                    },
+                    Ingredient {
+                        item_id: 0,
+                        amount: 0,
+                    },
+                ],
+                is_expert: false,
+                req_craftsmanship: 0,
+                req_control: 0,
+            },
+        ]
+    "#]];
+    expected.assert_debug_eq(&matching_recipes);
+}
+
+#[test]
+fn habitat_chair_jobid() {
+    let nonmatching_recipes =
+        find_recipes_exact("Habitat Chair", Locale::EN, Some(5)).collect::<Vec<_>>();
+    assert!(nonmatching_recipes.is_empty());
+
+    let matching_recipes =
+        find_recipes_exact("Habitat Chair", Locale::EN, Some(0)).collect::<Vec<_>>();
+    assert_eq!(matching_recipes.len(), 1);
     let expected = expect![[r#"
         [
             Recipe {

--- a/raphael-data/tests/test_stellar_missions.rs
+++ b/raphael-data/tests/test_stellar_missions.rs
@@ -65,8 +65,12 @@ impl DetailedMissionInfo {
 
 #[test]
 fn gathering_miscellany() {
-    let matching_missions =
-        find_stellar_missions("Gathering Miscellany", Locale::EN).collect::<Vec<_>>();
+    let matching_missions = find_stellar_missions(StellarSearchQuery {
+        text: "Gathering Miscellany",
+        locale: Locale::EN,
+        job_id: None,
+    })
+    .collect::<Vec<_>>();
     assert_eq!(matching_missions.len(), 1);
 
     let mission_id = matching_missions[0].0;
@@ -93,8 +97,12 @@ fn gathering_miscellany() {
 
 #[test]
 fn meteoric_material_test_processing() {
-    let matching_missions =
-        find_stellar_missions("Meteoric Material Test Processing", Locale::EN).collect::<Vec<_>>();
+    let matching_missions = find_stellar_missions(StellarSearchQuery {
+        text: "Meteoric Material Test Processing",
+        locale: Locale::EN,
+        job_id: None,
+    })
+    .collect::<Vec<_>>();
     assert_eq!(matching_missions.len(), 3); // BSM, ARM, GSM
 
     let mission_id = matching_missions[0].0;
@@ -223,8 +231,52 @@ fn meteoric_material_test_processing() {
 
 #[test]
 fn ex_natural_remedy_inspection_ii() {
-    let matching_missions =
-        find_stellar_missions("EX: Natural Remedy Inspection II", Locale::EN).collect::<Vec<_>>();
+    let matching_missions = find_stellar_missions(StellarSearchQuery {
+        text: "EX: Natural Remedy Inspection II",
+        locale: Locale::EN,
+        job_id: None,
+    })
+    .collect::<Vec<_>>();
+    assert_eq!(matching_missions.len(), 1);
+
+    let mission_id = matching_missions[0].0;
+    let mission_details = DetailedMissionInfo::from_mission_id(mission_id);
+    let expected_details = expect![[r#"
+        DetailedMissionInfo {
+            job_id: 6,
+            recipes: [
+                DetailedRecipeInfo {
+                    recipe_id: 36588,
+                    resulting_item: DetailedItemInfo {
+                        item_id: 48574,
+                        item_name: "Survey Tincture \u{e03d}",
+                    },
+                    progress: 7500,
+                    quality: 15400,
+                    durability: 75,
+                },
+            ],
+        }
+    "#]];
+    expected_details.assert_debug_eq(&mission_details);
+}
+
+#[test]
+fn ex_natural_remedy_inspection_ii_jobids() {
+    let nonmatching_missions = find_stellar_missions(StellarSearchQuery {
+        text: "EX: Natural Remedy Inspection II",
+        locale: Locale::EN,
+        job_id: Some(0),
+    })
+    .collect::<Vec<_>>();
+    assert_eq!(nonmatching_missions.len(), 0);
+
+    let matching_missions = find_stellar_missions(StellarSearchQuery {
+        text: "EX: Natural Remedy Inspection II",
+        locale: Locale::EN,
+        job_id: Some(6),
+    })
+    .collect::<Vec<_>>();
     assert_eq!(matching_missions.len(), 1);
 
     let mission_id = matching_missions[0].0;

--- a/raphael-data/tests/test_stellar_missions.rs
+++ b/raphael-data/tests/test_stellar_missions.rs
@@ -263,13 +263,13 @@ fn ex_natural_remedy_inspection_ii() {
 
 #[test]
 fn ex_natural_remedy_inspection_ii_jobids() {
-    let nonmatching_missions = find_stellar_missions(StellarSearchQuery {
+    let results_with_wrong_job = find_stellar_missions(StellarSearchQuery {
         text: "EX: Natural Remedy Inspection II",
         locale: Locale::EN,
         job_id: Some(0),
     })
     .collect::<Vec<_>>();
-    assert_eq!(nonmatching_missions.len(), 0);
+    assert!(results_with_wrong_job.is_empty());
 
     let matching_missions = find_stellar_missions(StellarSearchQuery {
         text: "EX: Natural Remedy Inspection II",

--- a/raphael-translations/translations.toml
+++ b/raphael-translations/translations.toml
@@ -58,7 +58,7 @@ chs = '''关闭'''
 tc = '''關閉'''
 ko = '''닫기'''
 version = "0.1.0"
-appearances = ["src/app.rs:100:45", "src/app.rs:152:45", "src/elements/panels/macro_view.rs:221:37", "src/update.rs:100:45", "src/update.rs:122:45", "src/update.rs:139:45"]
+appearances = ["src/app.rs:100:45", "src/app.rs:152:45", "src/elements/panels/macro_view.rs:221:37", "src/elements/panels/recipe_select.rs:465:41", "src/update.rs:100:45", "src/update.rs:122:45", "src/update.rs:139:45"]
 
 ["pgzB+gD4MKo66zNoY8FNpQ=="]
 en = '''No solution'''
@@ -578,7 +578,7 @@ chs = '''自定义'''
 tc = '''自訂'''
 ko = '''사용자 설정'''
 version = "0.1.0"
-appearances = ["src/config.rs:175:43", "src/elements/panels/recipe_select.rs:458:44"]
+appearances = ["src/config.rs:175:43", "src/elements/panels/recipe_select.rs:502:44"]
 
 ["u8MNP8lLoB18+dt06cfdzQ=="]
 en = '''The format can be any arbitrary text or FFXIV command.\n\nThe following placeholders can be used to output their respective value:\n  - {index} : the index or number of the macro block\n  - {max_index} : the maximum index or number of macro blocks\n  - {item_name} : the name of the selected recipe's item result\n  - {food} : the name of the selected food\n  - {potion} : the name of the selected potion\n  - {craftsmanship} : the base craftsmanship stat\n  - {control} : the base control stat\n  - {cp} : the base CP stat'''
@@ -858,7 +858,7 @@ chs = '''配方'''
 tc = '''配方'''
 ko = '''제작법'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:31:41"]
+appearances = ["src/elements/panels/recipe_select.rs:32:41"]
 
 ["s/ovMAAC5l5RoZQTq5NHTg=="]
 en = '''Missions'''
@@ -868,7 +868,7 @@ chs = '''任务'''
 tc = '''任務'''
 ko = '''임무'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:32:49"]
+appearances = ["src/elements/panels/recipe_select.rs:33:49"]
 
 ["3ninXzetsJO21k7Af0PZuA=="]
 en = '''🔍 Search'''
@@ -878,7 +878,7 @@ chs = '''🔍 搜索'''
 tc = '''🔍 搜尋'''
 ko = '''🔍 검색'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:133:39", "src/elements/panels/consumable_select.rs:114:43"]
+appearances = ["src/elements/panels/recipe_select.rs:135:39", "src/elements/panels/consumable_select.rs:114:43"]
 
 ["UfUIG2T4uxtuhNjcxVbhIw=="]
 en = '''Select'''
@@ -888,7 +888,7 @@ chs = '''选择'''
 tc = '''選擇'''
 ko = '''선택'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:199:45", "src/elements/panels/recipe_select.rs:273:57", "src/elements/panels/consumable_select.rs:161:53", "src/elements/util.rs:97:43"]
+appearances = ["src/elements/panels/recipe_select.rs:209:45", "src/elements/panels/recipe_select.rs:283:57", "src/elements/panels/consumable_select.rs:161:53", "src/elements/util.rs:97:43"]
 
 ["U71vRCskzp/0ZNKDCqyXYw=="]
 en = '''⚠ Patch {ffxiv_patch} recipes and items are already included. Only use custom recipes if you are an advanced user or if new recipes haven't been added yet.'''
@@ -898,7 +898,7 @@ chs = '''⚠ 已包含 {ffxiv_patch} 版本更新的配方和物品。仅推荐�
 tc = '''⚠ 已包含 {ffxiv_patch} 版本更新的配方和物品。僅推薦專業使用者或新配方資料尚未更新時使用自訂配方功能'''
 ko = '''⚠ 패치 {ffxiv_patch}의 제작법과 아이템이 이미 포함되어 있습니다. 사용자정의 제작법은 숙련자용 또는 신규 제작법이 아직 추가되지 않은 경우에만 사용해 주세요.'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:305:13"]
+appearances = ["src/elements/panels/recipe_select.rs:315:13"]
 
 ["d7HtKDFSNezpnAEROlmBfA=="]
 en = '''Level:'''
@@ -908,7 +908,7 @@ chs = '''等级：'''
 tc = '''等級：'''
 ko = '''레벨:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:313:41"]
+appearances = ["src/elements/panels/recipe_select.rs:323:41"]
 
 ["X9WQkgT1iJzBPCuNN/JvnA=="]
 en = '''Recipe Level:'''
@@ -918,7 +918,7 @@ chs = '''配方等级：'''
 tc = '''配方等級：'''
 ko = '''제작법 레벨:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:324:45"]
+appearances = ["src/elements/panels/recipe_select.rs:334:45"]
 
 ["YFBU1I3swO+hctnHg9pD9g=="]
 en = '''Progress:'''
@@ -928,7 +928,7 @@ chs = '''进展：'''
 tc = '''進展：'''
 ko = '''작업량:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:335:41"]
+appearances = ["src/elements/panels/recipe_select.rs:345:41"]
 
 ["1SwYHyOKKUpeJrqxy6qw3g=="]
 en = '''Quality:'''
@@ -938,7 +938,7 @@ chs = '''品质：'''
 tc = '''品質：'''
 ko = '''품질:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:341:41"]
+appearances = ["src/elements/panels/recipe_select.rs:351:41"]
 
 ["jZQbTryjaUmYZZvlsHUtAQ=="]
 en = '''Initial Quality:'''
@@ -948,7 +948,7 @@ chs = '''初期品质：'''
 tc = '''初期品質：'''
 ko = '''초기 품질:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:350:45"]
+appearances = ["src/elements/panels/recipe_select.rs:360:45"]
 
 ["W60Qz/MbXdea5Fbt8w36dQ=="]
 en = '''Durability:'''
@@ -958,7 +958,7 @@ chs = '''耐久：'''
 tc = '''耐久：'''
 ko = '''내구도:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:355:41"]
+appearances = ["src/elements/panels/recipe_select.rs:365:41"]
 
 ["JWHlmVKKcwQdoBto+WywoQ=="]
 en = '''Expert recipe'''
@@ -968,7 +968,7 @@ chs = '''专家配方'''
 tc = '''專家配方'''
 ko = '''고난도 제작법:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:361:63"]
+appearances = ["src/elements/panels/recipe_select.rs:371:63"]
 
 ["NnIkZMZ1I6bzAw6z+/Mkrw=="]
 en = '''Progress divider'''
@@ -978,7 +978,7 @@ chs = '''作业难度系数'''
 tc = '''作業難度系數'''
 ko = '''작업량 분리:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:368:45"]
+appearances = ["src/elements/panels/recipe_select.rs:378:45"]
 
 ["utcfvalMOEH1HXXDxo0QiQ=="]
 en = '''Quality divider'''
@@ -988,7 +988,7 @@ chs = '''加工难度系数'''
 tc = '''加工難度系數'''
 ko = '''품질 분리:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:372:45"]
+appearances = ["src/elements/panels/recipe_select.rs:382:45"]
 
 ["xG5frC1m0GiyFaKYj6hUbw=="]
 en = '''Progress modifier'''
@@ -997,7 +997,7 @@ de = '''Fortschritt-Modifikator'''
 chs = '''作业压制系数'''
 ko = '''작업량 보정:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:376:45"]
+appearances = ["src/elements/panels/recipe_select.rs:386:45"]
 
 ["IUbEtNqmPZ2zGIfJxqZ8ew=="]
 en = '''Quality modifier'''
@@ -1006,7 +1006,7 @@ de = '''Qualität-Modifikator'''
 chs = '''加工压制系数'''
 ko = '''품질 보정:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:380:45"]
+appearances = ["src/elements/panels/recipe_select.rs:390:45"]
 
 ["Ku75COVkZS7vs5feP8xfIg=="]
 en = '''Progress per 100% efficiency:'''
@@ -1015,7 +1015,7 @@ de = '''Fortschritt pro 100% Effizienz:'''
 chs = '''每100效率推动进展'''
 ko = '''효율 100%시의 작업량:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:386:41"]
+appearances = ["src/elements/panels/recipe_select.rs:396:41"]
 
 ["1lyQv8FR7jN32SKj8OGAEQ=="]
 en = '''Quality per 100% efficiency:'''
@@ -1024,7 +1024,7 @@ de = '''Qualität pro 100% Effizienz:'''
 chs = '''每100效率推动品质'''
 ko = '''효율 100%시의 품질'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:403:41"]
+appearances = ["src/elements/panels/recipe_select.rs:413:41"]
 
 ["+HWqDKvIsGRlyEP1fjeelQ=="]
 en = '''Override per 100% efficiency values'''
@@ -1033,7 +1033,7 @@ de = '''Werte für 100% Effizienz überschreiben'''
 chs = '''覆盖每100效率的数值'''
 ko = '''효율 100%의 수치를 덮어쓰기:'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:422:36"]
+appearances = ["src/elements/panels/recipe_select.rs:432:36"]
 
 ["xg14pFym75QkPxg+VMf70w=="]
 en = '''Recipe'''
@@ -1043,7 +1043,7 @@ chs = '''配方'''
 tc = '''配方'''
 ko = '''제작법'''
 version = "0.1.0"
-appearances = ["src/elements/panels/recipe_select.rs:452:61", "src/elements/panels/saved_rotations.rs:492:28", "src/elements/panels/saved_rotations.rs:505:28"]
+appearances = ["src/elements/panels/recipe_select.rs:496:61", "src/elements/panels/saved_rotations.rs:492:28", "src/elements/panels/saved_rotations.rs:505:28"]
 
 ["pwNUD9CFWaFvbreERTHQww=="]
 en = '''Food'''
@@ -1396,3 +1396,13 @@ appearances = ["src/app.rs:132:45"]
 en = '''Solving this configuration requires a 64-bit version of Raphael.'''
 version = "0.1.0"
 appearances = ["src/app.rs:133:45"]
+
+["dEkpIt0ZyrnzZHGx2Iuilw=="]
+en = '''Recipe Filter Settings'''
+version = "0.1.0"
+appearances = ["src/elements/panels/recipe_select.rs:457:53"]
+
+["HOE4QGs+EZhKpOBh3JbvPg=="]
+en = '''Active Job Only'''
+version = "0.1.0"
+appearances = ["src/elements/panels/recipe_select.rs:461:28"]

--- a/raphael-translations/translations.toml
+++ b/raphael-translations/translations.toml
@@ -1397,12 +1397,12 @@ en = '''Solving this configuration requires a 64-bit version of Raphael.'''
 version = "0.1.0"
 appearances = ["src/app.rs:133:45"]
 
-["dEkpIt0ZyrnzZHGx2Iuilw=="]
-en = '''Recipe Filter Settings'''
+["gXjI6djzbLN63op2crXLCg=="]
+en = '''Recipe filters'''
 version = "0.1.0"
 appearances = ["src/elements/panels/recipe_select.rs:457:53"]
 
-["HOE4QGs+EZhKpOBh3JbvPg=="]
-en = '''Active Job Only'''
+["Jmc3mzQWJhKQYa7M+LM3gA=="]
+en = '''Active job only'''
 version = "0.1.0"
 appearances = ["src/elements/panels/recipe_select.rs:461:28"]

--- a/src/context.rs
+++ b/src/context.rs
@@ -25,6 +25,7 @@ pub struct SearchState {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RecipeSearchState {
     pub show_custom_recipe_select: bool,
+    pub active_job_only: bool,
     pub search_domain: RecipeSearchDomain,
     pub search_text: String,
 }

--- a/src/elements/panels/recipe_select.rs
+++ b/src/elements/panels/recipe_select.rs
@@ -4,8 +4,9 @@ use egui::{
 };
 use egui_extras::Column;
 use raphael_data::{
-    Consumable, Locale, RLVLS, Recipe, RecipeSearchEntry, RecipeSearchQuery, StellarMissionSearchEntry, StellarSearchQuery, find_recipes,
-    find_stellar_missions, get_game_settings, get_job_name,
+    Consumable, Locale, RLVLS, Recipe, RecipeSearchEntry, RecipeSearchQuery,
+    StellarMissionSearchEntry, StellarSearchQuery, find_recipes, find_stellar_missions,
+    get_game_settings, get_job_name,
 };
 use raphael_translations::{t, t_format};
 
@@ -37,13 +38,8 @@ impl SearchDomain {
 #[derive(Default)]
 struct RecipeFinder {}
 
-impl ComputerMut<RecipeSearchQuery<'_>, Vec<RecipeSearchEntry>>
-    for RecipeFinder
-{
-    fn compute(
-        &mut self,
-        query: RecipeSearchQuery,
-    ) -> Vec<RecipeSearchEntry> {
+impl ComputerMut<RecipeSearchQuery<'_>, Vec<RecipeSearchEntry>> for RecipeFinder {
+    fn compute(&mut self, query: RecipeSearchQuery) -> Vec<RecipeSearchEntry> {
         find_recipes(query).collect::<Vec<_>>()
     }
 }
@@ -53,13 +49,8 @@ type RecipeSearchCache<'a> = FrameCache<Vec<RecipeSearchEntry>, RecipeFinder>;
 #[derive(Default)]
 struct StellarMissionFinder {}
 
-impl ComputerMut<StellarSearchQuery<'_>, Vec<StellarMissionSearchEntry>>
-    for StellarMissionFinder
-{
-    fn compute(
-        &mut self,
-        query: StellarSearchQuery,
-    ) -> Vec<StellarMissionSearchEntry> {
+impl ComputerMut<StellarSearchQuery<'_>, Vec<StellarMissionSearchEntry>> for StellarMissionFinder {
+    fn compute(&mut self, query: StellarSearchQuery) -> Vec<StellarMissionSearchEntry> {
         find_stellar_missions(query).collect::<Vec<_>>()
     }
 }

--- a/src/elements/panels/recipe_select.rs
+++ b/src/elements/panels/recipe_select.rs
@@ -127,16 +127,20 @@ impl<'a> RecipeSelect<'a> {
                 [SearchDomain::Recipes, SearchDomain::StellarMissions],
                 |search_domain: SearchDomain| search_domain.display(locale),
             ));
-            if ui.button("⚙").clicked() {
-                set_filter_modal_visibility(ui.ctx(), true);
-            }
+            let search_text_edit_width = ui.available_width()
+                - (util::text_width(ui, "⚙", egui::TextStyle::Button)
+                    + ui.style().spacing.button_padding.x * 2.0)
+                - ui.style().spacing.item_spacing.x;
             if egui::TextEdit::singleline(search_text)
-                .desired_width(f32::INFINITY)
+                .desired_width(search_text_edit_width)
                 .hint_text(t!(locale, "🔍 Search"))
                 .ui(ui)
                 .changed()
             {
                 *search_text = search_text.replace('\0', "");
+            }
+            if ui.button("⚙").clicked() {
+                set_filter_modal_visibility(ui.ctx(), true);
             }
         });
 
@@ -446,7 +450,7 @@ impl<'a> RecipeSelect<'a> {
             });
         });
     }
-    fn draw_config_menu(&mut self, ctx: &egui::Context) {
+    fn draw_recipe_filter_modal(&mut self, ctx: &egui::Context) {
         let locale = self.locale;
         egui::containers::Modal::new(egui::Id::new("RECIPE_FILTER_MODAL")).show(ctx, |ui| {
             ui.set_width(
@@ -454,11 +458,11 @@ impl<'a> RecipeSelect<'a> {
                     .clamp(0.0, 360.0),
             );
             ui.style_mut().spacing.item_spacing.y = 3.0;
-            ui.label(egui::RichText::new(t!(locale, "Recipe Filter Settings")).strong());
+            ui.label(egui::RichText::new(t!(locale, "Recipe filters")).strong());
             ui.separator();
             ui.checkbox(
                 &mut self.search_state.active_job_only,
-                t!(locale, "Active Job Only"),
+                t!(locale, "Active job only"),
             );
             ui.separator();
             ui.vertical_centered_justified(|ui| {
@@ -484,7 +488,7 @@ impl Widget for RecipeSelect<'_> {
         let locale = self.locale;
 
         if filter_modal_is_visible(ui.ctx()) {
-            self.draw_config_menu(ui.ctx());
+            self.draw_recipe_filter_modal(ui.ctx());
         }
         ui.group(|ui| {
             ui.style_mut().spacing.item_spacing = egui::vec2(8.0, 3.0);

--- a/src/elements/panels/recipe_select.rs
+++ b/src/elements/panels/recipe_select.rs
@@ -127,6 +127,9 @@ impl<'a> RecipeSelect<'a> {
                 [SearchDomain::Recipes, SearchDomain::StellarMissions],
                 |search_domain: SearchDomain| search_domain.display(locale),
             ));
+            if ui.button("⚙").clicked() {
+                set_filter_modal_visibility(ui.ctx(), true);
+            }
             if egui::TextEdit::singleline(search_text)
                 .desired_width(f32::INFINITY)
                 .hint_text(t!(locale, "🔍 Search"))
@@ -443,12 +446,46 @@ impl<'a> RecipeSelect<'a> {
             });
         });
     }
+    fn draw_config_menu(&mut self, ctx: &egui::Context) {
+        let locale = self.locale;
+        egui::containers::Modal::new(egui::Id::new("RECIPE_FILTER_MODAL")).show(ctx, |ui| {
+            ui.set_width(
+                (ctx.content_rect().width() - ui.style().spacing.item_spacing.x * 4.0)
+                    .clamp(0.0, 360.0),
+            );
+            ui.style_mut().spacing.item_spacing.y = 3.0;
+            ui.label(egui::RichText::new(t!(locale, "Recipe Filter Settings")).strong());
+            ui.separator();
+            ui.checkbox(
+                &mut self.search_state.active_job_only,
+                t!(locale, "Active Job Only"),
+            );
+            ui.separator();
+            ui.vertical_centered_justified(|ui| {
+                if ui.button(t!(locale, "Close")).clicked() {
+                    set_filter_modal_visibility(ctx, false);
+                }
+            });
+        });
+    }
+}
+fn filter_modal_is_visible(ctx: &egui::Context) -> bool {
+    let id = egui::Id::new("RECIPE_FILTER_MODAL_VISIBLE");
+    ctx.data(|data| data.get_temp(id) == Some(true))
+}
+
+fn set_filter_modal_visibility(ctx: &egui::Context, visible: bool) {
+    let id = egui::Id::new("RECIPE_FILTER_MODAL_VISIBLE");
+    ctx.data_mut(|data| data.insert_temp(id, visible));
 }
 
 impl Widget for RecipeSelect<'_> {
     fn ui(mut self, ui: &mut egui::Ui) -> egui::Response {
         let locale = self.locale;
 
+        if filter_modal_is_visible(ui.ctx()) {
+            self.draw_config_menu(ui.ctx());
+        }
         ui.group(|ui| {
             ui.style_mut().spacing.item_spacing = egui::vec2(8.0, 3.0);
             ui.vertical(|ui| {
@@ -482,10 +519,6 @@ impl Widget for RecipeSelect<'_> {
                                 );
                             self.recipe_config.quality_source = QualitySource::Value(0);
                         }
-                        ui.checkbox(
-                            &mut self.search_state.active_job_only,
-                            t!(locale, "Active Job Only"),
-                        );
                     });
                 });
 

--- a/src/elements/panels/recipe_select.rs
+++ b/src/elements/panels/recipe_select.rs
@@ -4,7 +4,7 @@ use egui::{
 };
 use egui_extras::Column;
 use raphael_data::{
-    Consumable, Locale, RLVLS, Recipe, RecipeSearchQuery, StellarSearchQuery, find_recipes,
+    Consumable, Locale, RLVLS, Recipe, RecipeSearchEntry, RecipeSearchQuery, StellarMissionSearchEntry, StellarSearchQuery, find_recipes,
     find_stellar_missions, get_game_settings, get_job_name,
 };
 use raphael_translations::{t, t_format};
@@ -37,35 +37,35 @@ impl SearchDomain {
 #[derive(Default)]
 struct RecipeFinder {}
 
-impl ComputerMut<raphael_data::RecipeSearchQuery<'_>, Vec<raphael_data::RecipeSearchEntry>>
+impl ComputerMut<RecipeSearchQuery<'_>, Vec<RecipeSearchEntry>>
     for RecipeFinder
 {
     fn compute(
         &mut self,
-        query: raphael_data::RecipeSearchQuery,
-    ) -> Vec<raphael_data::RecipeSearchEntry> {
+        query: RecipeSearchQuery,
+    ) -> Vec<RecipeSearchEntry> {
         find_recipes(query).collect::<Vec<_>>()
     }
 }
 
-type RecipeSearchCache<'a> = FrameCache<Vec<raphael_data::RecipeSearchEntry>, RecipeFinder>;
+type RecipeSearchCache<'a> = FrameCache<Vec<RecipeSearchEntry>, RecipeFinder>;
 
 #[derive(Default)]
 struct StellarMissionFinder {}
 
-impl ComputerMut<raphael_data::StellarSearchQuery<'_>, Vec<raphael_data::StellarMissionSearchEntry>>
+impl ComputerMut<StellarSearchQuery<'_>, Vec<StellarMissionSearchEntry>>
     for StellarMissionFinder
 {
     fn compute(
         &mut self,
-        query: raphael_data::StellarSearchQuery,
-    ) -> Vec<raphael_data::StellarMissionSearchEntry> {
+        query: StellarSearchQuery,
+    ) -> Vec<StellarMissionSearchEntry> {
         find_stellar_missions(query).collect::<Vec<_>>()
     }
 }
 
 type StellarMissionSearchCache<'a> =
-    FrameCache<Vec<raphael_data::StellarMissionSearchEntry>, StellarMissionFinder>;
+    FrameCache<Vec<StellarMissionSearchEntry>, StellarMissionFinder>;
 
 pub struct RecipeSelect<'a> {
     search_state: &'a mut RecipeSearchState,
@@ -181,7 +181,7 @@ impl<'a> RecipeSelect<'a> {
     fn draw_recipe_select_table(
         &mut self,
         ui: &mut egui::Ui,
-        search_result: Vec<raphael_data::RecipeSearchEntry>,
+        search_result: Vec<RecipeSearchEntry>,
     ) {
         let locale = self.locale;
         let line_height = ui.spacing().interact_size.y;

--- a/src/elements/panels/recipe_select.rs
+++ b/src/elements/panels/recipe_select.rs
@@ -4,8 +4,8 @@ use egui::{
 };
 use egui_extras::Column;
 use raphael_data::{
-    Consumable, Locale, RLVLS, Recipe, find_recipes, find_stellar_missions, get_game_settings,
-    get_job_name,
+    Consumable, Locale, RLVLS, Recipe, RecipeSearchQuery, StellarSearchQuery, find_recipes,
+    find_stellar_missions, get_game_settings, get_job_name,
 };
 use raphael_translations::{t, t_format};
 
@@ -37,9 +37,14 @@ impl SearchDomain {
 #[derive(Default)]
 struct RecipeFinder {}
 
-impl ComputerMut<(&str, Locale), Vec<raphael_data::RecipeSearchEntry>> for RecipeFinder {
-    fn compute(&mut self, (text, locale): (&str, Locale)) -> Vec<raphael_data::RecipeSearchEntry> {
-        find_recipes(text, locale).collect::<Vec<_>>()
+impl ComputerMut<raphael_data::RecipeSearchQuery<'_>, Vec<raphael_data::RecipeSearchEntry>>
+    for RecipeFinder
+{
+    fn compute(
+        &mut self,
+        query: raphael_data::RecipeSearchQuery,
+    ) -> Vec<raphael_data::RecipeSearchEntry> {
+        find_recipes(query).collect::<Vec<_>>()
     }
 }
 
@@ -48,14 +53,14 @@ type RecipeSearchCache<'a> = FrameCache<Vec<raphael_data::RecipeSearchEntry>, Re
 #[derive(Default)]
 struct StellarMissionFinder {}
 
-impl ComputerMut<(&str, Locale), Vec<raphael_data::StellarMissionSearchEntry>>
+impl ComputerMut<raphael_data::StellarSearchQuery<'_>, Vec<raphael_data::StellarMissionSearchEntry>>
     for StellarMissionFinder
 {
     fn compute(
         &mut self,
-        (text, locale): (&str, Locale),
+        query: raphael_data::StellarSearchQuery,
     ) -> Vec<raphael_data::StellarMissionSearchEntry> {
-        find_stellar_missions(text, locale).collect::<Vec<_>>()
+        find_stellar_missions(query).collect::<Vec<_>>()
     }
 }
 
@@ -116,10 +121,13 @@ impl<'a> RecipeSelect<'a> {
                 RecipeSearchState {
                     search_domain,
                     search_text,
+                    active_job_only,
                     ..
                 },
             ..
         } = self;
+
+        let job_id = active_job_only.then_some(self.crafter_config.selected_job);
 
         ui.horizontal(|ui| {
             ui.add(DropDown::new(
@@ -145,7 +153,11 @@ impl<'a> RecipeSelect<'a> {
                 let search_result = ui.ctx().memory_mut(|mem| {
                     mem.caches
                         .cache::<RecipeSearchCache<'_>>()
-                        .get((search_text, locale))
+                        .get(RecipeSearchQuery {
+                            text: search_text,
+                            locale,
+                            job_id,
+                        })
                         .clone()
                 });
                 self.draw_recipe_select_table(ui, search_result);
@@ -154,7 +166,11 @@ impl<'a> RecipeSelect<'a> {
                 let search_result = ui.ctx().memory_mut(|mem| {
                     mem.caches
                         .cache::<StellarMissionSearchCache<'_>>()
-                        .get((search_text, locale))
+                        .get(StellarSearchQuery {
+                            text: search_text,
+                            locale,
+                            job_id,
+                        })
                         .clone()
                 });
                 self.draw_mission_recipe_select(ui, search_result);
@@ -475,6 +491,10 @@ impl Widget for RecipeSelect<'_> {
                                 );
                             self.recipe_config.quality_source = QualitySource::Value(0);
                         }
+                        ui.checkbox(
+                            &mut self.search_state.active_job_only,
+                            t!(locale, "Active Job Only"),
+                        );
                     });
                 });
 


### PR DESCRIPTION
This adds a new "Active Job Only" checkbox to the recipe pane which limits the shown recipes/missions to the currently selected job.  Equivalent options are also added to the command line, the queries have been converted from nameless tuples to structs, and new tests are added.

Closes #343