### PR TITLE
Improve memory layout of QUB memoization data structure

### DIFF
--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -44,10 +44,7 @@ struct TemplateRecord<'alloc> {
 pub struct QualityUbSolver<'alloc> {
     context: QualityUbSolverContext<'alloc>,
     templates: FxHashMap<TemplateData, TemplateRecord<'alloc>>,
-    states_on_main: usize,
-    values_on_main: usize,
-    states_on_shards: usize,
-    values_on_shards: usize,
+    stats: QualityUbSolverStats,
 }
 
 pub struct QualityUbSolverShard<'main, 'alloc> {
@@ -79,10 +76,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
                 ),
             },
             templates: FxHashMap::default(),
-            states_on_main: 0,
-            values_on_main: 0,
-            states_on_shards: 0,
-            values_on_shards: 0,
+            stats: QualityUbSolverStats::default(),
         }
     }
 
@@ -97,8 +91,8 @@ impl<'alloc> QualityUbSolver<'alloc> {
             }
             if slots[index].is_none() {
                 slots[index] = Some(pareto_front);
-                self.states_on_shards += 1;
-                self.values_on_shards += pareto_front.len();
+                self.stats.states_on_shards += 1;
+                self.stats.values += pareto_front.len();
             }
         }
     }
@@ -248,7 +242,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
                             },
                         )
                         .collect::<Result<Vec<_>, SolverException>>()?;
-                    self.states_on_main += solved_states.len();
+                    self.stats.states_on_main += solved_states.len();
                     for (template_data, pareto_front) in solved_states {
                         let allocated = allocator.alloc_slice_copy(&pareto_front).into_ref();
                         let length_checked = allocated.try_into().map_err(|_| {
@@ -260,7 +254,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
                         let slots = &mut self.templates.get_mut(&template_data).unwrap().slots;
                         let index = usize::from((cp - min_solved_cp) / 2);
                         slots[index] = Some(length_checked);
-                        self.values_on_main += pareto_front.len();
+                        self.stats.values += pareto_front.len();
                     }
                 }
                 for template in templates {
@@ -332,11 +326,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
     }
 
     pub fn runtime_stats(&self) -> QualityUbSolverStats {
-        QualityUbSolverStats {
-            states_on_main: self.states_on_main,
-            states_on_shards: self.states_on_shards,
-            values: self.values_on_main + self.values_on_shards,
-        }
+        self.stats
     }
 }
 

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -41,54 +41,11 @@ struct TemplateRecord {
     required_cp_for_max: u16,
 }
 
-const UNSOLVED_SLOT: u32 = u32::MAX;
-
-const ARENA_SEGMENT_BITS: u32 = 20;
-const ARENA_SEGMENT_LEN: usize = 1 << ARENA_SEGMENT_BITS;
-
-/// Append-only storage for Pareto fronts
-#[derive(Default)]
-struct ValueArena {
-    segments: Vec<Vec<ParetoValue>>,
-}
-
-impl ValueArena {
-    fn push_front(&mut self, front: &[ParetoValue]) -> Option<u32> {
-        let needed = front.len() + 1;
-        debug_assert!(needed <= ARENA_SEGMENT_LEN);
-        if self
-            .segments
-            .last()
-            .is_none_or(|segment| ARENA_SEGMENT_LEN - segment.len() < needed)
-        {
-            self.segments.push(Vec::with_capacity(ARENA_SEGMENT_LEN));
-        }
-        let segment_index = self.segments.len() - 1;
-        let segment = self.segments.last_mut().unwrap();
-        let offset = u32::try_from(
-            (segment_index as u64) << ARENA_SEGMENT_BITS | segment.len() as u64,
-        )
-        .ok()
-        .filter(|&offset| offset != UNSOLVED_SLOT)?;
-        segment.push(ParetoValue::new(front.len() as u16, 0));
-        segment.extend_from_slice(front);
-        Some(offset)
-    }
-
-    fn resolve(&self, offset: u32) -> &[ParetoValue] {
-        let segment = &self.segments[(offset >> ARENA_SEGMENT_BITS) as usize];
-        let index = (offset as usize) & (ARENA_SEGMENT_LEN - 1);
-        let len = usize::from(segment[index].progress);
-        &segment[index + 1..index + 1 + len]
-    }
-}
-
 pub struct QualityUbSolver<'alloc> {
     context: QualityUbSolverContext<'alloc>,
     templates: FxHashMap<TemplateData, TemplateRecord>,
     /// indexed by `(cp - min_solved_cp) / 2`
-    slots: Vec<u32>,
-    arena: ValueArena,
+    slots: Vec<Option<&'alloc ParetoFront>>,
     /// States solved by shards during the search and merged back
     overflow: SolvedStates<'alloc>,
     states_on_main: usize,
@@ -99,8 +56,7 @@ pub struct QualityUbSolver<'alloc> {
 pub struct QualityUbSolverShard<'main, 'alloc> {
     context: &'main QualityUbSolverContext<'alloc>,
     templates: &'main FxHashMap<TemplateData, TemplateRecord>,
-    slots: &'main [u32],
-    arena: &'main ValueArena,
+    slots: &'main [Option<&'alloc ParetoFront>],
     overflow: &'main SolvedStates<'alloc>,
     local_states: SolvedStates<'alloc>,
 }
@@ -129,7 +85,6 @@ impl<'alloc> QualityUbSolver<'alloc> {
             },
             templates: FxHashMap::default(),
             slots: Vec::new(),
-            arena: ValueArena::default(),
             overflow: SolvedStates::default(),
             states_on_main: 0,
             values_on_main: 0,
@@ -149,7 +104,6 @@ impl<'alloc> QualityUbSolver<'alloc> {
             context: &self.context,
             templates: &self.templates,
             slots: &self.slots,
-            arena: &self.arena,
             overflow: &self.overflow,
             local_states: SolvedStates::default(),
         }
@@ -213,14 +167,8 @@ impl<'alloc> QualityUbSolver<'alloc> {
         2 * self.context.durability_cost
     }
 
-    fn lookup_slot(&self, state: &ReducedState) -> Option<&ParetoFront> {
-        lookup_slot(
-            &self.templates,
-            &self.slots,
-            &self.arena,
-            self.min_solved_cp(),
-            state,
-        )
+    fn lookup_slot(&self, state: &ReducedState) -> Option<&'alloc ParetoFront> {
+        lookup_slot(&self.templates, &self.slots, self.min_solved_cp(), state)
     }
 
     pub fn precompute(&mut self) -> Result<(), SolverException> {
@@ -232,11 +180,10 @@ impl<'alloc> QualityUbSolver<'alloc> {
         for template in &mut all_templates {
             template.slots_start = total_slots as u32;
             if template.max_instantiated_cp >= min_solved_cp {
-                total_slots +=
-                    usize::from((template.max_instantiated_cp - min_solved_cp) / 2) + 1;
+                total_slots += usize::from((template.max_instantiated_cp - min_solved_cp) / 2) + 1;
             }
         }
-        self.slots = vec![UNSOLVED_SLOT; total_slots];
+        self.slots = vec![None; total_slots];
         self.templates = all_templates
             .iter()
             .map(|template| {
@@ -250,6 +197,8 @@ impl<'alloc> QualityUbSolver<'alloc> {
                 )
             })
             .collect();
+
+        let allocator = self.context.allocator.get();
 
         // States are computed in order of less CP to more CP.
         // States currently being computed assume that child states have already been computed.
@@ -309,20 +258,19 @@ impl<'alloc> QualityUbSolver<'alloc> {
                         .collect::<Result<Vec<_>, SolverException>>()?;
                     self.states_on_main += solved_states.len();
                     for (slot, pareto_front) in solved_states {
-                        let offset =
-                            self.arena.push_front(&pareto_front).ok_or_else(|| {
-                                internal_error!(
-                                    "QualityUbSolver value arena exceeds u32 offsets.",
-                                    self.context.settings
-                                )
-                            })?;
-                        self.slots[slot] = offset;
+                        let allocated = allocator.alloc_slice_copy(&pareto_front).into_ref();
+                        let length_checked = allocated.try_into().map_err(|_| {
+                            internal_error!(
+                                "QualityUbSolver::precompute produced empty Pareto front.",
+                                self.context.settings
+                            )
+                        })?;
+                        self.slots[slot] = Some(length_checked);
                         self.values_on_main += pareto_front.len();
                     }
                 }
                 for template in templates {
-                    if let Some(required_cp) = template.required_cp_for_max_progress_and_quality
-                    {
+                    if let Some(required_cp) = template.required_cp_for_max_progress_and_quality {
                         self.templates
                             .get_mut(&template.data)
                             .unwrap()
@@ -408,11 +356,10 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
         self.local_states
     }
 
-    fn lookup_shared(&self, state: &ReducedState) -> Option<&'main ParetoFront> {
+    fn lookup_shared(&self, state: &ReducedState) -> Option<&'alloc ParetoFront> {
         lookup_slot(
             self.templates,
             self.slots,
-            self.arena,
             2 * self.context.durability_cost,
             state,
         )
@@ -461,24 +408,23 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
             }
         }
 
-        let pareto_front =
-            if let Some(pareto_front) = self.lookup_shared(&reduced_state) {
-                pareto_front
-            } else if let Some(pareto_front) = self.local_states.get(&reduced_state).copied() {
+        let pareto_front = if let Some(pareto_front) = self.lookup_shared(&reduced_state) {
+            pareto_front
+        } else if let Some(pareto_front) = self.local_states.get(&reduced_state).copied() {
+            pareto_front
+        } else {
+            let allocator = self.context.allocator.get();
+            self.solve_state(reduced_state, &allocator)?;
+            if let Some(pareto_front) = self.local_states.get(&reduced_state).copied() {
                 pareto_front
             } else {
-                let allocator = self.context.allocator.get();
-                self.solve_state(reduced_state, &allocator)?;
-                if let Some(pareto_front) = self.local_states.get(&reduced_state).copied() {
-                    pareto_front
-                } else {
-                    return Err(internal_error!(
-                        "State not found in memoization table after solve.",
-                        self.context.settings,
-                        reduced_state
-                    ));
-                }
-            };
+                return Err(internal_error!(
+                    "State not found in memoization table after solve.",
+                    self.context.settings,
+                    reduced_state
+                ));
+            }
+        };
         let i = pareto_front.partition_point(|value| value.progress < required_progress);
         let quality = pareto_front
             .get(i)
@@ -513,27 +459,26 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
             ) {
                 let action_value = ParetoValue::new(progress, quality);
                 if !child_state.is_final(self.context.durability_cost) {
-                    let child_pareto_front = if let Some(child_pareto_front) =
-                        self.lookup_shared(&child_state)
-                    {
-                        child_pareto_front
-                    } else if let Some(child_pareto_front) =
-                        self.local_states.get(&child_state).copied()
-                    {
-                        child_pareto_front
-                    } else {
-                        self.solve_state(child_state, allocator)?;
-                        self.local_states
-                            .get(&child_state)
-                            .copied()
-                            .ok_or_else(|| {
-                                internal_error!(
-                                    "State not found in memoization table after solving.",
-                                    self.context.settings,
-                                    child_state
-                                )
-                            })?
-                    };
+                    let child_pareto_front =
+                        if let Some(child_pareto_front) = self.lookup_shared(&child_state) {
+                            child_pareto_front
+                        } else if let Some(child_pareto_front) =
+                            self.local_states.get(&child_state).copied()
+                        {
+                            child_pareto_front
+                        } else {
+                            self.solve_state(child_state, allocator)?;
+                            self.local_states
+                                .get(&child_state)
+                                .copied()
+                                .ok_or_else(|| {
+                                    internal_error!(
+                                        "State not found in memoization table after solving.",
+                                        self.context.settings,
+                                        child_state
+                                    )
+                                })?
+                        };
                     pareto_front_builder.push_slice(
                         child_pareto_front
                             .iter()
@@ -562,25 +507,19 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
     }
 }
 
-fn lookup_slot<'arena>(
+fn lookup_slot<'alloc>(
     templates: &FxHashMap<TemplateData, TemplateRecord>,
-    slots: &[u32],
-    arena: &'arena ValueArena,
+    slots: &[Option<&'alloc ParetoFront>],
     min_solved_cp: u16,
     state: &ReducedState,
-) -> Option<&'arena ParetoFront> {
+) -> Option<&'alloc ParetoFront> {
     let data = TemplateData::new(state.effects, state.compressed_unreliable_quality);
     let record = templates.get(&data)?;
     if state.cp < min_solved_cp || state.cp > record.max_instantiated_cp {
         return None;
     }
     let index = record.slots_start as usize + usize::from((state.cp - min_solved_cp) / 2);
-    let offset = slots[index];
-    if offset == UNSOLVED_SLOT {
-        return None;
-    }
-    let front = arena.resolve(offset);
-    Some(front.try_into().expect("arena Pareto fronts are never empty"))
+    slots[index]
 }
 
 /// Calculates the CP cost to "magically" restore 5 durability

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -32,29 +32,27 @@ struct QualityUbSolverContext<'alloc> {
     largest_progress_increase: u16,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 struct TemplateRecord<'alloc> {
     /// Indexed by `(cp - min_solved_cp) / 2`
     slots: Vec<Option<&'alloc ParetoFront>>,
     /// Minimum CP at which the template reaches max Progress and max Quality,
-    /// or `u16::MAX` if it never does.
-    required_cp_for_max: u16,
+    /// or `None` if it never does.
+    required_cp_for_max: Option<u16>,
 }
 
 pub struct QualityUbSolver<'alloc> {
     context: QualityUbSolverContext<'alloc>,
     templates: FxHashMap<TemplateData, TemplateRecord<'alloc>>,
-    /// States solved by shards during the search and merged back
-    overflow: SolvedStates<'alloc>,
     states_on_main: usize,
     values_on_main: usize,
-    num_states_solved_on_shards: usize,
+    states_on_shards: usize,
+    values_on_shards: usize,
 }
 
 pub struct QualityUbSolverShard<'main, 'alloc> {
     context: &'main QualityUbSolverContext<'alloc>,
     templates: &'main FxHashMap<TemplateData, TemplateRecord<'alloc>>,
-    overflow: &'main SolvedStates<'alloc>,
     local_states: SolvedStates<'alloc>,
 }
 
@@ -81,25 +79,34 @@ impl<'alloc> QualityUbSolver<'alloc> {
                 ),
             },
             templates: FxHashMap::default(),
-            overflow: SolvedStates::default(),
             states_on_main: 0,
             values_on_main: 0,
-            num_states_solved_on_shards: 0,
+            states_on_shards: 0,
+            values_on_shards: 0,
         }
     }
 
     pub fn extend_solved_states(&mut self, new_solved_states: SolvedStates<'alloc>) {
-        let len_before = self.overflow.len();
-        self.overflow.extend(new_solved_states);
-        let len_after = self.overflow.len();
-        self.num_states_solved_on_shards += len_after - len_before;
+        let min_solved_cp = self.min_solved_cp();
+        for (state, pareto_front) in new_solved_states {
+            let key = TemplateData::new(state.effects, state.compressed_unreliable_quality);
+            let slots = &mut self.templates.entry(key).or_default().slots;
+            let index = usize::from((state.cp - min_solved_cp) / 2);
+            if slots.len() <= index {
+                slots.resize_with(index + 1, Default::default);
+            }
+            if slots[index].is_none() {
+                slots[index] = Some(pareto_front);
+                self.states_on_shards += 1;
+                self.values_on_shards += pareto_front.len();
+            }
+        }
     }
 
     pub fn create_shard<'main>(&'main self) -> QualityUbSolverShard<'main, 'alloc> {
         QualityUbSolverShard {
             context: &self.context,
             templates: &self.templates,
-            overflow: &self.overflow,
             local_states: SolvedStates::default(),
         }
     }
@@ -179,7 +186,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
                     .div_ceil(2);
                 let record = TemplateRecord {
                     slots: vec![None; usize::from(num_slots)],
-                    required_cp_for_max: u16::MAX,
+                    required_cp_for_max: None,
                 };
                 (template.data, record)
             })
@@ -261,7 +268,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
                         self.templates
                             .get_mut(&template.data)
                             .unwrap()
-                            .required_cp_for_max = required_cp;
+                            .required_cp_for_max = Some(required_cp);
                     }
                 }
             }
@@ -327,13 +334,8 @@ impl<'alloc> QualityUbSolver<'alloc> {
     pub fn runtime_stats(&self) -> QualityUbSolverStats {
         QualityUbSolverStats {
             states_on_main: self.states_on_main,
-            states_on_shards: self.num_states_solved_on_shards,
-            values: self.values_on_main
-                + self
-                    .overflow
-                    .values()
-                    .map(|front| front.len())
-                    .sum::<usize>(),
+            states_on_shards: self.states_on_shards,
+            values: self.values_on_main + self.values_on_shards,
         }
     }
 }
@@ -345,7 +347,6 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
 
     fn lookup_shared(&self, state: &ReducedState) -> Option<&'alloc ParetoFront> {
         lookup_slot(self.templates, 2 * self.context.durability_cost, state)
-            .or_else(|| self.overflow.get(state).copied())
     }
 
     pub fn quality_upper_bound(
@@ -368,11 +369,11 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
             reduced_state.compressed_unreliable_quality,
         );
         if let Some(record) = self.templates.get(&template_data)
-            && record.required_cp_for_max != u16::MAX
-            && reduced_state.cp >= record.required_cp_for_max
+            && let Some(required_cp_for_max) = record.required_cp_for_max
+            && reduced_state.cp >= required_cp_for_max
         {
             let reduced_state = ReducedState {
-                cp: record.required_cp_for_max,
+                cp: required_cp_for_max,
                 ..reduced_state
             };
             if let Some(pareto_front) = self.lookup_shared(&reduced_state)

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -32,17 +32,76 @@ struct QualityUbSolverContext<'alloc> {
     largest_progress_increase: u16,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct TemplateRecord {
+    slots_start: u32,
+    max_instantiated_cp: u16,
+    /// Minimum CP at which the template reaches max Progress and max Quality,
+    /// or `u16::MAX` if it never does.
+    required_cp_for_max: u16,
+}
+
+const UNSOLVED_SLOT: u32 = u32::MAX;
+
+const ARENA_SEGMENT_BITS: u32 = 20;
+const ARENA_SEGMENT_LEN: usize = 1 << ARENA_SEGMENT_BITS;
+
+/// Append-only storage for Pareto fronts
+#[derive(Default)]
+struct ValueArena {
+    segments: Vec<Vec<ParetoValue>>,
+}
+
+impl ValueArena {
+    fn push_front(&mut self, front: &[ParetoValue]) -> Option<u32> {
+        let needed = front.len() + 1;
+        debug_assert!(needed <= ARENA_SEGMENT_LEN);
+        if self
+            .segments
+            .last()
+            .is_none_or(|segment| ARENA_SEGMENT_LEN - segment.len() < needed)
+        {
+            self.segments.push(Vec::with_capacity(ARENA_SEGMENT_LEN));
+        }
+        let segment_index = self.segments.len() - 1;
+        let segment = self.segments.last_mut().unwrap();
+        let offset = u32::try_from(
+            (segment_index as u64) << ARENA_SEGMENT_BITS | segment.len() as u64,
+        )
+        .ok()
+        .filter(|&offset| offset != UNSOLVED_SLOT)?;
+        segment.push(ParetoValue::new(front.len() as u16, 0));
+        segment.extend_from_slice(front);
+        Some(offset)
+    }
+
+    fn resolve(&self, offset: u32) -> &[ParetoValue] {
+        let segment = &self.segments[(offset >> ARENA_SEGMENT_BITS) as usize];
+        let index = (offset as usize) & (ARENA_SEGMENT_LEN - 1);
+        let len = usize::from(segment[index].progress);
+        &segment[index + 1..index + 1 + len]
+    }
+}
+
 pub struct QualityUbSolver<'alloc> {
     context: QualityUbSolverContext<'alloc>,
-    maximal_templates: FxHashMap<TemplateData, u16>,
-    solved_states: SolvedStates<'alloc>,
+    templates: FxHashMap<TemplateData, TemplateRecord>,
+    /// indexed by `(cp - min_solved_cp) / 2`
+    slots: Vec<u32>,
+    arena: ValueArena,
+    /// States solved by shards during the search and merged back
+    overflow: SolvedStates<'alloc>,
+    states_on_main: usize,
+    values_on_main: usize,
     num_states_solved_on_shards: usize,
 }
 
 pub struct QualityUbSolverShard<'main, 'alloc> {
     context: &'main QualityUbSolverContext<'alloc>,
-    maximal_templates: &'main FxHashMap<TemplateData, u16>,
-    shared_states: &'main SolvedStates<'alloc>,
+    templates: &'main FxHashMap<TemplateData, TemplateRecord>,
+    slots: &'main [u32],
+    arena: &'main ValueArena,
+    overflow: &'main SolvedStates<'alloc>,
     local_states: SolvedStates<'alloc>,
 }
 
@@ -68,24 +127,30 @@ impl<'alloc> QualityUbSolver<'alloc> {
                     &settings.simulator_settings,
                 ),
             },
-            solved_states: FxHashMap::default(),
-            maximal_templates: FxHashMap::default(),
+            templates: FxHashMap::default(),
+            slots: Vec::new(),
+            arena: ValueArena::default(),
+            overflow: SolvedStates::default(),
+            states_on_main: 0,
+            values_on_main: 0,
             num_states_solved_on_shards: 0,
         }
     }
 
     pub fn extend_solved_states(&mut self, new_solved_states: SolvedStates<'alloc>) {
-        let len_before = self.solved_states.len();
-        self.solved_states.extend(new_solved_states);
-        let len_after = self.solved_states.len();
+        let len_before = self.overflow.len();
+        self.overflow.extend(new_solved_states);
+        let len_after = self.overflow.len();
         self.num_states_solved_on_shards += len_after - len_before;
     }
 
     pub fn create_shard<'main>(&'main self) -> QualityUbSolverShard<'main, 'alloc> {
         QualityUbSolverShard {
             context: &self.context,
-            maximal_templates: &self.maximal_templates,
-            shared_states: &self.solved_states,
+            templates: &self.templates,
+            slots: &self.slots,
+            arena: &self.arena,
+            overflow: &self.overflow,
             local_states: SolvedStates::default(),
         }
     }
@@ -144,8 +209,48 @@ impl<'alloc> QualityUbSolver<'alloc> {
             .collect()
     }
 
+    fn min_solved_cp(&self) -> u16 {
+        2 * self.context.durability_cost
+    }
+
+    fn lookup_slot(&self, state: &ReducedState) -> Option<&ParetoFront> {
+        lookup_slot(
+            &self.templates,
+            &self.slots,
+            &self.arena,
+            self.min_solved_cp(),
+            state,
+        )
+    }
+
     pub fn precompute(&mut self) -> Result<(), SolverException> {
-        let all_templates = self.generate_precompute_templates();
+        let min_solved_cp = self.min_solved_cp();
+        let mut all_templates = self.generate_precompute_templates();
+
+        // Lay out each template's CP range as a contiguous span
+        let mut total_slots: usize = 0;
+        for template in &mut all_templates {
+            template.slots_start = total_slots as u32;
+            if template.max_instantiated_cp >= min_solved_cp {
+                total_slots +=
+                    usize::from((template.max_instantiated_cp - min_solved_cp) / 2) + 1;
+            }
+        }
+        self.slots = vec![UNSOLVED_SLOT; total_slots];
+        self.templates = all_templates
+            .iter()
+            .map(|template| {
+                (
+                    template.data,
+                    TemplateRecord {
+                        slots_start: template.slots_start,
+                        max_instantiated_cp: template.max_instantiated_cp,
+                        required_cp_for_max: u16::MAX,
+                    },
+                )
+            })
+            .collect();
+
         // States are computed in order of less CP to more CP.
         // States currently being computed assume that child states have already been computed.
         // This is the reason why states with HeartAndSoul and QuickInnovation available must be computed separately.
@@ -168,9 +273,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
                     .collect();
                 // 2 * durability_cost is the minimum CP a state must have to not be considered "final".
                 // See `ReducedState::is_final` for details.
-                for cp in
-                    (2 * self.context.durability_cost..=self.context.settings.max_cp()).step_by(2)
-                {
+                for cp in (min_solved_cp..=self.context.settings.max_cp()).step_by(2) {
                     if self.context.interrupt_signal.is_set() {
                         return Err(SolverException::Interrupted);
                     }
@@ -180,12 +283,10 @@ impl<'alloc> QualityUbSolver<'alloc> {
                             template.instantiate(cp).map(|state| (template, state))
                         })
                         .map_init(
-                            || (ParetoFrontBuilder::new(), self.context.allocator.get()),
-                            |(pf_builder, allocator),
-                             (template, state)|
-                             -> Result<_, SolverException> {
+                            ParetoFrontBuilder::new,
+                            |pf_builder, (template, state)| -> Result<_, SolverException> {
                                 let pareto_front =
-                                    self.solve_precompute_state(pf_builder, state, allocator)?;
+                                    self.solve_precompute_state(pf_builder, state)?;
                                 let template_is_maximal = {
                                     // A template is "maximal" if there is no benefit of solving it with higher CP
                                     let required_progress = self.context.settings.max_progress();
@@ -194,24 +295,40 @@ impl<'alloc> QualityUbSolver<'alloc> {
                                             self.context.iq_quality_lut
                                                 [usize::from(state.effects.inner_quiet())],
                                         );
-                                    pareto_front.first().progress >= required_progress
-                                        && pareto_front.first().quality >= required_quality
+                                    pareto_front[0].progress >= required_progress
+                                        && pareto_front[0].quality >= required_quality
                                 };
                                 if template_is_maximal {
                                     template.required_cp_for_max_progress_and_quality = Some(cp);
                                 }
-                                Ok((state, pareto_front))
+                                let slot = template.slots_start as usize
+                                    + usize::from((cp - min_solved_cp) / 2);
+                                Ok((slot, pareto_front))
                             },
                         )
                         .collect::<Result<Vec<_>, SolverException>>()?;
-                    self.solved_states.extend(solved_states);
+                    self.states_on_main += solved_states.len();
+                    for (slot, pareto_front) in solved_states {
+                        let offset =
+                            self.arena.push_front(&pareto_front).ok_or_else(|| {
+                                internal_error!(
+                                    "QualityUbSolver value arena exceeds u32 offsets.",
+                                    self.context.settings
+                                )
+                            })?;
+                        self.slots[slot] = offset;
+                        self.values_on_main += pareto_front.len();
+                    }
                 }
-                self.maximal_templates
-                    .extend(templates.into_iter().filter_map(|template| {
-                        template
-                            .required_cp_for_max_progress_and_quality
-                            .map(|required_cp| (template.data, required_cp))
-                    }));
+                for template in templates {
+                    if let Some(required_cp) = template.required_cp_for_max_progress_and_quality
+                    {
+                        self.templates
+                            .get_mut(&template.data)
+                            .unwrap()
+                            .required_cp_for_max = required_cp;
+                    }
+                }
             }
         }
         Ok(())
@@ -221,8 +338,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
         &self,
         pf_builder: &mut ParetoFrontBuilder,
         state: ReducedState,
-        allocator: &BumpPoolGuard<'alloc>,
-    ) -> Result<&'alloc ParetoFront, SolverException> {
+    ) -> Result<Vec<ParetoValue>, SolverException> {
         let cutoff = ParetoValue::new(
             self.context.settings.max_progress(),
             self.context.settings.max_quality().saturating_sub(
@@ -239,7 +355,7 @@ impl<'alloc> QualityUbSolver<'alloc> {
             ) {
                 let action_value = ParetoValue::new(progress, quality);
                 if !new_state.is_final(self.context.durability_cost) {
-                    if let Some(pareto_front) = self.solved_states.get(&new_state).copied() {
+                    if let Some(pareto_front) = self.lookup_slot(&new_state) {
                         pf_builder.push_slice(
                             pareto_front
                                 .iter()
@@ -262,23 +378,27 @@ impl<'alloc> QualityUbSolver<'alloc> {
                 }
             }
         }
-        let pareto_front = allocator
-            .alloc_slice_copy(pf_builder.result_as_slice())
-            .into_ref();
-        pareto_front.try_into().map_err(|_| {
-            internal_error!(
+        let pareto_front = pf_builder.result_as_slice();
+        if pareto_front.is_empty() {
+            return Err(internal_error!(
                 "Empty precompute Pareto front.",
                 self.context.settings,
                 state
-            )
-        })
+            ));
+        }
+        Ok(pareto_front.to_vec())
     }
 
     pub fn runtime_stats(&self) -> QualityUbSolverStats {
         QualityUbSolverStats {
-            states_on_main: self.solved_states.len() - self.num_states_solved_on_shards,
+            states_on_main: self.states_on_main,
             states_on_shards: self.num_states_solved_on_shards,
-            values: self.solved_states.values().map(|value| value.len()).sum(),
+            values: self.values_on_main
+                + self
+                    .overflow
+                    .values()
+                    .map(|front| front.len())
+                    .sum::<usize>(),
         }
     }
 }
@@ -286,6 +406,17 @@ impl<'alloc> QualityUbSolver<'alloc> {
 impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
     pub fn solved_states(self) -> SolvedStates<'alloc> {
         self.local_states
+    }
+
+    fn lookup_shared(&self, state: &ReducedState) -> Option<&'main ParetoFront> {
+        lookup_slot(
+            self.templates,
+            self.slots,
+            self.arena,
+            2 * self.context.durability_cost,
+            state,
+        )
+        .or_else(|| self.overflow.get(state).copied())
     }
 
     pub fn quality_upper_bound(
@@ -307,14 +438,15 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
             reduced_state.effects,
             reduced_state.compressed_unreliable_quality,
         );
-        if let Some(&required_cp) = self.maximal_templates.get(&template_data)
-            && reduced_state.cp >= required_cp
+        if let Some(record) = self.templates.get(&template_data)
+            && record.required_cp_for_max != u16::MAX
+            && reduced_state.cp >= record.required_cp_for_max
         {
             let reduced_state = ReducedState {
-                cp: required_cp,
+                cp: record.required_cp_for_max,
                 ..reduced_state
             };
-            if let Some(pareto_front) = self.shared_states.get(&reduced_state).copied()
+            if let Some(pareto_front) = self.lookup_shared(&reduced_state)
                 && pareto_front.first().progress >= required_progress
                 && pareto_front.first().quality.saturating_add(state.quality)
                     >= self.context.settings.max_quality()
@@ -330,7 +462,7 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
         }
 
         let pareto_front =
-            if let Some(pareto_front) = self.shared_states.get(&reduced_state).copied() {
+            if let Some(pareto_front) = self.lookup_shared(&reduced_state) {
                 pareto_front
             } else if let Some(pareto_front) = self.local_states.get(&reduced_state).copied() {
                 pareto_front
@@ -382,7 +514,7 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
                 let action_value = ParetoValue::new(progress, quality);
                 if !child_state.is_final(self.context.durability_cost) {
                     let child_pareto_front = if let Some(child_pareto_front) =
-                        self.shared_states.get(&child_state).copied()
+                        self.lookup_shared(&child_state)
                     {
                         child_pareto_front
                     } else if let Some(child_pareto_front) =
@@ -428,6 +560,27 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
         self.local_states.insert(state, pareto_front);
         Ok(())
     }
+}
+
+fn lookup_slot<'arena>(
+    templates: &FxHashMap<TemplateData, TemplateRecord>,
+    slots: &[u32],
+    arena: &'arena ValueArena,
+    min_solved_cp: u16,
+    state: &ReducedState,
+) -> Option<&'arena ParetoFront> {
+    let data = TemplateData::new(state.effects, state.compressed_unreliable_quality);
+    let record = templates.get(&data)?;
+    if state.cp < min_solved_cp || state.cp > record.max_instantiated_cp {
+        return None;
+    }
+    let index = record.slots_start as usize + usize::from((state.cp - min_solved_cp) / 2);
+    let offset = slots[index];
+    if offset == UNSOLVED_SLOT {
+        return None;
+    }
+    let front = arena.resolve(offset);
+    Some(front.try_into().expect("arena Pareto fronts are never empty"))
 }
 
 /// Calculates the CP cost to "magically" restore 5 durability
@@ -477,6 +630,10 @@ struct Template {
     required_cp_for_max_progress_and_quality: Option<u16>,
 
     data: TemplateData,
+
+    /// Start of this template's span in `QualityUbSolver::slots`.
+    /// Assigned at the start of `QualityUbSolver::precompute`.
+    slots_start: u32,
 }
 
 impl Template {
@@ -485,6 +642,7 @@ impl Template {
             max_instantiated_cp: max_cp,
             required_cp_for_max_progress_and_quality: None,
             data,
+            slots_start: 0,
         }
     }
 

--- a/raphael-solver/src/quality_upper_bound_solver/solver.rs
+++ b/raphael-solver/src/quality_upper_bound_solver/solver.rs
@@ -32,10 +32,10 @@ struct QualityUbSolverContext<'alloc> {
     largest_progress_increase: u16,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct TemplateRecord {
-    slots_start: u32,
-    max_instantiated_cp: u16,
+#[derive(Debug, Clone)]
+struct TemplateRecord<'alloc> {
+    /// Indexed by `(cp - min_solved_cp) / 2`
+    slots: Vec<Option<&'alloc ParetoFront>>,
     /// Minimum CP at which the template reaches max Progress and max Quality,
     /// or `u16::MAX` if it never does.
     required_cp_for_max: u16,
@@ -43,9 +43,7 @@ struct TemplateRecord {
 
 pub struct QualityUbSolver<'alloc> {
     context: QualityUbSolverContext<'alloc>,
-    templates: FxHashMap<TemplateData, TemplateRecord>,
-    /// indexed by `(cp - min_solved_cp) / 2`
-    slots: Vec<Option<&'alloc ParetoFront>>,
+    templates: FxHashMap<TemplateData, TemplateRecord<'alloc>>,
     /// States solved by shards during the search and merged back
     overflow: SolvedStates<'alloc>,
     states_on_main: usize,
@@ -55,8 +53,7 @@ pub struct QualityUbSolver<'alloc> {
 
 pub struct QualityUbSolverShard<'main, 'alloc> {
     context: &'main QualityUbSolverContext<'alloc>,
-    templates: &'main FxHashMap<TemplateData, TemplateRecord>,
-    slots: &'main [Option<&'alloc ParetoFront>],
+    templates: &'main FxHashMap<TemplateData, TemplateRecord<'alloc>>,
     overflow: &'main SolvedStates<'alloc>,
     local_states: SolvedStates<'alloc>,
 }
@@ -84,7 +81,6 @@ impl<'alloc> QualityUbSolver<'alloc> {
                 ),
             },
             templates: FxHashMap::default(),
-            slots: Vec::new(),
             overflow: SolvedStates::default(),
             states_on_main: 0,
             values_on_main: 0,
@@ -103,7 +99,6 @@ impl<'alloc> QualityUbSolver<'alloc> {
         QualityUbSolverShard {
             context: &self.context,
             templates: &self.templates,
-            slots: &self.slots,
             overflow: &self.overflow,
             local_states: SolvedStates::default(),
         }
@@ -168,33 +163,25 @@ impl<'alloc> QualityUbSolver<'alloc> {
     }
 
     fn lookup_slot(&self, state: &ReducedState) -> Option<&'alloc ParetoFront> {
-        lookup_slot(&self.templates, &self.slots, self.min_solved_cp(), state)
+        lookup_slot(&self.templates, self.min_solved_cp(), state)
     }
 
     pub fn precompute(&mut self) -> Result<(), SolverException> {
         let min_solved_cp = self.min_solved_cp();
-        let mut all_templates = self.generate_precompute_templates();
+        let all_templates = self.generate_precompute_templates();
 
-        // Lay out each template's CP range as a contiguous span
-        let mut total_slots: usize = 0;
-        for template in &mut all_templates {
-            template.slots_start = total_slots as u32;
-            if template.max_instantiated_cp >= min_solved_cp {
-                total_slots += usize::from((template.max_instantiated_cp - min_solved_cp) / 2) + 1;
-            }
-        }
-        self.slots = vec![None; total_slots];
         self.templates = all_templates
             .iter()
             .map(|template| {
-                (
-                    template.data,
-                    TemplateRecord {
-                        slots_start: template.slots_start,
-                        max_instantiated_cp: template.max_instantiated_cp,
-                        required_cp_for_max: u16::MAX,
-                    },
-                )
+                let num_slots = 1 + template
+                    .max_instantiated_cp
+                    .saturating_sub(min_solved_cp)
+                    .div_ceil(2);
+                let record = TemplateRecord {
+                    slots: vec![None; usize::from(num_slots)],
+                    required_cp_for_max: u16::MAX,
+                };
+                (template.data, record)
             })
             .collect();
 
@@ -250,14 +237,12 @@ impl<'alloc> QualityUbSolver<'alloc> {
                                 if template_is_maximal {
                                     template.required_cp_for_max_progress_and_quality = Some(cp);
                                 }
-                                let slot = template.slots_start as usize
-                                    + usize::from((cp - min_solved_cp) / 2);
-                                Ok((slot, pareto_front))
+                                Ok((template.data, pareto_front))
                             },
                         )
                         .collect::<Result<Vec<_>, SolverException>>()?;
                     self.states_on_main += solved_states.len();
-                    for (slot, pareto_front) in solved_states {
+                    for (template_data, pareto_front) in solved_states {
                         let allocated = allocator.alloc_slice_copy(&pareto_front).into_ref();
                         let length_checked = allocated.try_into().map_err(|_| {
                             internal_error!(
@@ -265,7 +250,9 @@ impl<'alloc> QualityUbSolver<'alloc> {
                                 self.context.settings
                             )
                         })?;
-                        self.slots[slot] = Some(length_checked);
+                        let slots = &mut self.templates.get_mut(&template_data).unwrap().slots;
+                        let index = usize::from((cp - min_solved_cp) / 2);
+                        slots[index] = Some(length_checked);
                         self.values_on_main += pareto_front.len();
                     }
                 }
@@ -357,13 +344,8 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
     }
 
     fn lookup_shared(&self, state: &ReducedState) -> Option<&'alloc ParetoFront> {
-        lookup_slot(
-            self.templates,
-            self.slots,
-            2 * self.context.durability_cost,
-            state,
-        )
-        .or_else(|| self.overflow.get(state).copied())
+        lookup_slot(self.templates, 2 * self.context.durability_cost, state)
+            .or_else(|| self.overflow.get(state).copied())
     }
 
     pub fn quality_upper_bound(
@@ -508,18 +490,14 @@ impl<'main, 'alloc> QualityUbSolverShard<'main, 'alloc> {
 }
 
 fn lookup_slot<'alloc>(
-    templates: &FxHashMap<TemplateData, TemplateRecord>,
-    slots: &[Option<&'alloc ParetoFront>],
+    templates: &FxHashMap<TemplateData, TemplateRecord<'alloc>>,
     min_solved_cp: u16,
     state: &ReducedState,
 ) -> Option<&'alloc ParetoFront> {
     let data = TemplateData::new(state.effects, state.compressed_unreliable_quality);
     let record = templates.get(&data)?;
-    if state.cp < min_solved_cp || state.cp > record.max_instantiated_cp {
-        return None;
-    }
-    let index = record.slots_start as usize + usize::from((state.cp - min_solved_cp) / 2);
-    slots[index]
+    let index = usize::from(state.cp.checked_sub(min_solved_cp)? / 2);
+    *record.slots.get(index)?
 }
 
 /// Calculates the CP cost to "magically" restore 5 durability
@@ -569,10 +547,6 @@ struct Template {
     required_cp_for_max_progress_and_quality: Option<u16>,
 
     data: TemplateData,
-
-    /// Start of this template's span in `QualityUbSolver::slots`.
-    /// Assigned at the start of `QualityUbSolver::precompute`.
-    slots_start: u32,
 }
 
 impl Template {
@@ -581,7 +555,6 @@ impl Template {
             max_instantiated_cp: max_cp,
             required_cp_for_max_progress_and_quality: None,
             data,
-            slots_start: 0,
         }
     }
 


### PR DESCRIPTION
(from Discord logs)

I think a hash map is the wrong data structure for the QUB memoization. We spent 16 bytes of key per entry to store coordinates that positional indexing encodes for free, the power of two capacity slack means roughly half the table is empty, and the random placement scatters CP neighbors across memory even though they are queried together. I think there is a pretty strong opportunity to improve cache performance and reduce memory usage by changing it to instead use one hash entry per template, pointing to a contiguous CP-indexed span of offsets, which then point to a segmented value arena

I tested this out and it looks good. around a 10% reduction in QUB precompute and search times, ~20% reduction in peak memory usage. theres a slight offset due to SLB precompute taking longer (on the order of a few hundred ms), which I suspect is due to the SLB inheriting a different allocator/page state. It's still a net win and a pretty massive memory usage win