### PR TITLE
Add a greedy solver using beam search to warm-start the lower bounds on Quality

### DIFF
--- a/raphael-solver/src/lib.rs
+++ b/raphael-solver/src/lib.rs
@@ -12,6 +12,8 @@ use step_lower_bound_solver::StepLbSolver;
 mod macro_solver;
 pub use macro_solver::MacroSolver;
 
+mod seed_solver;
+
 mod utils;
 pub use utils::AtomicFlag;
 

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -97,7 +97,7 @@ impl<'a> MacroSolver<'a> {
 
         let seed = {
             let _timer = ScopedTimer::new("Seed Solver");
-            seed_solver::beam_seed(&self.settings)
+            seed_solver::beam_seed(&self.settings, &self.finish_solver)
         };
 
         let timer = ScopedTimer::new("Quality UB Solver");

--- a/raphael-solver/src/macro_solver/solver.rs
+++ b/raphael-solver/src/macro_solver/solver.rs
@@ -10,6 +10,7 @@ use crate::quality_upper_bound_solver::{
     QualityUbSolverShard, QualityUbSolverStats, QualityUbStates,
 };
 use crate::step_lower_bound_solver::{StepLbSolverShard, StepLbSolverStats, StepLbStates};
+use crate::seed_solver;
 use crate::utils::AtomicFlag;
 use crate::utils::ScopedTimer;
 use crate::{FinishSolver, QualityUbSolver, SolverException, SolverSettings, StepLbSolver};
@@ -94,6 +95,11 @@ impl<'a> MacroSolver<'a> {
         }
         drop(timer);
 
+        let seed = {
+            let _timer = ScopedTimer::new("Seed Solver");
+            seed_solver::beam_seed(&self.settings)
+        };
+
         let timer = ScopedTimer::new("Quality UB Solver");
         quality_ub_solver.precompute()?;
         drop(timer);
@@ -112,7 +118,7 @@ impl<'a> MacroSolver<'a> {
 
         let timer = ScopedTimer::new("Search");
         let actions = self
-            .do_solve(&mut quality_ub_solver, &mut step_lb_solver, initial_state)?
+            .do_solve(&mut quality_ub_solver, &mut step_lb_solver, initial_state, seed)?
             .actions();
         drop(timer);
 
@@ -121,15 +127,62 @@ impl<'a> MacroSolver<'a> {
         Ok(actions)
     }
 
+    /// Replays `seed` from `state`. Returns the final state and its solution
+    /// score if the rotation is valid and completes the craft.
+    fn replay_seed(
+        settings: &SolverSettings,
+        mut state: SimulationState,
+        seed: &[ActionCombo],
+    ) -> Option<(SimulationState, SearchScore)> {
+        let mut steps: u8 = 0;
+        let mut duration: u8 = 0;
+        for &combo in seed {
+            state = use_action_combo(settings, state, combo).ok()?;
+            steps = steps.saturating_add(combo.steps());
+            duration = duration.saturating_add(combo.duration());
+        }
+        if state.progress < settings.max_progress() {
+            return None;
+        }
+        let score = SearchScore {
+            quality_upper_bound: std::cmp::min(state.quality, settings.max_quality()),
+            steps_lower_bound: steps,
+            duration_lower_bound: duration,
+            current_steps: steps,
+            current_duration: duration,
+        };
+        Some((state, score))
+    }
+
     fn do_solve<'alloc>(
         &mut self,
         quality_ub_solver: &mut QualityUbSolver<'alloc>,
         step_lb_solver: &mut StepLbSolver<'alloc>,
         state: SimulationState,
+        seed: Option<Vec<ActionCombo>>,
     ) -> Result<Solution, SolverException> {
         let mut search_queue = SearchQueue::new(self.settings, state);
         let mut solution: Option<Solution> = None;
         let mut min_accepted_score = SearchScore::MIN;
+
+        // Replay-validate the seed rotation and install it as the initial
+        // solution, so the search starts with a non-trivial score lower-bound.
+        // A seed that fails validation is simply discarded.
+        if let Some(seed) = seed
+            && let Some((seed_state, seed_score)) = Self::replay_seed(&self.settings, state, &seed)
+        {
+            min_accepted_score = seed_score;
+            solution = Some(Solution {
+                score: (seed_score, seed_state.quality),
+                solver_actions: seed,
+            });
+            (self.solution_callback)(&solution.as_ref().unwrap().actions());
+            log::debug!(
+                "seed solution installed: quality {}, {} steps",
+                seed_state.quality,
+                seed_score.current_steps,
+            );
+        }
 
         while let Some(Batch {
             score,

--- a/raphael-solver/src/seed_solver.rs
+++ b/raphael-solver/src/seed_solver.rs
@@ -1,0 +1,285 @@
+//! Warm-start seeding for the macro solver.
+//!
+//! `beam_seed` runs a small beam search over the solver's action alphabet to
+//! produce a complete, valid rotation before the main search starts. The macro
+//! solver replays the seed and installs it as the initial solution, giving the
+//! search a non-trivial score lower-bound from the first batch instead of
+//! discovering one gradually. This only reduces the number of nodes inserted
+//! into the search queue; nodes required to prove optimality are unaffected,
+//! so the final solution is unchanged.
+//!
+//! Beam states are ranked by the quality of a greedy "close-out" rollout
+//! (finishing the craft from that state immediately), not by their held
+//! resources: a partial rotation is only worth what it can be converted into.
+//! The rollout of the best-ranked state doubles as the seed candidate.
+
+use raphael_sim::{Action, Condition, Settings, SimulationState};
+use rayon::prelude::*;
+use rustc_hash::FxHashMap;
+
+use crate::SolverSettings;
+use crate::actions::{ActionCombo, FULL_SEARCH_ACTIONS, use_action_combo};
+
+// Arbitrary. On M4 MBA this takes ~300ms. Might be worth benchmarking,
+// as weaker hardware might experience too much additional time during
+// this search to be worth the savings that only show up in harder crafts
+const BEAM_WIDTH: usize = 4096;
+const MAX_DEPTH: usize = 40;
+
+const PROGRESS_ACTIONS: [Action; 6] = [
+    Action::RapidSynthesis,
+    Action::Groundwork,
+    Action::PrudentSynthesis,
+    Action::CarefulSynthesis,
+    Action::DelicateSynthesis,
+    Action::BasicSynthesis,
+];
+
+/// Greedily completes Progress from `state`.
+/// Returns the capped Quality of the finished craft and the used actions.
+fn close_progress(
+    settings: &Settings,
+    mut state: SimulationState,
+    mut actions: Vec<Action>,
+) -> Option<(u16, Vec<Action>)> {
+    for _ in 0..20 {
+        if state.progress >= settings.max_progress {
+            return Some((std::cmp::min(state.quality, settings.max_quality), actions));
+        }
+        // Any single action that finishes the craft right now, cheapest CP first.
+        let mut finisher: Option<(u16, Action, SimulationState)> = None;
+        for action in PROGRESS_ACTIONS {
+            if let Ok(child) = state.use_action(action, Condition::Normal, settings)
+                && child.progress >= settings.max_progress
+            {
+                let cp_cost = state.cp - child.cp;
+                if finisher.as_ref().is_none_or(|(cost, _, _)| cp_cost < *cost) {
+                    finisher = Some((cp_cost, action, child));
+                }
+            }
+        }
+        if let Some((_, action, child)) = finisher {
+            actions.push(action);
+            state = child;
+            continue;
+        }
+        // Build-up: Stellar Steady Hand, Veneration, a mend if durability-starved,
+        // then the strongest affordable Progress action.
+        let mut candidates: Vec<Action> = Vec::new();
+        if state.effects.stellar_steady_hand_charges() > 0
+            && state.effects.stellar_steady_hand() == 0
+        {
+            candidates.push(Action::StellarSteadyHand);
+        }
+        if state.effects.veneration() == 0 && state.cp >= 18 + 7 {
+            candidates.push(Action::Veneration);
+        }
+        if state.durability <= 10 {
+            if state.cp >= 112 && settings.max_durability - state.durability > 30 {
+                candidates.push(Action::ImmaculateMend);
+            }
+            if state.cp >= 88 {
+                candidates.push(Action::MasterMend);
+            }
+        }
+        candidates.extend(PROGRESS_ACTIONS);
+        let mut advanced = false;
+        for action in candidates {
+            if let Ok(child) = state.use_action(action, Condition::Normal, settings) {
+                let is_progress_action = !matches!(
+                    action,
+                    Action::StellarSteadyHand
+                        | Action::Veneration
+                        | Action::ImmaculateMend
+                        | Action::MasterMend
+                );
+                if is_progress_action
+                    && child.durability == 0
+                    && child.progress < settings.max_progress
+                {
+                    continue; // would deadlock the rollout
+                }
+                actions.push(action);
+                state = child;
+                advanced = true;
+                break;
+            }
+        }
+        if !advanced {
+            return None;
+        }
+    }
+    None
+}
+
+/// Greedy close-out rollout: spends CP on Quality while reserving enough
+/// resources to complete Progress, then completes Progress.
+/// Returns the capped Quality of the finished craft and the used actions.
+fn close_out(settings: &Settings, mut state: SimulationState) -> Option<(u16, Vec<Action>)> {
+    let mut actions = Vec::new();
+    // Resources reserved for the Progress phase of the rollout.
+    let (reserve_cp, reserve_durability): (u16, u16) =
+        if state.effects.stellar_steady_hand_charges() > 0
+            || state.effects.stellar_steady_hand() >= 3
+        {
+            // Veneration + guaranteed Rapid Synthesis spam
+            (18, 30)
+        } else {
+            // Veneration + Careful Synthesis spam
+            (18 + 9 * 7, 90)
+        };
+    for _ in 0..24 {
+        if state.quality >= settings.max_quality {
+            break;
+        }
+        let effects = state.effects;
+        let mut budget = state.cp.saturating_sub(reserve_cp);
+        if state.durability < reserve_durability {
+            budget = budget.saturating_sub(88); // price in a Master's Mend
+        }
+        let action = if budget >= 24
+            && effects.inner_quiet() >= 8
+            && effects.great_strides() > 0
+            && effects.innovation() > 0
+        {
+            Some(Action::ByregotsBlessing)
+        } else if budget >= 50 && effects.innovation() == 0 {
+            if effects.quick_innovation_available() {
+                Some(Action::QuickInnovation)
+            } else {
+                Some(Action::Innovation)
+            }
+        } else if budget >= 56
+            && effects.inner_quiet() == 10
+            && effects.great_strides() == 0
+            && effects.innovation() > 1
+        {
+            Some(Action::GreatStrides)
+        } else if budget >= 32 && effects.inner_quiet() == 10 {
+            Some(Action::TrainedFinesse)
+        } else if budget >= 25 && state.durability > 5 && effects.waste_not() == 0 {
+            Some(Action::PrudentTouch)
+        } else if budget >= 18 && state.durability > 10 {
+            Some(Action::BasicTouch)
+        } else if budget >= 24 && effects.inner_quiet() > 0 {
+            Some(Action::ByregotsBlessing)
+        } else {
+            None
+        };
+        let Some(action) = action else { break };
+        let Ok(child) = state.use_action(action, Condition::Normal, settings) else {
+            break;
+        };
+        if child.durability == 0 {
+            break;
+        }
+        actions.push(action);
+        state = child;
+    }
+    close_progress(settings, state, actions)
+}
+
+/// Produces a complete rotation to be used as the macro solver's initial
+/// solution, or `None` if no complete rotation was found.
+pub fn beam_seed(settings: &SolverSettings) -> Option<Vec<ActionCombo>> {
+    let sim_settings = &settings.simulator_settings;
+    let initial_state = SimulationState::new(sim_settings);
+
+    // Arena of (parent index, combo). Rotations are reconstructed by walking
+    // parent links; index 0 is the root sentinel.
+    let mut arena: Vec<(usize, ActionCombo)> = vec![(usize::MAX, ActionCombo::None)];
+    let mut frontier: Vec<(SimulationState, usize)> = vec![(initial_state, 0)];
+    let mut best: Option<(u16, Vec<ActionCombo>)> = None;
+
+    let rotation_of = |arena: &[(usize, ActionCombo)], mut index: usize| -> Vec<ActionCombo> {
+        let mut combos = Vec::new();
+        while index != 0 {
+            let (parent, combo) = arena[index];
+            combos.push(combo);
+            index = parent;
+        }
+        combos.reverse();
+        combos
+    };
+
+    for _ in 0..MAX_DEPTH {
+        let expanded: Vec<(SimulationState, usize, ActionCombo)> = frontier
+            .par_iter()
+            .flat_map_iter(|&(state, parent_index)| {
+                FULL_SEARCH_ACTIONS.iter().filter_map(move |&combo| {
+                    use_action_combo(settings, state, combo)
+                        .ok()
+                        .map(|child| (child, parent_index, combo))
+                })
+            })
+            .collect();
+
+        let mut dedup: FxHashMap<SimulationState, (usize, ActionCombo)> = FxHashMap::default();
+        for (child, parent_index, combo) in expanded {
+            if child.progress >= sim_settings.max_progress {
+                // Completed within the beam itself.
+                let quality = std::cmp::min(child.quality, sim_settings.max_quality);
+                if best.as_ref().is_none_or(|(best_quality, _)| quality > *best_quality) {
+                    let mut combos = rotation_of(&arena, parent_index);
+                    combos.push(combo);
+                    best = Some((quality, combos));
+                }
+            } else if child.durability != 0 {
+                dedup.entry(child).or_insert((parent_index, combo));
+            }
+        }
+        if dedup.is_empty() {
+            break;
+        }
+
+        // Rank candidates by the quality of their close-out rollout.
+        let mut scored: Vec<(u16, u32, SimulationState, usize, ActionCombo, Vec<Action>)> = dedup
+            .into_par_iter()
+            .filter_map(|(child, (parent_index, combo))| {
+                let (rollout_quality, rollout) = close_out(sim_settings, child)?;
+                let tie_break = u32::from(child.quality)
+                    + 30 * u32::from(child.cp)
+                    + 55 * u32::from(child.durability);
+                Some((rollout_quality, tie_break, child, parent_index, combo, rollout))
+            })
+            .collect();
+        // The final state-derived key makes truncation deterministic across runs.
+        scored.par_sort_unstable_by_key(|&(quality, tie_break, state, ..)| {
+            (
+                std::cmp::Reverse(quality),
+                std::cmp::Reverse(tie_break),
+                state.effects.into_bits(),
+                state.cp,
+                state.durability,
+                state.progress,
+                state.quality,
+            )
+        });
+        scored.truncate(BEAM_WIDTH);
+
+        if let Some((rollout_quality, _, _, parent_index, combo, rollout)) = scored.first()
+            && best.as_ref().is_none_or(|(best_quality, _)| *rollout_quality > *best_quality)
+        {
+            let mut combos = rotation_of(&arena, *parent_index);
+            combos.push(*combo);
+            combos.extend(rollout.iter().copied().map(ActionCombo::Single));
+            best = Some((*rollout_quality, combos));
+        }
+
+        frontier = scored
+            .into_iter()
+            .map(|(_, _, child, parent_index, combo, _)| {
+                arena.push((parent_index, combo));
+                (child, arena.len() - 1)
+            })
+            .collect();
+
+        if best
+            .as_ref()
+            .is_some_and(|(quality, _)| *quality >= sim_settings.max_quality)
+        {
+            break;
+        }
+    }
+    best.map(|(_, combos)| combos)
+}

--- a/raphael-solver/src/seed_solver.rs
+++ b/raphael-solver/src/seed_solver.rs
@@ -1,187 +1,172 @@
 //! Warm-start seeding for the macro solver.
-//!
-//! `beam_seed` runs a small beam search over the solver's action alphabet to
-//! produce a complete, valid rotation before the main search starts. The macro
-//! solver replays the seed and installs it as the initial solution, giving the
-//! search a non-trivial score lower-bound from the first batch instead of
-//! discovering one gradually. This only reduces the number of nodes inserted
-//! into the search queue; nodes required to prove optimality are unaffected,
-//! so the final solution is unchanged.
-//!
-//! Beam states are ranked by the quality of a greedy "close-out" rollout
-//! (finishing the craft from that state immediately), not by their held
-//! resources: a partial rotation is only worth what it can be converted into.
-//! The rollout of the best-ranked state doubles as the seed candidate.
 
-use raphael_sim::{Action, Condition, Settings, SimulationState};
+use raphael_sim::{Action, SimulationState};
 use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 
-use crate::SolverSettings;
-use crate::actions::{ActionCombo, FULL_SEARCH_ACTIONS, use_action_combo};
+use crate::actions::{
+    ActionCombo, FULL_SEARCH_ACTIONS, PROGRESS_ONLY_SEARCH_ACTIONS, use_action_combo,
+};
+use crate::{FinishSolver, SolverSettings};
 
 // Arbitrary. On M4 MBA this takes ~300ms. Might be worth benchmarking,
 // as weaker hardware might experience too much additional time during
 // this search to be worth the savings that only show up in harder crafts
 const BEAM_WIDTH: usize = 4096;
 const MAX_DEPTH: usize = 40;
+/// Only the best `PRE_RANK_WIDTH` candidates (by held resources) of each
+/// depth receive a close-out rollout
+const PRE_RANK_WIDTH: usize = 4 * BEAM_WIDTH;
 
-const PROGRESS_ACTIONS: [Action; 6] = [
-    Action::RapidSynthesis,
-    Action::Groundwork,
-    Action::PrudentSynthesis,
-    Action::CarefulSynthesis,
-    Action::DelicateSynthesis,
-    Action::BasicSynthesis,
+/// Cheap state score used for pre-ranking and tie-breaking.
+fn resource_score(state: &SimulationState) -> u32 {
+    u32::from(state.quality) + 30 * u32::from(state.cp) + 55 * u32::from(state.durability)
+}
+
+/// Quality actions that can cash in a freshly applied buff.
+/// The rollout only casts a buff if at least one of these is usable afterwards.
+const CASH_ACTIONS: [Action; 4] = [
+    Action::ByregotsBlessing,
+    Action::TrainedFinesse,
+    Action::PrudentTouch,
+    Action::BasicTouch,
 ];
 
-/// Greedily completes Progress from `state`.
-/// Returns the capped Quality of the finished craft and the used actions.
-fn close_progress(
-    settings: &Settings,
+fn use_single(
+    settings: &SolverSettings,
+    state: SimulationState,
+    action: Action,
+) -> Option<SimulationState> {
+    use_action_combo(settings, state, ActionCombo::Single(action)).ok()
+}
+
+/// Greedy close-out rollout: spends CP on Quality for as long as the finish
+/// solver confirms the craft remains finishable, then completes Progress by
+/// walking the finish-solver table.
+/// Returns the capped Quality of the finished craft and, if `RECORD` is set,
+/// the used actions (otherwise the returned `Vec` is empty).
+fn close_out<const RECORD: bool>(
+    settings: &SolverSettings,
+    finish_solver: &FinishSolver,
     mut state: SimulationState,
-    mut actions: Vec<Action>,
-) -> Option<(u16, Vec<Action>)> {
-    for _ in 0..20 {
-        if state.progress >= settings.max_progress {
-            return Some((std::cmp::min(state.quality, settings.max_quality), actions));
+) -> Option<(u16, Vec<ActionCombo>)> {
+    let finishable = |state: &SimulationState| {
+        state.durability > 0 && finish_solver.can_finish(state).unwrap_or(false)
+    };
+    if !finishable(&state) {
+        return None;
+    }
+    let mut actions = Vec::new();
+    // Quality phase: greedy priority ladder. Every step must keep the craft
+    // finishable, and a buff must be cashable by at least one follow-up touch.
+    'quality: for _ in 0..24 {
+        if state.quality >= settings.max_quality() {
+            break;
         }
-        // Any single action that finishes the craft right now, cheapest CP first.
-        let mut finisher: Option<(u16, Action, SimulationState)> = None;
-        for action in PROGRESS_ACTIONS {
-            if let Ok(child) = state.use_action(action, Condition::Normal, settings)
-                && child.progress >= settings.max_progress
-            {
-                let cp_cost = state.cp - child.cp;
-                if finisher.as_ref().is_none_or(|(cost, _, _)| cp_cost < *cost) {
-                    finisher = Some((cp_cost, action, child));
-                }
-            }
-        }
-        if let Some((_, action, child)) = finisher {
-            actions.push(action);
-            state = child;
-            continue;
-        }
-        // Build-up: Stellar Steady Hand, Veneration, a mend if durability-starved,
-        // then the strongest affordable Progress action.
+        let effects = state.effects;
         let mut candidates: Vec<Action> = Vec::new();
-        if state.effects.stellar_steady_hand_charges() > 0
-            && state.effects.stellar_steady_hand() == 0
-        {
-            candidates.push(Action::StellarSteadyHand);
+        if effects.inner_quiet() >= 8 && effects.great_strides() > 0 && effects.innovation() > 0 {
+            candidates.push(Action::ByregotsBlessing);
         }
-        if state.effects.veneration() == 0 && state.cp >= 18 + 7 {
-            candidates.push(Action::Veneration);
-        }
-        if state.durability <= 10 {
-            if state.cp >= 112 && settings.max_durability - state.durability > 30 {
-                candidates.push(Action::ImmaculateMend);
-            }
-            if state.cp >= 88 {
-                candidates.push(Action::MasterMend);
+        if effects.innovation() == 0 {
+            if effects.quick_innovation_available() {
+                candidates.push(Action::QuickInnovation);
+            } else {
+                candidates.push(Action::Innovation);
             }
         }
-        candidates.extend(PROGRESS_ACTIONS);
-        let mut advanced = false;
+        if effects.inner_quiet() == 10 && effects.great_strides() == 0 && effects.innovation() > 1 {
+            candidates.push(Action::GreatStrides);
+        }
+        if effects.inner_quiet() == 10 {
+            candidates.push(Action::TrainedFinesse);
+        }
+        candidates.push(Action::PrudentTouch);
+        candidates.push(Action::BasicTouch);
+        if effects.inner_quiet() > 0 {
+            candidates.push(Action::ByregotsBlessing); // last call before Progress
+        }
         for action in candidates {
-            if let Ok(child) = state.use_action(action, Condition::Normal, settings) {
-                let is_progress_action = !matches!(
-                    action,
-                    Action::StellarSteadyHand
-                        | Action::Veneration
-                        | Action::ImmaculateMend
-                        | Action::MasterMend
-                );
-                if is_progress_action
-                    && child.durability == 0
-                    && child.progress < settings.max_progress
-                {
-                    continue; // would deadlock the rollout
+            let Some(child) = use_single(settings, state, action) else {
+                continue;
+            };
+            if !finishable(&child) {
+                continue;
+            }
+            let is_buff = matches!(
+                action,
+                Action::Innovation | Action::QuickInnovation | Action::GreatStrides
+            );
+            if is_buff
+                && !CASH_ACTIONS.iter().any(|&touch| {
+                    use_single(settings, child, touch).is_some_and(|gc| finishable(&gc))
+                })
+            {
+                continue;
+            }
+            if RECORD {
+                actions.push(ActionCombo::Single(action));
+            }
+            state = child;
+            continue 'quality;
+        }
+        break; // no quality action keeps the craft finishable
+    }
+    // Finish phase: extract a finishing line from the finish-solver table.
+    // A finishable child always exists here (Bellman property of the table);
+    // the refresh guard below can rarely hide it, in which case the rollout
+    // is simply discarded.
+    for _ in 0..20 {
+        if state.progress >= settings.max_progress() {
+            return Some((std::cmp::min(state.quality, settings.max_quality()), actions));
+        }
+        let mut chosen: Option<(SimulationState, ActionCombo)> = None;
+        for &combo in &PROGRESS_ONLY_SEARCH_ACTIONS {
+            // Refreshing an already-active timer never brings the craft closer
+            // to finishing; without this guard the greedy pick below can spin
+            // on re-casting buffs (each re-cast is still "finishable").
+            let is_pointless_refresh = match combo {
+                ActionCombo::Single(Action::Veneration) => state.effects.veneration() > 0,
+                ActionCombo::Single(Action::WasteNot | Action::WasteNot2) => {
+                    state.effects.waste_not() > 0
                 }
-                actions.push(action);
-                state = child;
-                advanced = true;
-                break;
+                ActionCombo::Single(Action::Manipulation) => state.effects.manipulation() > 0,
+                ActionCombo::Single(Action::StellarSteadyHand) => {
+                    state.effects.stellar_steady_hand() > 0
+                }
+                _ => false,
+            };
+            if is_pointless_refresh {
+                continue;
+            }
+            let Ok(child) = use_action_combo(settings, state, combo) else {
+                continue;
+            };
+            // Rank by progress gained, then durability (so a mend is chosen
+            // exactly when it heals and no progress action is viable).
+            if (child.progress >= settings.max_progress() || finishable(&child))
+                && chosen.as_ref().is_none_or(|(best, _)| {
+                    (child.progress, child.durability) > (best.progress, best.durability)
+                })
+            {
+                chosen = Some((child, combo));
             }
         }
-        if !advanced {
-            return None;
+        let (child, combo) = chosen?;
+        if RECORD {
+            actions.push(combo);
         }
+        state = child;
     }
     None
 }
 
-/// Greedy close-out rollout: spends CP on Quality while reserving enough
-/// resources to complete Progress, then completes Progress.
-/// Returns the capped Quality of the finished craft and the used actions.
-fn close_out(settings: &Settings, mut state: SimulationState) -> Option<(u16, Vec<Action>)> {
-    let mut actions = Vec::new();
-    // Resources reserved for the Progress phase of the rollout.
-    let (reserve_cp, reserve_durability): (u16, u16) =
-        if state.effects.stellar_steady_hand_charges() > 0
-            || state.effects.stellar_steady_hand() >= 3
-        {
-            // Veneration + guaranteed Rapid Synthesis spam
-            (18, 30)
-        } else {
-            // Veneration + Careful Synthesis spam
-            (18 + 9 * 7, 90)
-        };
-    for _ in 0..24 {
-        if state.quality >= settings.max_quality {
-            break;
-        }
-        let effects = state.effects;
-        let mut budget = state.cp.saturating_sub(reserve_cp);
-        if state.durability < reserve_durability {
-            budget = budget.saturating_sub(88); // price in a Master's Mend
-        }
-        let action = if budget >= 24
-            && effects.inner_quiet() >= 8
-            && effects.great_strides() > 0
-            && effects.innovation() > 0
-        {
-            Some(Action::ByregotsBlessing)
-        } else if budget >= 50 && effects.innovation() == 0 {
-            if effects.quick_innovation_available() {
-                Some(Action::QuickInnovation)
-            } else {
-                Some(Action::Innovation)
-            }
-        } else if budget >= 56
-            && effects.inner_quiet() == 10
-            && effects.great_strides() == 0
-            && effects.innovation() > 1
-        {
-            Some(Action::GreatStrides)
-        } else if budget >= 32 && effects.inner_quiet() == 10 {
-            Some(Action::TrainedFinesse)
-        } else if budget >= 25 && state.durability > 5 && effects.waste_not() == 0 {
-            Some(Action::PrudentTouch)
-        } else if budget >= 18 && state.durability > 10 {
-            Some(Action::BasicTouch)
-        } else if budget >= 24 && effects.inner_quiet() > 0 {
-            Some(Action::ByregotsBlessing)
-        } else {
-            None
-        };
-        let Some(action) = action else { break };
-        let Ok(child) = state.use_action(action, Condition::Normal, settings) else {
-            break;
-        };
-        if child.durability == 0 {
-            break;
-        }
-        actions.push(action);
-        state = child;
-    }
-    close_progress(settings, state, actions)
-}
-
 /// Produces a complete rotation to be used as the macro solver's initial
 /// solution, or `None` if no complete rotation was found.
-pub fn beam_seed(settings: &SolverSettings) -> Option<Vec<ActionCombo>> {
+pub fn beam_seed(
+    settings: &SolverSettings,
+    finish_solver: &FinishSolver,
+) -> Option<Vec<ActionCombo>> {
     let sim_settings = &settings.simulator_settings;
     let initial_state = SimulationState::new(sim_settings);
 
@@ -219,7 +204,10 @@ pub fn beam_seed(settings: &SolverSettings) -> Option<Vec<ActionCombo>> {
             if child.progress >= sim_settings.max_progress {
                 // Completed within the beam itself.
                 let quality = std::cmp::min(child.quality, sim_settings.max_quality);
-                if best.as_ref().is_none_or(|(best_quality, _)| quality > *best_quality) {
+                if best
+                    .as_ref()
+                    .is_none_or(|(best_quality, _)| quality > *best_quality)
+                {
                     let mut combos = rotation_of(&arena, parent_index);
                     combos.push(combo);
                     best = Some((quality, combos));
@@ -232,15 +220,36 @@ pub fn beam_seed(settings: &SolverSettings) -> Option<Vec<ActionCombo>> {
             break;
         }
 
-        // Rank candidates by the quality of their close-out rollout.
-        let mut scored: Vec<(u16, u32, SimulationState, usize, ActionCombo, Vec<Action>)> = dedup
+        let mut candidates: Vec<(SimulationState, usize, ActionCombo)> = dedup
+            .into_iter()
+            .map(|(child, (parent_index, combo))| (child, parent_index, combo))
+            .collect();
+        if candidates.len() > PRE_RANK_WIDTH {
+            candidates.par_sort_unstable_by_key(|&(state, ..)| {
+                (
+                    std::cmp::Reverse(resource_score(&state)),
+                    state.effects.into_bits(),
+                    state.cp,
+                    state.durability,
+                    state.progress,
+                    state.quality,
+                )
+            });
+            candidates.truncate(PRE_RANK_WIDTH);
+        }
+
+        // Rank candidates by the quality of their close-out rollout
+        let mut scored: Vec<(u16, u32, SimulationState, usize, ActionCombo)> = candidates
             .into_par_iter()
-            .filter_map(|(child, (parent_index, combo))| {
-                let (rollout_quality, rollout) = close_out(sim_settings, child)?;
-                let tie_break = u32::from(child.quality)
-                    + 30 * u32::from(child.cp)
-                    + 55 * u32::from(child.durability);
-                Some((rollout_quality, tie_break, child, parent_index, combo, rollout))
+            .filter_map(|(child, parent_index, combo)| {
+                let (rollout_quality, _) = close_out::<false>(settings, finish_solver, child)?;
+                Some((
+                    rollout_quality,
+                    resource_score(&child),
+                    child,
+                    parent_index,
+                    combo,
+                ))
             })
             .collect();
         // The final state-derived key makes truncation deterministic across runs.
@@ -257,18 +266,21 @@ pub fn beam_seed(settings: &SolverSettings) -> Option<Vec<ActionCombo>> {
         });
         scored.truncate(BEAM_WIDTH);
 
-        if let Some((rollout_quality, _, _, parent_index, combo, rollout)) = scored.first()
-            && best.as_ref().is_none_or(|(best_quality, _)| *rollout_quality > *best_quality)
+        if let Some(&(rollout_quality, _, state, parent_index, combo)) = scored.first()
+            && best
+                .as_ref()
+                .is_none_or(|(best_quality, _)| rollout_quality > *best_quality)
+            && let Some((quality, rollout)) = close_out::<true>(settings, finish_solver, state)
         {
-            let mut combos = rotation_of(&arena, *parent_index);
-            combos.push(*combo);
-            combos.extend(rollout.iter().copied().map(ActionCombo::Single));
-            best = Some((*rollout_quality, combos));
+            let mut combos = rotation_of(&arena, parent_index);
+            combos.push(combo);
+            combos.extend(rollout);
+            best = Some((quality, combos));
         }
 
         frontier = scored
             .into_iter()
-            .map(|(_, _, child, parent_index, combo, _)| {
+            .map(|(_, _, child, parent_index, combo)| {
                 arena.push((parent_index, combo));
                 (child, arena.len() - 1)
             })

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -137,7 +137,7 @@ fn zero_quality() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 52,
+                inserted_nodes: 64,
                 processed_nodes: 42,
             },
             finish_solver_stats: FinishSolverStats {
@@ -191,7 +191,7 @@ fn max_quality() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 97243,
+                inserted_nodes: 97351,
                 processed_nodes: 6915,
             },
             finish_solver_stats: FinishSolverStats {
@@ -245,7 +245,7 @@ fn large_progress_quality_increase() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 18,
+                inserted_nodes: 24,
                 processed_nodes: 18,
             },
             finish_solver_stats: FinishSolverStats {

--- a/raphael-solver/tests/00_edge_cases.rs
+++ b/raphael-solver/tests/00_edge_cases.rs
@@ -137,7 +137,7 @@ fn zero_quality() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 64,
+                inserted_nodes: 52,
                 processed_nodes: 42,
             },
             finish_solver_stats: FinishSolverStats {
@@ -191,7 +191,7 @@ fn max_quality() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 97351,
+                inserted_nodes: 97243,
                 processed_nodes: 6915,
             },
             finish_solver_stats: FinishSolverStats {
@@ -245,7 +245,7 @@ fn large_progress_quality_increase() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 76,
+                inserted_nodes: 18,
                 processed_nodes: 18,
             },
             finish_solver_stats: FinishSolverStats {
@@ -409,7 +409,7 @@ fn issue_312_quick_innovation_reflect() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 17,
+                inserted_nodes: 4,
                 processed_nodes: 4,
             },
             finish_solver_stats: FinishSolverStats {
@@ -477,7 +477,7 @@ fn daring_touch_interrupted_combo() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 27,
+                inserted_nodes: 11,
                 processed_nodes: 10,
             },
             finish_solver_stats: FinishSolverStats {

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -87,7 +87,7 @@ fn rinascita_3700_3280() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 5091,
+                inserted_nodes: 5063,
                 processed_nodes: 457,
             },
             finish_solver_stats: FinishSolverStats {
@@ -305,7 +305,7 @@ fn indagator_3858_4057() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 24040,
+                inserted_nodes: 23991,
                 processed_nodes: 3360,
             },
             finish_solver_stats: FinishSolverStats {
@@ -415,7 +415,7 @@ fn stuffed_peppers_2() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 46128,
+                inserted_nodes: 46061,
                 processed_nodes: 2788,
             },
             finish_solver_stats: FinishSolverStats {
@@ -531,7 +531,7 @@ fn stuffed_peppers_2_quick_innovation() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 47108,
+                inserted_nodes: 47096,
                 processed_nodes: 2788,
             },
             finish_solver_stats: FinishSolverStats {
@@ -747,7 +747,7 @@ fn rakaznar_lapidary_hammer_4900_4800() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 5598,
+                inserted_nodes: 5595,
                 processed_nodes: 362,
             },
             finish_solver_stats: FinishSolverStats {
@@ -801,7 +801,7 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 15034,
+                inserted_nodes: 15033,
                 processed_nodes: 930,
             },
             finish_solver_stats: FinishSolverStats {
@@ -909,7 +909,7 @@ fn hardened_survey_plank_5558_5216() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1228940,
+                inserted_nodes: 921527,
                 processed_nodes: 172691,
             },
             finish_solver_stats: FinishSolverStats {

--- a/raphael-solver/tests/01_progress_backload_exhaustive.rs
+++ b/raphael-solver/tests/01_progress_backload_exhaustive.rs
@@ -87,7 +87,7 @@ fn rinascita_3700_3280() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 5063,
+                inserted_nodes: 2786,
                 processed_nodes: 457,
             },
             finish_solver_stats: FinishSolverStats {
@@ -141,7 +141,7 @@ fn pactmaker_3240_3130() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 42206,
+                inserted_nodes: 9790,
                 processed_nodes: 4631,
             },
             finish_solver_stats: FinishSolverStats {
@@ -197,7 +197,7 @@ fn pactmaker_3240_3130_heart_and_soul() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 7415,
+                inserted_nodes: 6355,
                 processed_nodes: 578,
             },
             finish_solver_stats: FinishSolverStats {
@@ -251,7 +251,7 @@ fn diadochos_4021_3660() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 7609,
+                inserted_nodes: 6403,
                 processed_nodes: 1627,
             },
             finish_solver_stats: FinishSolverStats {
@@ -305,7 +305,7 @@ fn indagator_3858_4057() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 23991,
+                inserted_nodes: 16851,
                 processed_nodes: 3360,
             },
             finish_solver_stats: FinishSolverStats {
@@ -585,7 +585,7 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 3486,
+                inserted_nodes: 3119,
                 processed_nodes: 261,
             },
             finish_solver_stats: FinishSolverStats {
@@ -801,7 +801,7 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 15033,
+                inserted_nodes: 15034,
                 processed_nodes: 930,
             },
             finish_solver_stats: FinishSolverStats {

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -87,7 +87,7 @@ fn rinascita_3700_3280() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 47198,
+                inserted_nodes: 36360,
                 processed_nodes: 3719,
             },
             finish_solver_stats: FinishSolverStats {
@@ -141,7 +141,7 @@ fn pactmaker_3240_3130() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 72819,
+                inserted_nodes: 39932,
                 processed_nodes: 5240,
             },
             finish_solver_stats: FinishSolverStats {
@@ -197,7 +197,7 @@ fn pactmaker_3240_3130_heart_and_soul() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 17646,
+                inserted_nodes: 16211,
                 processed_nodes: 1021,
             },
             finish_solver_stats: FinishSolverStats {
@@ -251,7 +251,7 @@ fn diadochos_4021_3660() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 43693,
+                inserted_nodes: 37662,
                 processed_nodes: 6044,
             },
             finish_solver_stats: FinishSolverStats {
@@ -305,7 +305,7 @@ fn indagator_3858_4057() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 4930,
+                inserted_nodes: 3848,
                 processed_nodes: 342,
             },
             finish_solver_stats: FinishSolverStats {
@@ -585,7 +585,7 @@ fn rakaznar_lapidary_hammer_4462_4391() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 376873,
+                inserted_nodes: 356785,
                 processed_nodes: 21476,
             },
             finish_solver_stats: FinishSolverStats {
@@ -801,7 +801,7 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 171860,
+                inserted_nodes: 171861,
                 processed_nodes: 7939,
             },
             finish_solver_stats: FinishSolverStats {
@@ -963,7 +963,7 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 438956,
+                inserted_nodes: 433860,
                 processed_nodes: 41992,
             },
             finish_solver_stats: FinishSolverStats {
@@ -1018,7 +1018,7 @@ fn ceviche_4900_4800_no_quality() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 517,
+                inserted_nodes: 575,
                 processed_nodes: 30,
             },
             finish_solver_stats: FinishSolverStats {
@@ -1129,7 +1129,7 @@ fn ce_stellar_steady_hand() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1586537,
+                inserted_nodes: 1585580,
                 processed_nodes: 366678,
             },
             finish_solver_stats: FinishSolverStats {

--- a/raphael-solver/tests/02_exhaustive.rs
+++ b/raphael-solver/tests/02_exhaustive.rs
@@ -87,7 +87,7 @@ fn rinascita_3700_3280() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 51746,
+                inserted_nodes: 47198,
                 processed_nodes: 3719,
             },
             finish_solver_stats: FinishSolverStats {
@@ -251,7 +251,7 @@ fn diadochos_4021_3660() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 43698,
+                inserted_nodes: 43693,
                 processed_nodes: 6044,
             },
             finish_solver_stats: FinishSolverStats {
@@ -305,7 +305,7 @@ fn indagator_3858_4057() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 5408,
+                inserted_nodes: 4930,
                 processed_nodes: 342,
             },
             finish_solver_stats: FinishSolverStats {
@@ -415,7 +415,7 @@ fn stuffed_peppers_2() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 3886,
+                inserted_nodes: 3882,
                 processed_nodes: 180,
             },
             finish_solver_stats: FinishSolverStats {
@@ -693,7 +693,7 @@ fn claro_walnut_lumber_4900_4800() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 183400,
+                inserted_nodes: 183219,
                 processed_nodes: 8697,
             },
             finish_solver_stats: FinishSolverStats {
@@ -801,7 +801,7 @@ fn rarefied_tacos_de_carne_asada_4966_4817() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 171861,
+                inserted_nodes: 171860,
                 processed_nodes: 7939,
             },
             finish_solver_stats: FinishSolverStats {
@@ -855,7 +855,7 @@ fn archeo_kingdom_broadsword_4966_4914() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 209791,
+                inserted_nodes: 209790,
                 processed_nodes: 9797,
             },
             finish_solver_stats: FinishSolverStats {
@@ -963,7 +963,7 @@ fn hardened_survey_plank_5558_5216_heart_and_soul_quick_innovation() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 439861,
+                inserted_nodes: 438956,
                 processed_nodes: 41992,
             },
             finish_solver_stats: FinishSolverStats {
@@ -1018,7 +1018,7 @@ fn ceviche_4900_4800_no_quality() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 575,
+                inserted_nodes: 517,
                 processed_nodes: 30,
             },
             finish_solver_stats: FinishSolverStats {

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -102,7 +102,7 @@ fn stuffed_peppers() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 1806300,
+                inserted_nodes: 1776654,
                 processed_nodes: 85863,
             },
             finish_solver_stats: FinishSolverStats {
@@ -218,7 +218,7 @@ fn test_mountain_chromite_ingot_no_manipulation() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 484906,
+                inserted_nodes: 442462,
                 processed_nodes: 33166,
             },
             finish_solver_stats: FinishSolverStats {
@@ -272,7 +272,7 @@ fn test_indagator_3858_4057() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 231358,
+                inserted_nodes: 227444,
                 processed_nodes: 20794,
             },
             finish_solver_stats: FinishSolverStats {
@@ -330,7 +330,7 @@ fn test_rare_tacos_4628_4410() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 4881826,
+                inserted_nodes: 4868050,
                 processed_nodes: 1055885,
             },
             finish_solver_stats: FinishSolverStats {
@@ -387,7 +387,7 @@ fn issue_113() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 22701824,
+                inserted_nodes: 22701815,
                 processed_nodes: 1410264,
             },
             finish_solver_stats: FinishSolverStats {
@@ -442,7 +442,7 @@ fn issue_118() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 18992408,
+                inserted_nodes: 18811544,
                 processed_nodes: 1375324,
             },
             finish_solver_stats: FinishSolverStats {

--- a/raphael-solver/tests/03_adversarial_exhaustive.rs
+++ b/raphael-solver/tests/03_adversarial_exhaustive.rs
@@ -272,7 +272,7 @@ fn test_indagator_3858_4057() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 227444,
+                inserted_nodes: 193565,
                 processed_nodes: 20794,
             },
             finish_solver_stats: FinishSolverStats {
@@ -330,7 +330,7 @@ fn test_rare_tacos_4628_4410() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 4868050,
+                inserted_nodes: 4659968,
                 processed_nodes: 1055885,
             },
             finish_solver_stats: FinishSolverStats {
@@ -387,7 +387,7 @@ fn issue_113() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 22701815,
+                inserted_nodes: 18420360,
                 processed_nodes: 1410264,
             },
             finish_solver_stats: FinishSolverStats {
@@ -442,7 +442,7 @@ fn issue_118() {
     let expected_runtime_stats = expect![[r#"
         MacroSolverStats {
             search_queue_stats: SearchQueueStats {
-                inserted_nodes: 18811544,
+                inserted_nodes: 15560156,
                 processed_nodes: 1375324,
             },
             finish_solver_stats: FinishSolverStats {


### PR DESCRIPTION
TODOs:

- [x] Remove hardcoded CP breakpoints from rollout
- [x] Update expected outputs (again)
- [x] Profile memory and wall clock time impact on various hardware (particularly tradeoff between beam precomputation and solve speedup when the latter is fast due to a simple recipe)
- [x] Before/after wall clock time profiling
- [x] SIMD pass/precomputation opportunities

Benchmark craft: `raphael-cli --recipe-id 38217 --stats 5953 5605 791 --level 100 --manipulation --heart-and-soul --quick-innovation --stellar-steady-hand 2`

Ryzen 7 9800X3D, 96GB DDR5 on Linux

|                      | stock                | this PR              | delta           |
| -------------------- | -------------------- | -------------------- | ----------- |
| Seed solver          |                    | 0.44 s / 0.44 s      | +0.44 s     |
| Search               | 52.25 s / 52.40 s    | 48.58 s / 48.45 s    | -7.3 % |
| Total                | 133.96 s / 134.03 s  | 128.64 s / 128.58 s  | -4.0 % |
| Peak RSS             | 10.51 GB / 10.50 GB  | 9.32 GB / 9.33 GB    | -11.2 % |
| inserted_nodes       | 331,608,839          | 179,397,503          | -45.9 % |
| processed_nodes      | 17,150,335           | 17,150,335           | 0          |

A bit of context from Discord logs explaining the reasoning behind this change:
The idea is that you can save a lot of time in the forward search and node insertion time by pre-seeding a 'best guess' solution that finishes with some arbitrary-but-good quality, computed fast and cheap with a beam search, where each beam state is scored by greedily completing it into a real finished rotation, and ranking it on the resulting quality. We search best-first and we only bound off min_accepted_score as min_accepted_score rises over the course of the search... but this happens slowly, because best-first search expands high-upper-bound paths, and the upper-bounds live early in the rotation since they decay as resources get spent. all of the value that actually bumps up our min_accepted_score lives in the back end of 30+ step macros. So, instead, we produce a good, working solution before we search so the bar starts near its final height instead of at zero. The answer is identical, and so is the expanded node count, only inserts differ.

[2:31 AM]Akira [RAPH], : there used to be a fast_lower_bound solver but i removed it since it didn't help as much as i thought. maybe i'll revisit it.
2:53 AM]scatterflower [IPv6], : I went back and looked at the commit that removed this. I think my idea wins out over it since its not oracle-guided (and avoids coupling to QUB state) and can run during precompute, and it has a hard time complexity cap since it is bounded by a chosen width*depth. I reran the same test against the cited regression on the stuffed peppers recipe with qi too, and the beam search preseed wall clock time is the same within the error bars of the measurement, with the same stats. I think it performs a lot better there since in specialist configs the UB plateaus out, and oracle-guided frontiers see no gradient where the decisiosn actually matter, and without a width bound it thrashes and gets slow